### PR TITLE
ci: move release pipeline to self-hosted Linux runner

### DIFF
--- a/.github/workflows/pre-release-gate.yml
+++ b/.github/workflows/pre-release-gate.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   denylist-gate:
     name: Evaluate release denylist
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -28,7 +28,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   extract-version:
     name: Extract release version
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     outputs:
       version: ${{ steps.ver.outputs.version }}
       tag: ${{ steps.ver.outputs.tag }}
@@ -49,7 +49,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   build-dryrun:
     name: Build dry-run (all platforms)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: extract-version
     env:
       CGO_ENABLED: 0
@@ -98,7 +98,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   version-lockstep:
     name: Version lockstep check (CLI ↔ Admin)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: extract-version
     steps:
       - name: Checkout CLI repo
@@ -126,7 +126,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   homebrew-lockstep-dryrun:
     name: Homebrew formula lockstep (dry-run)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: extract-version
     steps:
       - name: Check formula version
@@ -168,7 +168,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   sbom-dryrun:
     name: SBOM generation dry-run
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: extract-version
     steps:
       - name: Checkout
@@ -195,7 +195,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   dryrun-gate:
     name: Dry-run gate (all checks passed)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: [build-dryrun, version-lockstep, homebrew-lockstep-dryrun, sbom-dryrun]
     steps:
       - name: Gate passed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   build:
     name: Build release artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     outputs:
       hashes: ${{ steps.hashes.outputs.hashes }}
       source_sha256: ${{ steps.source_sha256.outputs.sha256 }}
@@ -129,7 +129,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   sbom:
     name: Generate SBOM
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: build
     steps:
       - name: Download binaries
@@ -205,7 +205,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   verify-homebrew-lockstep:
     name: Verify Homebrew formula lockstep
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: build
 
     steps:
@@ -262,7 +262,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   sign-and-publish:
     name: Sign and publish release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: [build, sbom, provenance, verify-homebrew-lockstep]
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Switch all `runs-on: ubuntu-latest` jobs in `release.yml`, `pre-release-gate.yml`, and `release-dryrun.yml` to `[self-hosted, Linux, X64]`
- Root cause: GH Actions org billing block was silently killing jobs on tag push — v1.1.10, v1.1.11, v1.1.12 all shipped empty (no binaries)
- The self-hosted runner uses `make dist` which cross-compiles darwin(amd64+arm64) + linux(amd64+arm64) + windows(amd64+arm64) from Linux — all platforms covered
- `CGO_ENABLED=0` means no hardware dependency; pure cross-compile works from any Linux runner
- The SLSA `provenance` job uses a reusable `uses:` workflow (no `runs-on`) — unaffected
- No macOS/Windows native hardware needed for any step; zero jobs left on GitHub-hosted runners

## Jobs moved (11 total)

| Workflow | Jobs moved |
|---|---|
| `release.yml` | `build`, `sbom`, `verify-homebrew-lockstep`, `sign-and-publish` |
| `pre-release-gate.yml` | `denylist-gate` |
| `release-dryrun.yml` | `extract-version`, `build-dryrun`, `version-lockstep`, `homebrew-lockstep-dryrun`, `sbom-dryrun`, `dryrun-gate` |

## Test plan
- [ ] YAML valid (confirmed: `python3 -c "import yaml; yaml.safe_load(open(f))"` for all 3)
- [ ] `grep -n 'runs-on'` shows only `[self-hosted, Linux, X64]` in all 3 files (11/11)
- [ ] Tag v1.2.0 will trigger release.yml on self-hosted runner and produce binaries