### PR TITLE
fix(scripts): fix admin-merge.sh — gh api flag compatibility + enforce_admins disable

### DIFF
--- a/scripts/admin-merge.sh
+++ b/scripts/admin-merge.sh
@@ -485,6 +485,10 @@ if [ "${DRY_RUN}" -eq 0 ]; then
   fi
 
   ok "Branch protection relaxed (HTTP ${HTTP})."
+  # Also disable enforce_admins via dedicated endpoint (PUT /protection sets field but
+  # the separate /enforce_admins endpoint is the authoritative toggle on some repo configs)
+  gh api "repos/${TARGET_REPO}/branches/main/protection/enforce_admins" \
+    -X DELETE > /dev/null 2>&1 || true
   touch "${RELAX_MARKER}"
   # Write post-relax epoch for watchdog deadline reset (FIX3)
   date '+%s' > "${RELAX_TS_MARKER}"
@@ -501,8 +505,8 @@ if [ "${DRY_RUN}" -eq 0 ]; then
   if gh pr merge "${PR_NUMBER}" \
       --repo "${TARGET_REPO}" \
       --squash \
-      --delete-branch \
-      --auto 2>&1; then
+      --admin \
+      --delete-branch 2>&1; then
     MERGE_SUCCESS=1
     ok "PR #${PR_NUMBER} merged."
     audit "MERGE  pr=${PR_NUMBER}  result=success"

--- a/scripts/admin-merge.sh
+++ b/scripts/admin-merge.sh
@@ -243,14 +243,15 @@ restore_protection() {
       allow_deletions: false
     }')
 
-  HTTP_STATUS=$(gh api "repos/${repo}/branches/main/protection" \
+  if gh api "repos/${repo}/branches/main/protection" \
     -X PUT \
     --input - \
     -H "Accept: application/vnd.github.v3+json" \
-    --timeout 30 \
-    -w '%{http_code}' \
-    -o /dev/null \
-    <<< "${PAYLOAD}" 2>/dev/null || printf '000')
+    <<< "${PAYLOAD}" > /dev/null 2>&1; then
+    HTTP_STATUS="200"
+  else
+    HTTP_STATUS="000"
+  fi
 
   if [ "${HTTP_STATUS}" = "200" ] || [ "${HTTP_STATUS}" = "201" ]; then
     printf '[RESTORE] Protection restored successfully (HTTP %s).\n' "${HTTP_STATUS}" >&2
@@ -400,9 +401,13 @@ restore_protection() {
       allow_force_pushes: false,
       allow_deletions: false
     }')
-  HTTP=\$(gh api "repos/\${repo}/branches/main/protection" -X PUT \
+  if gh api "repos/\${repo}/branches/main/protection" -X PUT \
     --input - -H "Accept: application/vnd.github.v3+json" \
-    -w '%{http_code}' -o /dev/null <<< "\${PAYLOAD}" 2>/dev/null || printf '000')
+    <<< "\${PAYLOAD}" > /dev/null 2>&1; then
+    HTTP="200"
+  else
+    HTTP="000"
+  fi
   printf '[WATCHDOG-RESTORE] HTTP %s\n' "\${HTTP}"
   printf '%s  WATCHDOG_RESTORE  repo=%s  reason=%s  http=%s\n' "\$(date '+%Y-%m-%dT%H:%M:%S%z')" "\${repo}" "\${reason}" "\${HTTP}" \
     >> "\${AUDIT_LOG}" 2>/dev/null || true
@@ -464,16 +469,16 @@ RELAX_PAYLOAD=$(jq -n \
   }')
 
 if [ "${DRY_RUN}" -eq 0 ]; then
-  # --timeout 30: if relax hangs, abort immediately WITHOUT writing RELAX_MARKER
-  # (watchdog also exits cleanly because it never sees the relax marker)
-  HTTP=$(gh api "repos/${TARGET_REPO}/branches/main/protection" \
+  # gh api does not support -w or --timeout flags; use exit code to determine success
+  if gh api "repos/${TARGET_REPO}/branches/main/protection" \
     -X PUT \
     --input - \
     -H "Accept: application/vnd.github.v3+json" \
-    --timeout 30 \
-    -w '%{http_code}' \
-    -o /dev/null \
-    <<< "${RELAX_PAYLOAD}" 2>/dev/null || printf '000')
+    <<< "${RELAX_PAYLOAD}" > /dev/null 2>&1; then
+    HTTP="200"
+  else
+    HTTP="000"
+  fi
 
   if [ "${HTTP}" != "200" ] && [ "${HTTP}" != "201" ]; then
     die "Failed to relax branch protection (HTTP ${HTTP}). Aborting — protection unchanged."


### PR DESCRIPTION
## Summary

Fixes three bugs in `scripts/admin-merge.sh` discovered when merging nself-org/plugins#9:

- **Bug 1 (`-w '%{http_code}'`):** `gh api` does not support curl's write-out flag. Every relax/restore call returned HTTP 000, causing every admin merge to abort immediately. Fixed: use `gh api` exit code (0 = 200 OK) instead.
- **Bug 2 (`--timeout 30`):** `gh api` does not support `--timeout`. Removed.
- **Bug 3 (missing `--admin` on merge):** After relaxing branch protection, `gh pr merge` still needed `--admin` flag to bypass remaining constraints.
- **Bug 4 (`--auto` on merge):** `nself-org` repos have auto-merge disabled. Removed `--auto` flag.
- **Enhancement:** Call `DELETE /branches/main/protection/enforce_admins` separately after the PUT relax, since the PUT's `enforce_admins: false` field is not always honored by GitHub's policy engine.

## Test plan

- [x] admin-merge.sh successfully merged nself-org/plugins#9 after these fixes
- [ ] Smoke test: `bash scripts/admin-merge.sh --dry-run --repo nself-org/plugins --pr 1` should print dry-run output without HTTP 000 errors