### PR TITLE
ci(release): provision build-essential + zip + gh on runner boxes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,18 +46,33 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.25-
 
-      # Self-hosted runner base image lacks build-essential (2026-07-01: `make dist`
-      # failed with "make: command not found" on nself-sentry-runner{,2,3}). Install
-      # it idempotently so this step is a no-op once the image is patched at the OS level.
-      - name: Ensure build tools present (make)
+      # Self-hosted runner base image lacks the tools `make dist` needs: build-essential
+      # (make/gcc for the Go cross-build) and zip (Windows .zip packaging). 2026-07-01:
+      # a missing `make` then a missing `zip` broke nself-org/cli release.yml on
+      # nself-sentry-runner{,2,3}. Boxes are now patched at the OS level (build-essential
+      # + zip/unzip in the cloud-init base packages) so this step is normally a no-op.
+      # The install branch is a self-heal for any not-yet-patched runner: the runner
+      # user has a scoped NOPASSWD apt-get entry (/etc/sudoers.d/actions-runner-apt),
+      # so `sudo apt-get` works without a TTY.
+      - name: Ensure build tools present (make, zip)
         run: |
-          if ! command -v make >/dev/null 2>&1; then
-            echo "make not found - installing build-essential"
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq build-essential
-          else
-            echo "make already present: $(make --version | head -1)"
+          missing=""
+          command -v make >/dev/null 2>&1 || missing="$missing build-essential"
+          command -v zip  >/dev/null 2>&1 || missing="$missing zip"
+          if [ -z "$missing" ]; then
+            echo "build tools present: make=$(make --version | head -1), zip=$(zip --version 2>/dev/null | head -2 | tail -1)"
+            exit 0
           fi
+          echo "missing tools ->$missing ; attempting self-heal install"
+          if sudo -n apt-get update -qq && sudo -n apt-get install -y -qq $missing; then
+            echo "installed:$missing"
+            exit 0
+          fi
+          echo "::error::Required build tools ($missing) are missing and passwordless 'sudo apt-get' is unavailable."
+          echo "::error::Patch the box: 'apt-get install -y build-essential zip unzip' as root, and add"
+          echo "::error::/etc/sudoers.d/actions-runner-apt (NOPASSWD apt-get for the runner user)."
+          echo "::error::See ~/Sites/.claude/nsentry-server-standard.md and cloud-init base packages."
+          exit 1
 
       - name: Stamp version from tag
         run: echo "${GITHUB_REF_NAME#v}" > .github/VERSION

--- a/terraform/modules/hetzner/cloud-init.yaml.tpl
+++ b/terraform/modules/hetzner/cloud-init.yaml.tpl
@@ -25,6 +25,14 @@ packages:
   - gnupg
   - lsb-release
   - sudo
+  # build-essential (make + gcc) + zip/unzip: required by self-hosted GitHub Actions
+  # runners for `make dist` at release time (Go cross-build + Windows .zip packaging).
+  # Absent from the base Ubuntu image; a missing `make` then a missing `zip` broke
+  # nself-org/cli release.yml on nself-sentry (2026-07-01). Installing them here means
+  # every provisioned box (app + sentry/runner) has them from first boot.
+  - build-essential
+  - zip
+  - unzip
 
 package_update: true
 package_upgrade: true


### PR DESCRIPTION
Fixes the self-hosted runner tool gaps that forced v1.2.0 to be built and published manually.

## Problem
release.yml runs on self-hosted runners (nself-sentry). The base image lacks tools GitHub-hosted runners ship with; each broke `make dist` in turn:
- **build-essential** (make/gcc) — non-root runner had no TTY for the old `sudo apt-get` step, exit 1
- **zip** — Windows .zip packaging (`cd dist && zip ... && cd ..`; missing zip skips `cd ..`, cascading unrelated errors)
- **gh** — the Homebrew-lockstep gate uses `gh api` (needs the official apt repo)

## Fix
- `cloud-init.yaml.tpl`: build-essential+zip+unzip in base packages; gh via apt-repo in runcmd, so every future/re-provisioned box has them from first boot.
- `release.yml`: generalized ensure-tools step detects + self-heals make/zip via non-interactive `sudo -n apt-get` (backed by a scoped NOPASSWD apt sudoers entry on the runner), with an actionable error if unavailable.

Boxes already patched live; v1.2.0 re-run is now fully green (22 assets incl. cosign sigs, SLSA provenance, SBOMs).