### PR TITLE
ci: fix nightly-registry-perf workflow (YAML parse error from printf %s)

### DIFF
--- a/.github/workflows/nightly-registry-perf.yml
+++ b/.github/workflows/nightly-registry-perf.yml
@@ -108,19 +108,24 @@ jobs:
       - name: Update baseline on perf/baseline branch
         if: success()
         run: |
+          SEARCH_VAL="${{ steps.search.outputs.search_ms }}"
+          SINGLE_VAL="${{ steps.single.outputs.single_ms }}"
+          BUNDLE_VAL="${{ steps.bundle.outputs.bundle_ms }}"
           PARSE_VAL="${{ steps.parse.outputs.parse_ms }}"
           PARSE_VAL="${PARSE_VAL:-0}"
+          TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           git fetch origin perf/baseline
           git checkout -B perf/baseline FETCH_HEAD
           mkdir -p .github
-          printf '{
-  "search_ms": %s,
-  "single_ms": %s,
-  "bundle_ms": %s,
-  "parse_ms": %s,
-  "timestamp": "%s"
-}
-'             "${{ steps.search.outputs.search_ms }}"             "${{ steps.single.outputs.single_ms }}"             "${{ steps.bundle.outputs.bundle_ms }}"             "${PARSE_VAL}"             "$(date -u +%Y-%m-%dT%H:%M:%SZ)"             > .github/registry-perf-baseline.json
+          cat > .github/registry-perf-baseline.json << JSONEOF
+          {
+            "search_ms": $SEARCH_VAL,
+            "single_ms": $SINGLE_VAL,
+            "bundle_ms": $BUNDLE_VAL,
+            "parse_ms": $PARSE_VAL,
+            "timestamp": "$TIMESTAMP"
+          }
+          JSONEOF
           git add .github/registry-perf-baseline.json
           git -c user.email="ci@nself.org" -c user.name="nself-ci" commit -m "perf: update registry baseline [skip ci]" || true
           git push origin perf/baseline


### PR DESCRIPTION
## Problem

The nightly-registry-perf workflow has been failing since PR #110 was merged. Root cause: the `Update baseline` step used `printf '{ "search_ms": %s, ... }' $ARGS` in a YAML `run: |` block. GitHub's YAML parser rejects bare `%` characters outside quoted strings, causing the workflow to fail before any job starts (0 jobs, `conclusion=failure`).

This is confirmed by:
- Run 26084434180: completed/failure, 0 jobs (YAML parse error)
- Local YAML validation: `found character '%' that cannot start any token, line 117`

## Fix

Replace `printf` with pre-assigned shell variables and a heredoc pattern:
```bash
SEARCH_VAL="${{ steps.search.outputs.search_ms }}"
...
cat > .github/registry-perf-baseline.json << JSONEOF
{
  "search_ms": $SEARCH_VAL,
  ...
}
JSONEOF
```

This is valid YAML and produces identical JSON output.

## All fixes included

- `permissions: contents: write` at job level (prevents 403 on baseline push)
- `ns_per_op="${ns_per_op:-0}"` null guard (prevents `bc` syntax error on missing benchmark)
- `git push origin perf/baseline` instead of `git push` to main (avoids branch protection rejection)
- `printf` replaced with heredoc (fixes YAML parse error)

## Verified

- YAML validates locally (python3 yaml.safe_load)
- No `printf %s` in run blocks
- `permissions.contents: write` present
- `PARSE_VAL` null guard present
- Push targets `perf/baseline` unprotected branch