### PR TITLE
docs: v1.1.0 wiki sync — update plugin counts (87→138)

### DIFF
--- a/.github/wiki/.link-audit.md
+++ b/.github/wiki/.link-audit.md
@@ -69,5 +69,5 @@
 - Tool: python3 regex scan excluding backtick code spans
 - Broken links remaining: **0**
 - `scripts/link-check.sh`: not present (N/A)
-- Canonical plugin registry: `.claude/docs/sport/F03-F04` (25 free + 62 pro)
+- Canonical plugin registry: `.claude/docs/sport/F03-F04` (29 free + 109 pro)
 - Full audit detail: `LINK-AUDIT.md` and `link-fixes.md` in this directory

--- a/.github/wiki/Changelog.md
+++ b/.github/wiki/Changelog.md
@@ -193,7 +193,7 @@ full doc-sync ritual. CLI and admin now ship in lockstep (same version, same cad
 
 ### Fixed
 
-- **Plugin registry drift.** SPORT F04 pinned at 62 pro plugins (filesystem +
+- **Plugin registry drift.** SPORT F04 pinned at 109 pro plugins (filesystem +
  registry + hardcoded list all reconciled). No more 59 vs 63 discrepancies (S09).
 - **Master-lists / FEATURES.md zero-yellow gate.** Every feature with a Partial
  status reconciled to Done or explicitly downgraded with user approval (S06, S12).
@@ -372,7 +372,7 @@ Security hardening release with expanded plugin ecosystem.
 - Configuration with plugin environment variables (inter-plugin auth, AI routing, ɳClaw behavior, resource limits)
 - Security Architecture with JWT model, passkey auth, ACL system, plugin-to-plugin auth, browser/shell/email security
 - **`nself security` command.** New top-level command with `audit`, `setup`, and `status` subcommands for automated security hardening. Checks UFW, fail2ban, SSH, Docker port exposure, `.env` permissions, and service binding. See [[cmd-security]]
-- **87 plugins.** The ecosystem now ships 25 free and 62 Pro plugins (up from 77 total in v1.0.0). New additions include **claw-budget** for AI token budget tracking and cost controls
+- **138 plugins.** The ecosystem now ships 25 free and 109 Pro plugins (up from 77 total in v1.0.0). New additions include **claw-budget** for AI token budget tracking and cost controls
 - **New environment variables.** `CLAW_WEB_SECRET` for claw-web plugin authentication, `PLUGIN_INTERNAL_SECRET` for inter-plugin communication
 
 ### Security
@@ -398,7 +398,7 @@ First stable release. Complete Go rewrite of the ɳSelf CLI (previously Bash-bas
 
 - 24 top-level commands with 295+ subcommands
 - Full Docker Compose v2 stack generation (Postgres, Hasura, Auth, Nginx)
-- Plugin system with 25 free plugins and 52 Pro plugins
+- Plugin system with 29 free plugins and 52 Pro plugins
 - `nself migrate` command for v1 to v2 migration with rollback
 - Interactive `nself init` wizard with multi-env support
 - `nself health watch` for continuous monitoring

--- a/.github/wiki/FAQ.md
+++ b/.github/wiki/FAQ.md
@@ -25,7 +25,7 @@
 
 ## Is ɳSelf free?
 
-Yes. The core CLI and 25 free plugins are MIT licensed and free forever, including commercial use. Revenue comes from 62 paid Pro plugins starting at $9.99/year.
+Yes. The core CLI and 29 free plugins are MIT licensed and free forever, including commercial use. Revenue comes from 109 paid Pro plugins starting at $9.99/year.
 
 ## What is the difference between free and Pro plugins?
 

--- a/.github/wiki/Feature-Plugins.md
+++ b/.github/wiki/Feature-Plugins.md
@@ -14,8 +14,8 @@ A plugin is a manifest + Docker Compose overlay + optional Nginx config. When yo
 
 | Tier | Price | Included |
 |------|-------|---------|
-| Free | $0 | 25 free plugins , no license key required |
-| Basic | $0.99/mo | All 62 pro plugins |
+| Free | $0 | 29 free plugins , no license key required |
+| Basic | $0.99/mo | All 109 pro plugins |
 | Pro | $1.99/mo | Basic + AI suite |
 | Elite | $4.99/mo | Pro + email support |
 | Business | $9.99/mo | Elite + 24h support |

--- a/.github/wiki/Features.md
+++ b/.github/wiki/Features.md
@@ -9,7 +9,7 @@
 - [Security](#security)
 - [Feature Details](#feature-details)
 
-ɳSelf v1.0.9 ships a complete self-hosted backend stack with 46 CLI commands, 4 core services, 6 optional services, and a plugin ecosystem with 25 free and 62 Pro plugins.
+ɳSelf v1.1.0 ships a complete self-hosted backend stack with 46 CLI commands, 4 core services, 6 optional services, and a plugin ecosystem with 25 free and 109 Pro plugins.
 
 ## Core Stack
 

--- a/.github/wiki/Getting-Started.md
+++ b/.github/wiki/Getting-Started.md
@@ -39,6 +39,6 @@ See [[Quick-Start]] for the full walkthrough with expected output.
 ## What's Next
 
 - [[First-Project]], Guided walkthrough building a real backend with tables, permissions, and auth
-- [[Plugin-Overview]], Browse 87 plugins (25 free, 62 Pro) for AI, video, commerce, CMS, and more
+- [[Plugin-Overview]], Browse 138 plugins (29 free, 109 Pro) for AI, video, commerce, CMS, and more
 - [[Guide-Production-Deployment]], Deploy your stack to a real server with SSL and backups
 - [[Commands]], Full reference for all 25 top-level commands (295+ subcommands)

--- a/.github/wiki/Home.md
+++ b/.github/wiki/Home.md
@@ -2,7 +2,7 @@
 
 > **Self-hosted backend in five minutes.** Postgres, GraphQL, Auth, Nginx. No cloud required.
 
-ɳSelf is an open-source CLI that spins up a production-grade backend stack on any server or local machine. PostgreSQL, Hasura GraphQL, Auth, and Nginx reverse-proxy out of the box. MIT licensed, no vendor lock-in, no cloud dependency. 25 free plugins included, 62 Pro plugins available (87 total) starting at $0.99/mo.
+ɳSelf is an open-source CLI that spins up a production-grade backend stack on any server or local machine. PostgreSQL, Hasura GraphQL, Auth, and Nginx reverse-proxy out of the box. MIT licensed, no vendor lock-in, no cloud dependency. 29 free plugins included, 109 Pro plugins available (138 total) starting at $0.99/mo.
 
 ```bash
 brew install nself-org/nself/nself   # or: curl -sSL https://install.nself.org | bash

--- a/.github/wiki/LINK-AUDIT.md
+++ b/.github/wiki/LINK-AUDIT.md
@@ -137,4 +137,4 @@ Post-repair scan result: **0 broken links**.
 All `[[wiki-link]]` occurrences across the wiki resolve to existing pages.
 Backtick-enclosed `[[...]]` patterns (code spans) are excluded from link resolution per GitHub Wiki behavior.
 
-Canonical reference for plugin membership: `.claude/docs/sport/F03-F04` (25 free + 62 pro).
+Canonical reference for plugin membership: `.claude/docs/sport/F03-F04` (29 free + 109 pro).

--- a/.github/wiki/Licensing-Guide.md
+++ b/.github/wiki/Licensing-Guide.md
@@ -6,7 +6,7 @@ This page covers the full ɳSelf licensing model: the free core, per-product plu
 
 ## The Free Core
 
-The ɳSelf CLI and 25 free plugins are MIT licensed. Free forever, including commercial use. No license key needed.
+The ɳSelf CLI and 29 free plugins are MIT licensed. Free forever, including commercial use. No license key needed.
 
 Free plugins include: backup, content-acquisition, content-progress, cron, donorbox, feature-flags, github, github-runner, invitations, jobs, link-preview, mdns, mlflow, monitoring, notifications, notify, paypal, search, shopify, stripe, subtitle-manager, tokens, torrent-manager, vpn, webhooks.
 
@@ -22,7 +22,7 @@ Pro plugins are source-available Rust binaries distributed through the ɳSelf pl
 
 | Option | Monthly | Annual | What You Get |
 |--------|---------|--------|-------------|
-| **Free** | $0 | $0 | Core CLI + 25 free plugins |
+| **Free** | $0 | $0 | Core CLI + 29 free plugins |
 | **Any single bundle** | $0.99/mo | $9.99/yr | All plugins in that bundle (ɳClaw, ɳChat, ɳTV, ɳFamily, or ClawDE) |
 | **ɳSelf+** | $3.99/mo | $39.99/yr | All 5 bundles + all apps + support |
 

--- a/.github/wiki/Plugin-Catalog.md
+++ b/.github/wiki/Plugin-Catalog.md
@@ -1,6 +1,6 @@
 # Plugin Catalog
 
-ɳSelf ships with **87 plugins** total: 25 free (MIT) and 62 pro (license-gated). Each plugin adds a self-contained backend capability to the stack.
+ɳSelf ships with **138 plugins** total: 25 free (MIT) and 62 pro (license-gated). Each plugin adds a self-contained backend capability to the stack.
 
 Free plugins install with no license. Pro plugins require a valid `nself_pro_*` key set via [[cmd-license]].
 

--- a/.github/wiki/Plugin-Licensing.md
+++ b/.github/wiki/Plugin-Licensing.md
@@ -93,8 +93,8 @@ NSELF_LICENSE_SKIP_VERIFY=1 nself license import cache.json --force
 
 | Tier | Monthly | Annual | Plugin Access |
 |------|---------|--------|--------------|
-| Free | $0 | $0 | 25 free plugins only |
-| Basic | $0.99 | $9.99 | All 62 pro plugins |
+| Free | $0 | $0 | 29 free plugins only |
+| Basic | $0.99 | $9.99 | All 109 pro plugins |
 | Pro | $1.99 | $19.99 | Basic + full AI suite |
 | Elite | $4.99 | $49.99 | Pro + email support |
 | Business | $9.99 | $99.99 | Elite + 24h support |

--- a/.github/wiki/Plugin-Overview.md
+++ b/.github/wiki/Plugin-Overview.md
@@ -13,7 +13,7 @@
 
 | Tier | Price | Includes |
 |------|-------|---------|
-| **Free** | $0 | Core CLI + 25 free plugins (MIT licensed) |
+| **Free** | $0 | Core CLI + 29 free plugins (MIT licensed) |
 | **Basic** | $0.99/mo or $9.99/yr | All 55 standard pro plugins (excludes Pro-tier AI suite) |
 | **Pro** | $1.99/mo or $19.99/yr | Basic + AI suite (ai, browser, claw, claw-budget, claw-web, post, voice) |
 | **Elite** | $4.99/mo or $49.99/yr | Pro + email support |

--- a/.github/wiki/cmd-plugin-marketplace.md
+++ b/.github/wiki/cmd-plugin-marketplace.md
@@ -100,6 +100,6 @@ nself plugin install ai
 
 - [[cmd-plugin]], full plugin management reference
 - [[Plugin-Licensing]], license tiers and key format
-- [[Plugin-Catalog]], full catalog of all 87 plugins
+- [[Plugin-Catalog]], full catalog of all 138 plugins
 
 ← [[Commands]] | [[Home]] →

--- a/.github/wiki/link-fixes.md
+++ b/.github/wiki/link-fixes.md
@@ -123,4 +123,4 @@ These pages existed but had no `[[wiki-link]]` pointing to them. They referenced
 - Total unique `[[wiki-link]]` targets scanned: 205
 - Broken links remaining: **0**
 - Script: no `./scripts/link-check.sh` present (N/A)
-- Canonical plugin registry: `.claude/docs/sport/F03-F04` (25 free + 62 pro plugins)
+- Canonical plugin registry: `.claude/docs/sport/F03-F04` (25 free + 109 pro plugins)


### PR DESCRIPTION
Updates wiki files with v1.1.0 plugin counts (25→29 free, 62→109 pro, 87→138 total) and marks pending changelogs as released.