### PR TITLE
security: add TLS/SSL cert and key patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,10 @@ node_modules/
 
 # Vercel CLI artifacts (accidental link — cli is Go binary, not a Vercel project)
 .vercel/
+
+# TLS/SSL cert and key files — never track private keys
+*.key
+*.pem
+bin/certs/
+src/templates/certs/**/*.key
+src/templates/certs/**/*.pem


### PR DESCRIPTION
## Summary

- Add `*.key`, `*.pem`, `bin/certs/`, and `src/templates/certs/**/*.key/.pem` to `.gitignore`
- Prevents future accidental tracking of private keys and TLS certificates
- Part of P98 security audit (compose-file leak incident response)

## Context

Historical `bin/certs/nself.org.key` from bash v0.2.0 era is a self-signed local dev wildcard cert (`*.nself.org`) that does NOT match the production certificate (verified by modulus comparison). No production exposure. History scrub deferred pending explicit authorization.

## Test plan

- [ ] CI clean-root check passes
- [ ] gitleaks check passes