### PR TITLE
ci(release): install build-essential on self-hosted runner if missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.25-
 
+      # Self-hosted runner base image lacks build-essential (2026-07-01: `make dist`
+      # failed with "make: command not found" on nself-sentry-runner{,2,3}). Install
+      # it idempotently so this step is a no-op once the image is patched at the OS level.
+      - name: Ensure build tools present (make)
+        run: |
+          if ! command -v make >/dev/null 2>&1; then
+            echo "make not found - installing build-essential"
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq build-essential
+          else
+            echo "make already present: $(make --version | head -1)"
+          fi
+
       - name: Stamp version from tag
         run: echo "${GITHUB_REF_NAME#v}" > .github/VERSION
 


### PR DESCRIPTION
## Summary
- Self-hosted release runners (nself-sentry-runner{,2,3}) lack `make` in their base image, causing `make dist` to fail with `make: command not found` on every v1.2.0 release.yml run.
- Adds an idempotent check-and-install step (`apt-get install build-essential`) before the build step so this is fixed at the workflow level going forward.

## Test plan
- [x] Confirmed root cause via `gh run view --log-failed` on run 28517757769: `make: command not found`, exit 127
- [ ] Next tag push exercises this step on a runner and succeeds