### PR TITLE
feat(cli): nself sentry status — EOP health gate

### DIFF
--- a/cmd/commands/sentry.go
+++ b/cmd/commands/sentry.go
@@ -1,0 +1,32 @@
+package commands
+
+// sentry.go — 'nself sentry' command group.
+//
+// Purpose: Parent command for ɳSentry operations (status, alerts, etc.).
+//   Prints help when invoked without a subcommand.
+// Inputs:  subcommand
+// Outputs: help text or delegates to subcommand
+// Constraints: no flags at parent level; add flags on subcommands only.
+// SPORT: CLI-CMD-SENTRY-001
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var sentryCmd = &cobra.Command{
+	Use:   "sentry",
+	Short: "ɳSentry ops: status, alerts, and observability",
+	Long: `Manage and inspect ɳSentry observability resources.
+
+Examples:
+  nself sentry status
+  nself sentry status --json
+  nself sentry status --url https://status.nself.org/status.json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(sentryCmd)
+}

--- a/cmd/commands/sentry_status.go
+++ b/cmd/commands/sentry_status.go
@@ -1,0 +1,258 @@
+package commands
+
+// sentry_status.go — 'nself sentry status' command.
+//
+// Purpose: Fetch and display the ɳSentry status page JSON, report component
+//   health, and exit non-zero when any component is in outage/degraded state.
+// Inputs:  --url, --token, --json, --timeout flags
+// Outputs: human summary to stdout (or JSON when --json); errors to stderr.
+// Constraints: token appended as ?t=<token> query param; exit 0 = fully
+//   operational, exit 1 = any outage/degraded/unreachable condition.
+// SPORT: CLI-CMD-SENTRY-002
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/nself-org/cli/internal/httptimeout"
+	"github.com/nself-org/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// statusPageResponse is the normalized shape returned by the status JSON endpoint.
+type statusPageResponse struct {
+	SiteName      string              `json:"site_name"`
+	OverallStatus string              `json:"overall_status"`
+	Components    []statusComponent   `json:"components"`
+}
+
+// statusComponent represents a single monitored component.
+type statusComponent struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// statusJSONOut is the normalized JSON output shape for --json mode.
+type statusJSONOut struct {
+	Overall     string            `json:"overall"`
+	Total       int               `json:"total"`
+	Operational int               `json:"operational"`
+	Degraded    int               `json:"degraded"`
+	Down        []string          `json:"down"`
+	Components  []compactComponent `json:"components"`
+}
+
+// compactComponent is the per-component shape inside statusJSONOut.
+type compactComponent struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// outageStatuses are component statuses that trigger exit 1.
+var outageStatuses = map[string]bool{
+	"partial_outage": true,
+	"major_outage":   true,
+}
+
+// degradedStatuses count toward the degraded tally but do not alone trigger exit 1.
+var degradedStatuses = map[string]bool{
+	"degraded_performance": true,
+	"under_maintenance":    true,
+}
+
+var sentryStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Fetch and display the ɳSentry status page",
+	Long: `Fetch the ɳSentry status page JSON and display component health.
+
+Exits 0 when overall_status is operational and no component is in
+partial_outage or major_outage. Exits 1 otherwise.
+
+Examples:
+  nself sentry status
+  nself sentry status --json
+  nself sentry status --url https://status.nself.org/status.json --timeout 15s
+  nself sentry status --token mytoken --json`,
+	RunE: runSentryStatus,
+}
+
+func init() {
+	sentryStatusCmd.Flags().String("url", "https://status.nself.org/status.json", "Status JSON endpoint URL")
+	sentryStatusCmd.Flags().String("token", "", "Auth token (env: NSENTRY_PRIVATE_TOKEN or STATUS_PAGE_PRIVATE_TOKEN)")
+	sentryStatusCmd.Flags().Bool("json", false, "Output normalized JSON to stdout")
+	sentryStatusCmd.Flags().Duration("timeout", 10*time.Second, "HTTP request timeout")
+
+	sentryCmd.AddCommand(sentryStatusCmd)
+}
+
+// runSentryStatus implements 'nself sentry status'.
+//
+// Purpose:  GET the status JSON endpoint, parse component health, display
+//   human or JSON output, and exit non-zero on any outage/unreachable state.
+// Inputs:   --url, --token, --json, --timeout flags (cmd).
+// Outputs:  Human table to stdout, or normalized JSON when --json; errors to stderr.
+func runSentryStatus(cmd *cobra.Command, _ []string) error {
+	rawURL, _ := cmd.Flags().GetString("url")
+	token, _ := cmd.Flags().GetString("token")
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+
+	// Resolve token: flag → NSENTRY_PRIVATE_TOKEN → STATUS_PAGE_PRIVATE_TOKEN.
+	if token == "" {
+		token = os.Getenv("NSENTRY_PRIVATE_TOKEN")
+	}
+	if token == "" {
+		token = os.Getenv("STATUS_PAGE_PRIVATE_TOKEN")
+	}
+
+	// Append token as query param when provided.
+	if token != "" {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid --url %q: %v\n", rawURL, err)
+			os.Exit(1)
+		}
+		q := u.Query()
+		q.Set("t", token)
+		u.RawQuery = q.Encode()
+		rawURL = u.String()
+	}
+
+	// Build HTTP client with the requested timeout.
+	client := httptimeout.WithTimeout(timeout)
+
+	page, err := fetchStatusPage(cmd.Context(), client, rawURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s %v\n", ui.C(ui.Red, ui.IconFailure), err)
+		os.Exit(1)
+	}
+
+	// Compute aggregates.
+	totalComponents := len(page.Components)
+	operationalCount := 0
+	degradedCount := 0
+	var downNames []string
+	var compacts []compactComponent
+
+	for _, c := range page.Components {
+		compacts = append(compacts, compactComponent{Name: c.Name, Status: c.Status})
+		if c.Status == "operational" {
+			operationalCount++
+		} else if degradedStatuses[c.Status] {
+			degradedCount++
+		} else if outageStatuses[c.Status] {
+			degradedCount++
+			downNames = append(downNames, c.Name)
+		}
+	}
+
+	// Determine exit code: 1 if not operational overall OR any component is in outage.
+	exitBad := page.OverallStatus != "operational" || len(downNames) > 0
+
+	if jsonOut {
+		out := statusJSONOut{
+			Overall:     page.OverallStatus,
+			Total:       totalComponents,
+			Operational: operationalCount,
+			Degraded:    degradedCount,
+			Down:        downNames,
+			Components:  compacts,
+		}
+		if out.Down == nil {
+			out.Down = []string{}
+		}
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "json marshal error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(data))
+		if exitBad {
+			os.Exit(1)
+		}
+		return nil
+	}
+
+	// Human output.
+	overallColor := ui.Green
+	overallIcon := ui.IconSuccess
+	if exitBad {
+		overallColor = ui.Red
+		overallIcon = ui.IconFailure
+	} else if degradedCount > 0 {
+		overallColor = ui.Yellow
+		overallIcon = ui.IconWarning
+	}
+
+	ui.CommandHeader("ɳSentry Status", page.SiteName)
+	fmt.Printf("\nStatus: %s\n\n", ui.C(overallColor, overallIcon+" "+page.OverallStatus))
+
+	notOKCount := 0
+	for _, c := range page.Components {
+		prefix := "   "
+		color := ui.Dim
+		if outageStatuses[c.Status] || degradedStatuses[c.Status] {
+			prefix = ui.C(ui.Yellow, "[!]")
+			color = ui.Yellow
+			if outageStatuses[c.Status] {
+				color = ui.Red
+				prefix = ui.C(ui.Red, "[!]")
+			}
+			notOKCount++
+		}
+		fmt.Printf("%s %s — %s\n", prefix, c.Name, ui.C(color, c.Status))
+	}
+
+	notOKLabel := "all operational"
+	if notOKCount > 0 {
+		notOKLabel = fmt.Sprintf("%d not operational", notOKCount)
+	}
+	fmt.Printf("\n%d components, %s\n", totalComponents, notOKLabel)
+
+	if exitBad {
+		os.Exit(1)
+	}
+	return nil
+}
+
+// fetchStatusPage performs the GET request and decodes the response JSON.
+//
+// Purpose:  Execute HTTP GET with context, enforce non-200 as error, decode JSON.
+// Inputs:   ctx (cancellation), client (timeout-bounded), rawURL (fully formed).
+// Outputs:  Parsed statusPageResponse or an error.
+func fetchStatusPage(ctx context.Context, client *http.Client, rawURL string) (*statusPageResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching status page: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status page returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	var page statusPageResponse
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, fmt.Errorf("parsing status JSON: %w", err)
+	}
+	return &page, nil
+}

--- a/cmd/commands/sentry_status_test.go
+++ b/cmd/commands/sentry_status_test.go
@@ -1,0 +1,210 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// operationalPayload returns a fully-operational status page JSON body.
+func operationalPayload() string {
+	return `{
+		"site_name": "nSelf Status",
+		"overall_status": "operational",
+		"components": [
+			{"id": "c1", "name": "API", "status": "operational", "updated_at": "2026-06-01T00:00:00Z"},
+			{"id": "c2", "name": "Auth", "status": "operational", "updated_at": "2026-06-01T00:00:00Z"},
+			{"id": "c3", "name": "DB",   "status": "operational", "updated_at": "2026-06-01T00:00:00Z"}
+		]
+	}`
+}
+
+// degradedPayload returns a status page where one component is degraded.
+func degradedPayload() string {
+	return `{
+		"site_name": "nSelf Status",
+		"overall_status": "degraded_performance",
+		"components": [
+			{"id": "c1", "name": "API",  "status": "operational",         "updated_at": "2026-06-01T00:00:00Z"},
+			{"id": "c2", "name": "Auth", "status": "degraded_performance","updated_at": "2026-06-01T00:00:00Z"},
+			{"id": "c3", "name": "DB",   "status": "partial_outage",      "updated_at": "2026-06-01T00:00:00Z"}
+		]
+	}`
+}
+
+// TestFetchStatusPage_Operational verifies that a fully-operational response
+// is parsed correctly and no outage components are reported.
+func TestFetchStatusPage_Operational(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(operationalPayload()))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	page, err := fetchStatusPage(context.Background(), client, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if page.OverallStatus != "operational" {
+		t.Errorf("expected overall_status=operational, got %q", page.OverallStatus)
+	}
+	if len(page.Components) != 3 {
+		t.Errorf("expected 3 components, got %d", len(page.Components))
+	}
+
+	// Exit-code logic: no outage → should be exit 0.
+	for _, c := range page.Components {
+		if outageStatuses[c.Status] {
+			t.Errorf("unexpected outage component %q with status %q", c.Name, c.Status)
+		}
+	}
+}
+
+// TestFetchStatusPage_Degraded verifies that a degraded response is parsed and
+// outage components are correctly identified for exit-1 logic.
+func TestFetchStatusPage_Degraded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(degradedPayload()))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	page, err := fetchStatusPage(context.Background(), client, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if page.OverallStatus == "operational" {
+		t.Errorf("expected non-operational overall_status, got %q", page.OverallStatus)
+	}
+
+	// DB component has partial_outage → exitBad = true.
+	exitBad := page.OverallStatus != "operational"
+	var downNames []string
+	for _, c := range page.Components {
+		if outageStatuses[c.Status] {
+			downNames = append(downNames, c.Name)
+		}
+	}
+	exitBad = exitBad || len(downNames) > 0
+	if !exitBad {
+		t.Error("expected exitBad=true for degraded/outage response")
+	}
+	if len(downNames) != 1 || downNames[0] != "DB" {
+		t.Errorf("expected down=[DB], got %v", downNames)
+	}
+}
+
+// TestFetchStatusPage_Non200 verifies that a non-200 HTTP response returns an error.
+func TestFetchStatusPage_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := fetchStatusPage(context.Background(), client, srv.URL)
+	if err == nil {
+		t.Fatal("expected error for HTTP 503, got nil")
+	}
+}
+
+// TestStatusJSONOutput verifies the normalized JSON output structure matches spec.
+func TestStatusJSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(degradedPayload()))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	page, err := fetchStatusPage(context.Background(), client, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Build the same normalized output as runSentryStatus --json would.
+	operationalCount := 0
+	degradedCount := 0
+	var downNames []string
+	var compacts []compactComponent
+
+	for _, c := range page.Components {
+		compacts = append(compacts, compactComponent{Name: c.Name, Status: c.Status})
+		if c.Status == "operational" {
+			operationalCount++
+		} else if degradedStatuses[c.Status] {
+			degradedCount++
+		} else if outageStatuses[c.Status] {
+			degradedCount++
+			downNames = append(downNames, c.Name)
+		}
+	}
+
+	out := statusJSONOut{
+		Overall:     page.OverallStatus,
+		Total:       len(page.Components),
+		Operational: operationalCount,
+		Degraded:    degradedCount,
+		Down:        downNames,
+		Components:  compacts,
+	}
+
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var roundTrip statusJSONOut
+	if err := json.Unmarshal(data, &roundTrip); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if roundTrip.Total != 3 {
+		t.Errorf("expected total=3, got %d", roundTrip.Total)
+	}
+	if roundTrip.Operational != 1 {
+		t.Errorf("expected operational=1, got %d", roundTrip.Operational)
+	}
+	if roundTrip.Degraded != 2 {
+		t.Errorf("expected degraded=2, got %d", roundTrip.Degraded)
+	}
+	if len(roundTrip.Down) != 1 || roundTrip.Down[0] != "DB" {
+		t.Errorf("expected down=[DB], got %v", roundTrip.Down)
+	}
+	if roundTrip.Overall != "degraded_performance" {
+		t.Errorf("expected overall=degraded_performance, got %q", roundTrip.Overall)
+	}
+}
+
+// TestFetchStatusPage_TokenQueryParam verifies the token is appended to the URL.
+func TestFetchStatusPage_TokenQueryParam(t *testing.T) {
+	var receivedToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedToken = r.URL.Query().Get("t")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(operationalPayload()))
+	}))
+	defer srv.Close()
+
+	// Manually append token as runSentryStatus does.
+	targetURL := srv.URL + "?t=mytoken"
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := fetchStatusPage(context.Background(), client, targetURL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedToken != "mytoken" {
+		t.Errorf("expected token=mytoken, got %q", receivedToken)
+	}
+}


### PR DESCRIPTION
Programmatic nSentry health command for EOP/Claude Code. Build+vet clean, 5 tests pass, live endpoint exit 0.