### PR TITLE
fix(ci): billing-monitor uses new enhanced billing API (P103)

### DIFF
--- a/.github/workflows/billing-monitor.yml
+++ b/.github/workflows/billing-monitor.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      issues: write
 
     steps:
       - name: Fetch billing usage
@@ -27,10 +28,30 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Graceful skip if secret is not configured (soft monitor — never fail CI)
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::GH_BILLING_PAT secret not configured — billing monitor skipped (soft no-op)"
+            echo "total_used=0"  >> "$GITHUB_OUTPUT"
+            echo "included=2000" >> "$GITHUB_OUTPUT"
+            echo "paid_used=0"   >> "$GITHUB_OUTPUT"
+            echo "estimated=0"   >> "$GITHUB_OUTPUT"
+            echo "pct=0"         >> "$GITHUB_OUTPUT"
+            echo "skipped=true"  >> "$GITHUB_OUTPUT"
+            echo "## Billing Monitor SKIPPED" >> "$GITHUB_STEP_SUMMARY"
+            echo "GH_BILLING_PAT secret is not set. Set it via:" >> "$GITHUB_STEP_SUMMARY"
+            echo '`gh auth token | gh secret set GH_BILLING_PAT --repo nself-org/cli --body -`' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # The /settings/billing/actions endpoint was deprecated (HTTP 410) in 2025.
+          # Use the new enhanced billing platform endpoint /orgs/{org}/settings/billing/usage
+          # which returns usageItems[] with per-month, per-SKU breakdown.
+          # Docs: https://docs.github.com/en/rest/billing/enhanced-billing
+          #
           # Retry up to 3 attempts with 10s backoff
           RESPONSE=""
           for attempt in 1 2 3; do
-            if RESPONSE=$(gh api /orgs/nself-org/settings/billing/actions \
+            if RESPONSE=$(gh api "/orgs/nself-org/settings/billing/usage" \
               --header "Accept: application/vnd.github+json" \
               --header "X-GitHub-Api-Version: 2022-11-28" 2>/dev/null); then
               break
@@ -49,10 +70,31 @@ jobs:
             sleep 10
           done
 
-          TOTAL_USED=$(echo "$RESPONSE" | jq -r '.total_minutes_used // 0')
-          INCLUDED=$(echo "$RESPONSE"   | jq -r '.included_minutes // 2000')
-          PAID=$(echo "$RESPONSE"       | jq -r '.total_paid_minutes_used // 0')
-          ESTIMATED=$(echo "$RESPONSE"  | jq -r '.estimated_paid_minutes_used // 0')
+          # Current month in YYYY-MM-01T00:00:00Z form for matching usageItems[].date
+          CURRENT_MONTH=$(date -u +%Y-%m-01T00:00:00Z)
+
+          # Sum Actions Minutes used this month (Linux + Windows + macOS + ARM — all SKUs containing "Actions" and unitType=Minutes)
+          TOTAL_USED=$(echo "$RESPONSE" | jq -r --arg m "$CURRENT_MONTH" '
+            [.usageItems[]
+              | select(.product=="actions" and .unitType=="Minutes" and .date==$m)
+              | .quantity] | add // 0 | floor')
+
+          # Enhanced billing API does not expose included_minutes directly; nself-org plan baseline is 3000/mo (Team plan)
+          # If you upgrade plan, update INCLUDED accordingly.
+          INCLUDED=${BILLING_INCLUDED_MINUTES:-3000}
+
+          # Paid minutes = (TOTAL_USED - INCLUDED) when positive, else 0
+          if [ "$TOTAL_USED" -gt "$INCLUDED" ]; then
+            PAID=$((TOTAL_USED - INCLUDED))
+          else
+            PAID=0
+          fi
+
+          # Estimated paid = sum of netAmount this month (post-discount), in dollars
+          ESTIMATED=$(echo "$RESPONSE" | jq -r --arg m "$CURRENT_MONTH" '
+            [.usageItems[]
+              | select(.product=="actions" and .date==$m)
+              | .netAmount] | add // 0')
 
           # Guard against divide-by-zero when no paid minutes are included
           if [ "$INCLUDED" -eq 0 ]; then


### PR DESCRIPTION
## Problem

`.github/workflows/billing-monitor.yml` fails on schedule with:
- `gh: GH_TOKEN env not set` when `GH_BILLING_PAT` secret missing
- `HTTP 410 — This endpoint has been moved` from `/orgs/{org}/settings/billing/actions` (deprecated by GitHub)

## Fix

1. **Switch to new enhanced billing API:** `/orgs/{org}/settings/billing/usage` returns `usageItems[]` with per-month, per-SKU quantity + cost breakdown.
2. **Sum Actions Minutes across all SKUs** (Linux + Windows + macOS + ARM) for the current month.
3. **Compute paid minutes** as `max(0, total_used - included)` since the enhanced API does not expose `included_minutes` directly (configurable via `BILLING_INCLUDED_MINUTES` env, default 3000 for nself-org Team plan).
4. **Estimated cost** from `netAmount` sum (post-discount).
5. **Add `issues: write` permission** for alert issue creation.
6. **Graceful skip** when `GH_BILLING_PAT` is not set — emits a `::notice::` and exits 0, so missing-secret never fails CI.

## Verification

- Endpoint tested locally with `gh auth token` (admin:org scope) — returns valid usageItems[] data.
- `GH_BILLING_PAT` secret set on nself-org/cli repo (rotates with gh keyring token).
- YAML valid (`python3 -c 'import yaml; yaml.safe_load(open(...))'`).
- No stubs / TODOs in changed file.
- Workflow dispatch tested on branch (see linked run).

## Risk

LOW — monitoring tool only; failure has no impact on releases or app surfaces. Path-A.a (`GITHUB_TOKEN` auto-token) was rejected because billing API requires `admin:org` scope which `GITHUB_TOKEN` cannot grant. Path-A.b (PAT secret) chosen.

## Refs

- P103 True-100%-Done blocker (LOW priority)
- GitHub Enhanced Billing API: https://docs.github.com/en/rest/billing/enhanced-billing