### PR TITLE
chore(git): harden .gitignore for binary exclusions (Mega P1 T-E3-03)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,9 @@ node_modules/
 bin/certs/
 !src/templates/certs/**/*.key
 !src/templates/certs/**/*.pem
+
+# Binary exclusions (Mega P1 T-E3-03 hardening)
+*.exe
+*.dll
+*.so
+*.dylib


### PR DESCRIPTION
## Summary
- Adds `*.exe`, `*.dll`, `*.so`, `*.dylib` generic binary glob patterns to prevent compiled binaries from being accidentally tracked
- Part of Mega Phase 1 T-E3-03: harden .gitignore files across nself repos

## Context
T-E3-01 removed the tracked `endpoint-auth-checker` binary (PR #119). This PR hardens the .gitignore so future compiled binaries cannot sneak in. The existing `/nself.exe` entry only covered one specific binary by name; these globs cover all platforms.

## Test plan
- [ ] Verify no existing tracked files match the new patterns
- [ ] Confirm CI passes