### PR TITLE
p94: minimal test fixes for v1.0.9 release gate (cherry-pick from s58)

### DIFF
--- a/cmd/commands/doctor.go
+++ b/cmd/commands/doctor.go
@@ -126,10 +126,10 @@ Exit codes:
 			}
 			printDoctorSummary(report)
 			if report.Summary.Failed > 0 {
-				os.Exit(1)
+				return &plugin.ExitCodeError{Code: 1}
 			}
 			if report.Summary.Warnings > 0 {
-				os.Exit(2)
+				return &plugin.ExitCodeError{Code: 2}
 			}
 			return nil
 		}
@@ -224,10 +224,10 @@ Exit codes:
 
 		// Exit code: 1=failures, 2=warnings only, 0=all pass
 		if report.Summary.Failed > 0 {
-			os.Exit(1)
+			return &plugin.ExitCodeError{Code: 1}
 		}
 		if report.Summary.Warnings > 0 {
-			os.Exit(2)
+			return &plugin.ExitCodeError{Code: 2}
 		}
 		return nil
 	},

--- a/scripts/soak/03-critical-events.sh
+++ b/scripts/soak/03-critical-events.sh
@@ -6,7 +6,8 @@
 set -euo pipefail
 
 ALERTMANAGER_URL="${ALERTMANAGER_URL:-https://alertmanager.nself.org/api/v2/alerts}"
-CLOCK_FILE="${CLOCK_FILE:-/var/lib/nself/soak-clock}"
+SOAK_STATE_DIR="${SOAK_STATE_DIR:-/var/lib/nself}"
+CLOCK_FILE="${CLOCK_FILE:-${SOAK_STATE_DIR}/soak-clock}"
 
 if [ ! -f "$CLOCK_FILE" ]; then
   printf "ERROR: clock not started — run 02-clock.sh start\n"


### PR DESCRIPTION
## Summary
Cherry-pick of 2 test fixes from PR #77 (s58-plugin-lifecycle-policy).
Sidesteps the s58 branch governance-gate issues (API Contract Check, 8 pre-existing governance failures) to land minimal v1.0.9 release gate fixes in isolation.

## Commits
- \`03ce072\` fix(doctor): return ExitCodeError instead of os.Exit
- \`62b1164\` fix(soak): make SOAK_STATE_DIR configurable in critical-events script

Note: the third commit from PR #77 (\`65aadaa\` - remove unused os import) targeted \`test/e2e/plugin_install_journey_test.go\` which does not exist on main. Skipped; not applicable here.

## Local validation
- \`go build ./...\` - PASS
- \`go test ./...\` - PASS

## Scope
Both commits are self-contained and touch only:
- \`cmd/commands/doctor.go\` - graceful exit code return
- \`scripts/soak/critical-events\` - env-configurable state dir

API Contract / doc-sync / binary-size / governance-gate issues on PR #77 remain to be addressed separately.