### PR TITLE
feat(sentry): W7 cloud CLI + MCP tools + nsentry alias, W8 local-first preset

### DIFF
--- a/.github/wiki/COMMANDS.md
+++ b/.github/wiki/COMMANDS.md
@@ -26,6 +26,7 @@
 | [[cmd-urls]] | Display all service URLs grouped by type with route conflict detection |
 | [[cmd-monitor]] | Monitoring stack management (Grafana dashboard upgrades) |
 | [[cmd-alerts]] | Manage Prometheus alert rules and silences |
+| [[cmd-sentry]] | Operate ɳSentry monitoring: monitors, incidents, status pages, alert channels (SaaS or self-hosted) |
 | [[cmd-watchdog]] | Self-healing container watchdog with circuit breaker |
 | [[cmd-dogfood]] | Production dogfood audit and reporting |
 

--- a/.github/wiki/_Sidebar.md
+++ b/.github/wiki/_Sidebar.md
@@ -15,7 +15,7 @@
 **Commands**
 - [[Commands]], Overview
 - _Lifecycle:_ [[cmd-init]] · [[cmd-build]] · [[cmd-start]] · [[cmd-stop]] · [[cmd-restart]] · [[cmd-dev]]
-- _Monitoring:_ [[cmd-status]] · [[cmd-logs]] · [[cmd-health]] · [[cmd-urls]] · [[cmd-doctor]] · [[cmd-monitor]] · [[cmd-alerts]] · [[cmd-watchdog]] · [[cmd-dogfood]]
+- _Monitoring:_ [[cmd-status]] · [[cmd-logs]] · [[cmd-health]] · [[cmd-urls]] · [[cmd-doctor]] · [[cmd-monitor]] · [[cmd-alerts]] · [[cmd-sentry]] · [[cmd-watchdog]] · [[cmd-dogfood]]
 - _Data:_ [[cmd-db]] · [[cmd-backup]] · [[cmd-dr]] · [[cmd-queue]] · [[cmd-webhooks]]
 - _Config:_ [[cmd-config]] · [[cmd-service]] · [[cmd-env]] · [[cmd-promote]]
 - _Networking:_ [[cmd-ssl]] · [[cmd-trust]] · [[cmd-dns-setup]]

--- a/.github/wiki/cmd-mcp.md
+++ b/.github/wiki/cmd-mcp.md
@@ -18,16 +18,21 @@ By default the server runs over `stdio`, which is the correct mode for Claude Co
 `mcpServers` configuration. Use `--transport sse` to expose the server over HTTP on a local
 port instead.
 
-The server provides six tools:
+The server provides eleven tools:
 
 | Tool | Description |
 |------|-------------|
 | `nself_list_plugins` | List the plugin catalog (installed and available plugins) |
 | `nself_get_schema` | Hasura GraphQL schema introspection |
 | `nself_get_permissions` | Hasura role permissions snapshot |
-| `nself_run_migration` | Apply a SQL migration (requires `confirm: true`; DDL allowlist enforced — see below) |
+| `nself_run_migration` | Apply a SQL migration (requires `confirm: true`; DDL allowlist enforced, see below) |
 | `nself_tail_logs` | Tail Docker logs for a named service or plugin container |
 | `nself_doctor` | Run `nself doctor --deep` and return the diagnostic report |
+| `sentry_monitors_list` | List ɳSentry uptime monitors for the authenticated tenant |
+| `sentry_monitors_add` | Create an ɳSentry uptime monitor (tier quotas apply) |
+| `sentry_incidents_list` | List ɳSentry incidents, optionally filtered by status |
+| `sentry_incidents_ack` | Acknowledge an open ɳSentry incident by id |
+| `sentry_status` | Fetch the ɳSentry public status page summary |
 
 The server advertises itself via mDNS as `_nself._tcp.local` so Claude Code and other
 mDNS-aware clients can discover a running instance on the local network automatically.
@@ -87,6 +92,37 @@ Add the following to your project's `.claude/settings.json`:
 ```
 
 Claude Code will start `nself mcp` automatically and connect over stdio.
+
+## ɳSentry Tools: AI Agents Operate Monitoring
+
+The five `sentry_*` tools wrap the same typed client the [[cmd-sentry]] command group uses,
+so any MCP-capable AI agent can operate monitoring end to end. No dashboard visit needed.
+
+Authentication resolves in this order: `NSELF_SENTRY_API_KEY` environment variable, then
+`~/.nself/sentry.json` (written by `nself sentry login`). Set `NSELF_SENTRY_API_URL` to
+target a self-hosted or local sentry bundle instead of the hosted SaaS.
+
+Example prompts an agent can now handle:
+
+```text
+Add an uptime monitor for https://api.example.com checked every minute.
+```
+
+```text
+Any open incidents right now? Acknowledge the critical one and summarize it.
+```
+
+```text
+Is our status page fully operational? If a component is degraded, list it.
+```
+
+```text
+List every monitor slower than a 60s interval and tell me which ones to tighten.
+```
+
+Write tools respect tier quotas server-side (free: 10 monitors at 5-minute intervals). The
+API returns a quota error with an upgrade hint when a limit is reached. Monitor deletion is
+deliberately not exposed over MCP; use `nself sentry monitors rm` from the CLI.
 
 ## nself_run_migration DDL Allowlist
 

--- a/.github/wiki/cmd-sentry.md
+++ b/.github/wiki/cmd-sentry.md
@@ -1,0 +1,128 @@
+# nself sentry
+
+> Operate ɳSentry monitoring from the CLI: monitors, incidents, status pages, and alert channels against the hosted SaaS or a self-hosted bundle.
+
+## Synopsis
+
+```
+nself sentry <subcommand> [flags]
+```
+
+## Description
+
+`nself sentry` is the CLI surface for ɳSentry. The `status` subcommand reads a public
+status page. Every other subcommand talks to the ɳSentry REST API, either the hosted
+SaaS at `https://api.sentry.nself.org` (default) or a self-hosted/local sentry bundle.
+
+| Subcommand | Purpose |
+|------------|---------|
+| `login` | Validate and store an API key at `~/.nself/sentry.json` (mode 0600) |
+| `logout` | Remove the stored API key |
+| `whoami` | Show account, tier, and quota usage |
+| `monitors list\|add\|rm\|pause\|resume` | Manage uptime monitors |
+| `incidents list\|ack\|resolve` | Incident lifecycle |
+| `status-pages list\|create` | Manage public status pages |
+| `alerts channels\|test` | List alert channels, send test notifications |
+| `status` | Fetch a status page JSON and report component health |
+
+### Authentication
+
+API keys start with `nsk_` and are created in the ɳSentry dashboard, or seeded locally
+by the sentry dev preset. Resolution order for both the key and the API URL:
+
+1. `--api-key` / `--api-url` flags
+2. `NSELF_SENTRY_API_KEY` / `NSELF_SENTRY_API_URL` environment variables
+3. `~/.nself/sentry.json` (written by `nself sentry login`)
+4. Default API URL `https://api.sentry.nself.org`
+
+A 401 response always suggests `nself sentry login`. Quota errors (402/429) include the
+server message and an upgrade hint.
+
+### The nsentry alias
+
+A symlink named `nsentry` behaves as this command group:
+
+```bash
+ln -s $(which nself) /usr/local/bin/nsentry
+nsentry monitors list    # same as: nself sentry monitors list
+```
+
+### JSON output
+
+Every cloud subcommand accepts `--json` for script and AI-agent consumption. The same
+operations are also exposed as MCP tools by [[cmd-mcp]] (`sentry_monitors_list`,
+`sentry_monitors_add`, `sentry_incidents_list`, `sentry_incidents_ack`, `sentry_status`).
+
+## Flags
+
+Common to all cloud subcommands:
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--api-url` | string | `https://api.sentry.nself.org` | ɳSentry API base URL |
+| `--api-key` | string | stored key | ɳSentry API key (`nsk_*`) |
+| `--json` | bool | `false` | Output JSON instead of tables |
+
+`monitors add` flags:
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--url` | string | (required) | Target URL or host to monitor |
+| `--name` | string | the URL | Display name |
+| `--kind` | string | `http` | Monitor kind: `http`, `tcp`, or `ping` |
+| `--interval` | duration | `60s` | Check interval (tier floors: free 5m, bundle 1m, ɳSelf+ 30s) |
+
+## Examples
+
+```bash
+# Log in to the hosted SaaS
+nself sentry login --api-key nsk_abc123...
+```
+
+```bash
+# Add a monitor and list monitors
+nself sentry monitors add --name api --url https://api.example.com --interval 60s
+nself sentry monitors list
+```
+
+```bash
+# Triage incidents
+nself sentry incidents list --status open
+nself sentry incidents ack inc_123
+nself sentry incidents resolve inc_123
+```
+
+```bash
+# Status pages and alert channels
+nself sentry status-pages create --name "Public Status" --slug public
+nself sentry alerts channels
+nself sentry alerts test ch_email_1
+```
+
+```bash
+# Account, tier, and quota usage as JSON
+nself sentry whoami --json
+```
+
+```bash
+# Fully local, zero cloud: sentry dev preset seeds a tenant + dev API key
+nself init --preset sentry && nself build && nself start
+nself sentry login --api-url http://localhost:3848 --api-key nsk_dev_local_0000000000000000
+nself sentry monitors add --url https://example.com
+```
+
+## Tier Quotas
+
+| | Free | Sentry Bundle | ɳSelf+ |
+|---|---|---|---|
+| Monitors | 10 at 5-min | 50 at 1-min | 100 at 30s |
+| Status pages | 1 | 3 | 10 |
+| API/CLI/MCP | read-only | full | full |
+
+## See Also
+
+- [[cmd-mcp]] — MCP server with the `sentry_*` tools for AI agents
+- [[cmd-init]] — `--preset sentry` for the local-first dev stack
+- [[cmd-doctor]] — nSelf diagnostics
+
+← [[Commands]] | [[Home]] →

--- a/cmd/commands/aliases.go
+++ b/cmd/commands/aliases.go
@@ -1,6 +1,38 @@
 package commands
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// normalizeInvokedBinary rewrites os.Args when the binary is invoked through
+// a product-alias name, so a symlink gives a dedicated CLI for free:
+//
+//	ln -s $(which nself) /usr/local/bin/nsentry
+//	nsentry monitors list   ≡   nself sentry monitors list
+//
+// Called from Execute() before any arg parsing (never from init(): init must
+// only do cobra registration). Idempotent: skips when the subcommand is
+// already present.
+func normalizeInvokedBinary() {
+	if len(os.Args) == 0 {
+		return
+	}
+	base := strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
+	if base != "nsentry" {
+		return
+	}
+	if len(os.Args) > 1 && os.Args[1] == "sentry" {
+		return
+	}
+	rewritten := make([]string, 0, len(os.Args)+1)
+	rewritten = append(rewritten, os.Args[0], "sentry")
+	rewritten = append(rewritten, os.Args[1:]...)
+	os.Args = rewritten
+}
 
 func init() {
 	// TRAP-09: guard against duplicate registration if up/down are ever

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -65,7 +65,7 @@ func init() {
 	f.String("domain", "", "Base domain (skips interactive domain selection, e.g. myapp.dev)")
 	f.String("profile", "", "Resource profile: 'tiny' for small VPS (Postgres+nginx only)")
 	f.Bool("no-pgvector", false, "Skip pgvector extension and RAG scaffold tables (sets PGVECTOR_ENABLED=false)")
-	f.String("preset", "", "Use a project-type preset: b2b-saas, mobile-backend, ai-assistant, community-forum, media-hosting, dev, nclaw-app")
+	f.String("preset", "", "Use a project-type preset: b2b-saas, mobile-backend, ai-assistant, community-forum, media-hosting, dev, sentry, nclaw-app")
 	f.Bool("list-presets", false, "List all available project presets and exit")
 	f.String("cs-template", "", "Scaffold a custom service at init time: specify language (go, node, python, rust, other)")
 

--- a/cmd/commands/init_presets.go
+++ b/cmd/commands/init_presets.go
@@ -85,6 +85,20 @@ var initPresets = map[string]initPreset{
 			"Install free plugins as needed: nself plugin install <name>",
 		},
 	},
+	"sentry": {
+		Name:             "sentry",
+		Description:      "Local-first ɳSentry observability stack: uptime, status pages, incidents, alerts, errors, RUM",
+		SuggestedPlugins: []string{"uptime-monitor", "status-page", "incident-mgmt", "alert-router", "slo-tracker", "synthetic-monitor", "rum", "errors", "cron-monitor", "oncall", "crash", "anomaly", "audit"},
+		EnabledServices:  []string{"redis"},
+		Notes: []string{
+			"Install the ɳSentry bundle: nself plugin install uptime-monitor status-page incident-mgmt alert-router",
+			"Bundle plugins need a license key (nself license activate) — audit is free (Security-Always-Free)",
+			"Plugin migrations seed a dev tenant + dev API key: nsk_dev_local_0000000000000000 (local only, never valid in cloud)",
+			"Point the CLI at the local API: export NSELF_SENTRY_API_URL=http://localhost:3848",
+			"Log in with the dev key: nself sentry login --api-url http://localhost:3848 --api-key nsk_dev_local_0000000000000000",
+			"Now the full cloud CLI works offline: nself sentry monitors add --url https://example.com",
+		},
+	},
 	"nclaw-app": {
 		Name:             "nclaw-app",
 		Description:      "Pre-configured backend for ɳClaw: AI memory, multi-model routing, email, and OAuth",
@@ -106,7 +120,7 @@ func listInitPresets() {
 	fmt.Println()
 
 	tbl := ui.NewTable("Preset", "Description", "Suggested plugins")
-	for _, name := range []string{"b2b-saas", "mobile-backend", "ai-assistant", "community-forum", "media-hosting", "dev", "nclaw-app"} {
+	for _, name := range []string{"b2b-saas", "mobile-backend", "ai-assistant", "community-forum", "media-hosting", "dev", "sentry", "nclaw-app"} {
 		p := initPresets[name]
 		plugins := "(none)"
 		if len(p.SuggestedPlugins) > 0 {

--- a/cmd/commands/mcp.go
+++ b/cmd/commands/mcp.go
@@ -47,6 +47,14 @@ Available tools:
   nself_run_migration     Apply a SQL migration (confirmation-gated)
   nself_tail_logs         Tail docker logs for a service
   nself_doctor            Run nself doctor --deep
+  sentry_monitors_list    List ɳSentry uptime monitors
+  sentry_monitors_add     Create an ɳSentry uptime monitor
+  sentry_incidents_list   List ɳSentry incidents (filter by status)
+  sentry_incidents_ack    Acknowledge an incident
+  sentry_status           Public status page summary
+
+Sentry tools authenticate via NSELF_SENTRY_API_KEY or ~/.nself/sentry.json
+(run 'nself sentry login'); NSELF_SENTRY_API_URL targets a self-hosted bundle.
 
 Claude Code config (.claude/settings.json):
   "mcpServers": {
@@ -108,8 +116,11 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 	}
 }
 
-// registerMCPTools attaches all 6 nSelf MCP tools to the server.
+// registerMCPTools attaches all nSelf MCP tools to the server
+// (6 infrastructure tools here + 5 ɳSentry tools in mcp_sentry.go).
 func registerMCPTools(s *server.MCPServer) {
+	registerSentryMCPTools(s)
+
 	s.AddTool(
 		mcp.NewTool("nself_list_plugins",
 			mcp.WithDescription("List the nSelf plugin catalog: installed and available plugins"),

--- a/cmd/commands/mcp_sentry.go
+++ b/cmd/commands/mcp_sentry.go
@@ -1,0 +1,182 @@
+package commands
+
+// mcp_sentry.go — ɳSentry tools for the nSelf MCP server.
+//
+// Purpose: Let AI agents operate monitoring directly ("add a monitor for X,
+//   page me if it goes down") — thin wrappers over internal/sentryapi, the
+//   same client the 'nself sentry' commands use.
+// Inputs:  MCP tool calls; auth resolved via NSELF_SENTRY_API_KEY /
+//   ~/.nself/sentry.json; NSELF_SENTRY_API_URL selects SaaS vs self-hosted.
+// Outputs: JSON text results (mcp.CallToolResult); errors returned as text so
+//   agents can self-correct (e.g. "run 'nself sentry login'").
+// Constraints: read+write tools respect tier quotas server-side; no
+//   destructive tool (monitor delete stays CLI-only by design).
+// SPORT: CLI-CMD-MCP-002
+//
+// Example agent prompts these tools enable:
+//   "Add an uptime monitor for https://api.example.com checked every minute."
+//   "Any open incidents right now? Acknowledge the critical one."
+//   "Is our status page fully operational?"
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/nself-org/cli/internal/sentryapi"
+)
+
+// registerSentryMCPTools attaches the 5 ɳSentry tools to the MCP server.
+func registerSentryMCPTools(s *server.MCPServer) {
+	s.AddTool(
+		mcp.NewTool("sentry_monitors_list",
+			mcp.WithDescription("List ɳSentry uptime monitors for the authenticated tenant (id, name, url, kind, interval, status)"),
+		),
+		mcpSentryMonitorsListHandler(),
+	)
+
+	s.AddTool(
+		mcp.NewTool("sentry_monitors_add",
+			mcp.WithDescription("Create an ɳSentry uptime monitor. Tier quotas apply (free: 10 @ 5-min)."),
+			mcp.WithString("url", mcp.Required(), mcp.Description("Target URL or host to monitor")),
+			mcp.WithString("name", mcp.Description("Display name (defaults to the URL)")),
+			mcp.WithString("kind", mcp.Description("Monitor kind: http, tcp, or ping (default http)")),
+			mcp.WithNumber("interval_seconds", mcp.Description("Check interval in seconds (default 60; tier floors apply)")),
+		),
+		mcpSentryMonitorsAddHandler(),
+	)
+
+	s.AddTool(
+		mcp.NewTool("sentry_incidents_list",
+			mcp.WithDescription("List ɳSentry incidents, optionally filtered by status (open, acknowledged, resolved)"),
+			mcp.WithString("status", mcp.Description("Status filter: open, acknowledged, or resolved (empty = all)")),
+		),
+		mcpSentryIncidentsListHandler(),
+	)
+
+	s.AddTool(
+		mcp.NewTool("sentry_incidents_ack",
+			mcp.WithDescription("Acknowledge an open ɳSentry incident by id"),
+			mcp.WithString("id", mcp.Required(), mcp.Description("Incident id")),
+		),
+		mcpSentryIncidentsAckHandler(),
+	)
+
+	s.AddTool(
+		mcp.NewTool("sentry_status",
+			mcp.WithDescription("Fetch the ɳSentry public status page summary (overall status + per-component health)"),
+			mcp.WithString("url", mcp.Description("Status JSON endpoint (default https://status.nself.org/status.json or NSENTRY_STATUS_URL)")),
+		),
+		mcpSentryStatusHandler(),
+	)
+}
+
+// mcpSentryClient builds a sentryapi client from env + credentials file.
+func mcpSentryClient() *sentryapi.Client {
+	apiURL, apiKey := sentryapi.Resolve("", "")
+	return sentryapi.New(apiURL, apiKey)
+}
+
+// mcpSentryJSON marshals v for a tool result, or reports the error as text.
+func mcpSentryJSON(v interface{}) (*mcp.CallToolResult, error) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("Error encoding result: %v", err)), nil
+	}
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func mcpSentryMonitorsListHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		monitors, err := mcpSentryClient().ListMonitors(ctx)
+		if err != nil {
+			return mcp.NewToolResultText(fmt.Sprintf("Error: %v", err)), nil
+		}
+		if monitors == nil {
+			monitors = []sentryapi.Monitor{}
+		}
+		return mcpSentryJSON(monitors)
+	}
+}
+
+func mcpSentryMonitorsAddHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		target, _ := args["url"].(string)
+		if target == "" {
+			return mcp.NewToolResultText("Error: url is required"), nil
+		}
+		name, _ := args["name"].(string)
+		if name == "" {
+			name = target
+		}
+		kind, _ := args["kind"].(string)
+		if kind == "" {
+			kind = "http"
+		}
+		interval := 60
+		if n, ok := args["interval_seconds"].(float64); ok && n > 0 {
+			interval = int(n)
+		}
+
+		m, err := mcpSentryClient().CreateMonitor(ctx, sentryapi.CreateMonitorRequest{
+			Name: name, URL: target, Kind: kind, IntervalSeconds: interval,
+		})
+		if err != nil {
+			return mcp.NewToolResultText(fmt.Sprintf("Error: %v", err)), nil
+		}
+		return mcpSentryJSON(m)
+	}
+}
+
+func mcpSentryIncidentsListHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		status, _ := req.GetArguments()["status"].(string)
+		incidents, err := mcpSentryClient().ListIncidents(ctx, status)
+		if err != nil {
+			return mcp.NewToolResultText(fmt.Sprintf("Error: %v", err)), nil
+		}
+		if incidents == nil {
+			incidents = []sentryapi.Incident{}
+		}
+		return mcpSentryJSON(incidents)
+	}
+}
+
+func mcpSentryIncidentsAckHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id, _ := req.GetArguments()["id"].(string)
+		if id == "" {
+			return mcp.NewToolResultText("Error: id is required"), nil
+		}
+		inc, err := mcpSentryClient().AckIncident(ctx, id)
+		if err != nil {
+			return mcp.NewToolResultText(fmt.Sprintf("Error: %v", err)), nil
+		}
+		return mcpSentryJSON(inc)
+	}
+}
+
+func mcpSentryStatusHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		statusURL, _ := req.GetArguments()["url"].(string)
+		if statusURL == "" {
+			statusURL = os.Getenv("NSENTRY_STATUS_URL")
+		}
+		if statusURL == "" {
+			statusURL = "https://status.nself.org/status.json"
+		}
+
+		client := &http.Client{Timeout: 10 * time.Second}
+		page, err := fetchStatusPage(ctx, client, statusURL)
+		if err != nil {
+			return mcp.NewToolResultText(fmt.Sprintf("Error: %v", err)), nil
+		}
+		return mcpSentryJSON(page)
+	}
+}

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -175,6 +175,9 @@ func init() {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main().
 func Execute() error {
+	// Product-alias shim: 'nsentry <args>' (symlinked binary) ≡ 'nself sentry <args>'.
+	normalizeInvokedBinary()
+
 	// Route cobra error/usage output to stderr so structured output stays clean.
 	RootCmd.SetErr(os.Stderr)
 

--- a/cmd/commands/sentry.go
+++ b/cmd/commands/sentry.go
@@ -18,10 +18,21 @@ var sentryCmd = &cobra.Command{
 	Short: "ɳSentry ops: status, alerts, and observability",
 	Long: `Manage and inspect ɳSentry observability resources.
 
+Cloud subcommands (login, monitors, incidents, status-pages, alerts, whoami)
+target the hosted SaaS at ` + "`https://api.sentry.nself.org`" + ` by default, or a
+self-hosted/local sentry bundle via --api-url / NSELF_SENTRY_API_URL.
+Auth: API key (nsk_*) via 'nself sentry login', --api-key, or NSELF_SENTRY_API_KEY.
+
+A symlinked binary named 'nsentry' behaves as this command group:
+  ln -s $(which nself) /usr/local/bin/nsentry
+  nsentry monitors list
+
 Examples:
-  nself sentry status
-  nself sentry status --json
-  nself sentry status --url https://status.nself.org/status.json`,
+  nself sentry login --api-key nsk_abc123...
+  nself sentry monitors add --name api --url https://api.example.com --interval 60s
+  nself sentry incidents list --status open
+  nself sentry whoami --json
+  nself sentry status --json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	},

--- a/cmd/commands/sentry_cloud.go
+++ b/cmd/commands/sentry_cloud.go
@@ -1,0 +1,58 @@
+package commands
+
+// sentry_cloud.go — shared plumbing for the 'nself sentry' cloud subcommands.
+//
+// Purpose: One place for the --api-url/--api-key/--json flag trio, client
+//   construction (flag → env → ~/.nself/sentry.json → default), and JSON output.
+// Inputs:  cobra flags + NSELF_SENTRY_API_URL / NSELF_SENTRY_API_KEY env vars.
+// Outputs: configured *sentryapi.Client; JSON printing helper.
+// Constraints: parent sentryCmd carries no flags (see sentry.go) — every cloud
+//   subcommand registers this trio itself via addSentryCloudFlags.
+// SPORT: CLI-CMD-SENTRY-003
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/nself-org/cli/internal/sentryapi"
+	"github.com/spf13/cobra"
+)
+
+// addSentryCloudFlags registers the standard cloud-API flag trio on a subcommand.
+func addSentryCloudFlags(cmd *cobra.Command) {
+	cmd.Flags().String("api-url", "", "ɳSentry API base URL (env: "+sentryapi.EnvAPIURL+"; default: "+sentryapi.DefaultAPIURL+")")
+	cmd.Flags().String("api-key", "", "ɳSentry API key nsk_* (env: "+sentryapi.EnvAPIKey+"; default: ~/.nself/sentry.json)")
+	cmd.Flags().Bool("json", false, "Output JSON (AI/script-friendly)")
+}
+
+// sentryClientFromCmd builds a sentryapi.Client from the resolved config.
+func sentryClientFromCmd(cmd *cobra.Command) *sentryapi.Client {
+	flagURL, _ := cmd.Flags().GetString("api-url")
+	flagKey, _ := cmd.Flags().GetString("api-key")
+	apiURL, apiKey := sentryapi.Resolve(flagURL, flagKey)
+	return sentryapi.New(apiURL, apiKey)
+}
+
+// sentryJSONFlag reads the --json flag.
+func sentryJSONFlag(cmd *cobra.Command) bool {
+	j, _ := cmd.Flags().GetBool("json")
+	return j
+}
+
+// printSentryJSON marshals v as indented JSON to stdout.
+func printSentryJSON(cmd *cobra.Command, v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json output: %w", err)
+	}
+	cmd.Println(string(data))
+	return nil
+}
+
+// dashIfEmpty returns "-" for empty table cells.
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/commands/sentry_cloud_test.go
+++ b/cmd/commands/sentry_cloud_test.go
@@ -1,0 +1,186 @@
+package commands
+
+// sentry_cloud_test.go — happy-path tests for the 'nself sentry' cloud
+// subcommands against an httptest ɳSentry API.
+//
+// Purpose: Verify flag→client wiring, --json output, login credential
+//   persistence (0600), and the nsentry argv0 alias shim.
+// Constraints: no network; HOME isolated per test via t.Setenv.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/sentryapi"
+	"github.com/spf13/cobra"
+)
+
+// newSentryTestAPI serves a minimal ɳSentry API for command tests.
+func newSentryTestAPI(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/me", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer nsk_cmdtest12345" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"code":"unauthorized","message":"bad key"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"tenant_id":"t-cmd","email":"cmd@test.dev","tier":"bundle","quotas":{"monitors":{"used":1,"limit":50}}}`))
+	})
+	mux.HandleFunc("GET /v1/monitors", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"monitors":[{"id":"m1","name":"api","url":"https://api.test.dev","kind":"http","interval_seconds":60,"status":"up"}]}`))
+	})
+	mux.HandleFunc("POST /v1/monitors", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"monitor":{"id":"m2","name":"web","url":"https://test.dev","kind":"http","interval_seconds":300,"status":"pending"}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// isolateSentryEnv points the resolver at the test server with a clean HOME.
+func isolateSentryEnv(t *testing.T, apiURL string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(sentryapi.EnvAPIURL, apiURL)
+	t.Setenv(sentryapi.EnvAPIKey, "nsk_cmdtest12345")
+}
+
+// runSentrySubcommand executes a RunE with the cloud flag trio + extra flags,
+// capturing --json output written via cmd.Println.
+func runSentrySubcommand(t *testing.T, target *cobra.Command, args []string) (string, error) {
+	t.Helper()
+	// Fresh command that shares the target's flag definitions (cloud trio +
+	// subcommand-specific flags were registered on target in init()).
+	c := &cobra.Command{Use: target.Use, RunE: target.RunE, Args: target.Args, SilenceUsage: true}
+	c.Flags().AddFlagSet(target.Flags())
+	var out bytes.Buffer
+	c.SetOut(&out)
+	c.SetErr(&out)
+	c.SetArgs(args)
+	err := c.Execute()
+	return out.String(), err
+}
+
+func TestSentryMonitorsList_JSON(t *testing.T) {
+	srv := newSentryTestAPI(t)
+	isolateSentryEnv(t, srv.URL)
+
+	out, err := runSentrySubcommand(t, sentryMonitorsListCmd, []string{"--json"})
+	if err != nil {
+		t.Fatalf("monitors list: %v (out=%s)", err, out)
+	}
+	var monitors []sentryapi.Monitor
+	if err := json.Unmarshal([]byte(out), &monitors); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out)
+	}
+	if len(monitors) != 1 || monitors[0].ID != "m1" {
+		t.Errorf("unexpected monitors: %+v", monitors)
+	}
+}
+
+func TestSentryWhoami_JSON(t *testing.T) {
+	srv := newSentryTestAPI(t)
+	isolateSentryEnv(t, srv.URL)
+
+	out, err := runSentrySubcommand(t, sentryWhoamiCmd, []string{"--json"})
+	if err != nil {
+		t.Fatalf("whoami: %v (out=%s)", err, out)
+	}
+	var acct sentryapi.Account
+	if err := json.Unmarshal([]byte(out), &acct); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out)
+	}
+	if acct.Tier != "bundle" || acct.Quotas["monitors"].Limit != 50 {
+		t.Errorf("unexpected account: %+v", acct)
+	}
+}
+
+func TestSentryLogin_PersistsCredentials0600(t *testing.T) {
+	srv := newSentryTestAPI(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(sentryapi.EnvAPIURL, "")
+	t.Setenv(sentryapi.EnvAPIKey, "")
+
+	out, err := runSentrySubcommand(t, sentryLoginCmd,
+		[]string{"--api-url", srv.URL, "--api-key", "nsk_cmdtest12345"})
+	if err != nil {
+		t.Fatalf("login: %v (out=%s)", err, out)
+	}
+
+	path := filepath.Join(home, ".nself", "sentry.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("credentials not written: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("credentials mode = %v, want 0600", info.Mode().Perm())
+	}
+	creds, err := sentryapi.ReadCredentials()
+	if err != nil {
+		t.Fatalf("ReadCredentials: %v", err)
+	}
+	if creds.APIKey != "nsk_cmdtest12345" || creds.APIURL != srv.URL {
+		t.Errorf("unexpected credentials: %+v", creds)
+	}
+}
+
+func TestSentryLogin_RejectsBadKey(t *testing.T) {
+	srv := newSentryTestAPI(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(sentryapi.EnvAPIURL, "")
+	t.Setenv(sentryapi.EnvAPIKey, "")
+
+	_, err := runSentrySubcommand(t, sentryLoginCmd,
+		[]string{"--api-url", srv.URL, "--api-key", "nsk_wrongkey9999"})
+	if err == nil || !strings.Contains(err.Error(), "rejected") {
+		t.Errorf("want rejection error, got %v", err)
+	}
+}
+
+func TestNormalizeInvokedBinary_NSentryAlias(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+
+	os.Args = []string{"/usr/local/bin/nsentry", "monitors", "list"}
+	normalizeInvokedBinary()
+	want := []string{"/usr/local/bin/nsentry", "sentry", "monitors", "list"}
+	if strings.Join(os.Args, " ") != strings.Join(want, " ") {
+		t.Errorf("nsentry shim: got %v, want %v", os.Args, want)
+	}
+
+	// Idempotent: running again must not double-insert.
+	normalizeInvokedBinary()
+	if strings.Join(os.Args, " ") != strings.Join(want, " ") {
+		t.Errorf("nsentry shim not idempotent: got %v", os.Args)
+	}
+
+	// Plain nself invocation untouched.
+	os.Args = []string{"/usr/local/bin/nself", "status"}
+	normalizeInvokedBinary()
+	if strings.Join(os.Args, " ") != "/usr/local/bin/nself status" {
+		t.Errorf("nself args mutated: %v", os.Args)
+	}
+}
+
+func TestSentryPresetRegistered(t *testing.T) {
+	p, ok := initPresets["sentry"]
+	if !ok {
+		t.Fatal("sentry preset missing from initPresets")
+	}
+	if len(p.SuggestedPlugins) != 13 {
+		t.Errorf("sentry preset should list the 13 bundle plugins, got %d", len(p.SuggestedPlugins))
+	}
+	joined := strings.Join(p.Notes, "\n")
+	if !strings.Contains(joined, "nsk_dev_local") || !strings.Contains(joined, "3848") {
+		t.Errorf("sentry preset notes must document the dev API key and local API port:\n%s", joined)
+	}
+}

--- a/cmd/commands/sentry_incidents.go
+++ b/cmd/commands/sentry_incidents.go
@@ -1,0 +1,122 @@
+package commands
+
+// sentry_incidents.go — 'nself sentry incidents list|ack|resolve'.
+//
+// Purpose: Incident lifecycle against the ɳSentry API (open → ack → resolved).
+// Inputs:  cloud flag trio; list supports --status filter.
+// Outputs: ui.Table (human) or --json.
+// Constraints: ack/resolve are idempotent server-side; non-2xx surfaces the
+//   server error message.
+// SPORT: CLI-CMD-SENTRY-006
+
+import (
+	"fmt"
+
+	"github.com/nself-org/cli/internal/sentryapi"
+	"github.com/nself-org/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var sentryIncidentsCmd = &cobra.Command{
+	Use:   "incidents",
+	Short: "Manage ɳSentry incidents",
+	Long: `List, acknowledge, and resolve ɳSentry incidents.
+
+Examples:
+  nself sentry incidents list
+  nself sentry incidents list --status open
+  nself sentry incidents ack <id>
+  nself sentry incidents resolve <id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var sentryIncidentsListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List incidents",
+	SilenceUsage: true,
+	RunE:         runSentryIncidentsList,
+}
+
+var sentryIncidentsAckCmd = &cobra.Command{
+	Use:          "ack <id>",
+	Short:        "Acknowledge an incident",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSentryIncidentAction(cmd, args[0], "ack")
+	},
+}
+
+var sentryIncidentsResolveCmd = &cobra.Command{
+	Use:          "resolve <id>",
+	Short:        "Resolve an incident",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSentryIncidentAction(cmd, args[0], "resolve")
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{sentryIncidentsListCmd, sentryIncidentsAckCmd, sentryIncidentsResolveCmd} {
+		addSentryCloudFlags(c)
+		sentryIncidentsCmd.AddCommand(c)
+	}
+	sentryIncidentsListCmd.Flags().String("status", "", "Filter by status: open, acknowledged, or resolved")
+	sentryCmd.AddCommand(sentryIncidentsCmd)
+}
+
+// runSentryIncidentsList implements 'nself sentry incidents list'.
+func runSentryIncidentsList(cmd *cobra.Command, _ []string) error {
+	status, _ := cmd.Flags().GetString("status")
+	client := sentryClientFromCmd(cmd)
+	incidents, err := client.ListIncidents(cmd.Context(), status)
+	if err != nil {
+		return err
+	}
+
+	if sentryJSONFlag(cmd) {
+		if incidents == nil {
+			incidents = []sentryapi.Incident{}
+		}
+		return printSentryJSON(cmd, incidents)
+	}
+
+	if len(incidents) == 0 {
+		ui.Info("No incidents. All quiet.")
+		return nil
+	}
+
+	tbl := ui.NewTable("ID", "Title", "Status", "Severity", "Started", "Monitor")
+	for _, inc := range incidents {
+		tbl.AddRow(inc.ID, dashIfEmpty(inc.Title), dashIfEmpty(inc.Status),
+			dashIfEmpty(inc.Severity), dashIfEmpty(inc.StartedAt), dashIfEmpty(inc.MonitorID))
+	}
+	tbl.Render()
+	fmt.Printf("\n%d incidents\n", len(incidents))
+	return nil
+}
+
+// runSentryIncidentAction implements ack/resolve.
+func runSentryIncidentAction(cmd *cobra.Command, id, action string) error {
+	client := sentryClientFromCmd(cmd)
+	var (
+		inc *sentryapi.Incident
+		err error
+	)
+	if action == "ack" {
+		inc, err = client.AckIncident(cmd.Context(), id)
+	} else {
+		inc, err = client.ResolveIncident(cmd.Context(), id)
+	}
+	if err != nil {
+		return err
+	}
+	if sentryJSONFlag(cmd) {
+		return printSentryJSON(cmd, inc)
+	}
+	ui.Success(fmt.Sprintf("Incident %s is now %s.", inc.ID, inc.Status))
+	return nil
+}

--- a/cmd/commands/sentry_login.go
+++ b/cmd/commands/sentry_login.go
@@ -1,0 +1,161 @@
+package commands
+
+// sentry_login.go — 'nself sentry login|logout|whoami' commands.
+//
+// Purpose: Store/remove the ɳSentry API key (~/.nself/sentry.json, 0600) and
+//   show the authenticated account with tier + quota usage.
+// Inputs:  --api-key / --api-url flags, NSELF_SENTRY_API_KEY env, stdin prompt.
+// Outputs: credentials file; whoami table or --json.
+// Constraints: key validated against GET /v1/me before saving; never echo the
+//   full key back (mask to prefix + last 4).
+// SPORT: CLI-CMD-SENTRY-004
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nself-org/cli/internal/sentryapi"
+	"github.com/nself-org/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var sentryLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Authenticate the CLI with ɳSentry (SaaS or self-hosted)",
+	Long: `Store an ɳSentry API key for use by all 'nself sentry' cloud commands.
+
+The key (nsk_*) is created in the ɳSentry dashboard at
+https://sentry.nself.org/settings/api-keys, or seeded locally by the
+sentry dev preset (see 'nself init --preset sentry').
+
+The key is validated against the API, then stored at ~/.nself/sentry.json (0600).
+
+Examples:
+  nself sentry login --api-key nsk_abc123...
+  nself sentry login --api-url http://localhost:3848 --api-key nsk_dev_local...
+  NSELF_SENTRY_API_KEY=nsk_abc123 nself sentry login`,
+	SilenceUsage: true,
+	RunE:         runSentryLogin,
+}
+
+var sentryLogoutCmd = &cobra.Command{
+	Use:          "logout",
+	Short:        "Remove the stored ɳSentry API key",
+	Long:         `Delete the local ɳSentry credentials file at ~/.nself/sentry.json.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if err := sentryapi.DeleteCredentials(); err != nil {
+			return fmt.Errorf("logout: %w", err)
+		}
+		ui.Success("Logged out of ɳSentry (credentials removed).")
+		return nil
+	},
+}
+
+var sentryWhoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Show the authenticated ɳSentry account, tier, and quota usage",
+	Long: `Show the account behind the configured API key: tenant, email, tier,
+and per-dimension quota usage (monitors, status pages, error events, ...).
+
+Examples:
+  nself sentry whoami
+  nself sentry whoami --json`,
+	SilenceUsage: true,
+	RunE:         runSentryWhoami,
+}
+
+func init() {
+	addSentryCloudFlags(sentryLoginCmd)
+	addSentryCloudFlags(sentryWhoamiCmd)
+	sentryCmd.AddCommand(sentryLoginCmd, sentryLogoutCmd, sentryWhoamiCmd)
+}
+
+// runSentryLogin resolves the key (flag → env → prompt), validates it via
+// GET /v1/me, and persists it.
+func runSentryLogin(cmd *cobra.Command, _ []string) error {
+	flagURL, _ := cmd.Flags().GetString("api-url")
+	flagKey, _ := cmd.Flags().GetString("api-key")
+	apiURL, apiKey := sentryapi.Resolve(flagURL, flagKey)
+
+	if apiKey == "" {
+		fmt.Fprint(cmd.OutOrStdout(), "Paste your ɳSentry API key (nsk_...): ")
+		reader := bufio.NewReader(cmd.InOrStdin())
+		line, err := reader.ReadString('\n')
+		if err != nil && line == "" {
+			return fmt.Errorf("reading API key: %w", err)
+		}
+		apiKey = strings.TrimSpace(line)
+	}
+	if err := sentryapi.ValidateKeyFormat(apiKey); err != nil {
+		return err
+	}
+
+	client := sentryapi.New(apiURL, apiKey)
+	acct, err := client.WhoAmI(cmd.Context())
+	if err != nil {
+		if errors.Is(err, sentryapi.ErrUnauthorized) {
+			return fmt.Errorf("API key rejected by %s — check the key and try again", apiURL)
+		}
+		return fmt.Errorf("validating key against %s: %w", apiURL, err)
+	}
+
+	// Persist api_url only when it differs from the default, so a later
+	// default change is picked up automatically.
+	creds := &sentryapi.Credentials{APIKey: apiKey}
+	if apiURL != sentryapi.DefaultAPIURL {
+		creds.APIURL = apiURL
+	}
+	if err := sentryapi.WriteCredentials(creds); err != nil {
+		return fmt.Errorf("saving credentials: %w", err)
+	}
+
+	ui.Success(fmt.Sprintf("Logged in to ɳSentry as %s (tenant %s, tier %s) — key %s",
+		acct.Email, acct.TenantID, dashIfEmpty(acct.Tier), maskSentryKey(apiKey)))
+	return nil
+}
+
+// runSentryWhoami prints the account + quota table (or --json).
+func runSentryWhoami(cmd *cobra.Command, _ []string) error {
+	client := sentryClientFromCmd(cmd)
+	acct, err := client.WhoAmI(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if sentryJSONFlag(cmd) {
+		return printSentryJSON(cmd, acct)
+	}
+
+	ui.CommandHeader("ɳSentry Account", acct.Email)
+	fmt.Printf("\nTenant: %s\nTier:   %s\nAPI:    %s\n\n", acct.TenantID, dashIfEmpty(acct.Tier), client.BaseURL)
+
+	if len(acct.Quotas) > 0 {
+		// Stable ordering for the quota table.
+		names := make([]string, 0, len(acct.Quotas))
+		for name := range acct.Quotas {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		tbl := ui.NewTable("Quota", "Used", "Limit")
+		for _, name := range names {
+			q := acct.Quotas[name]
+			tbl.AddRow(name, fmt.Sprintf("%d", q.Used), fmt.Sprintf("%d", q.Limit))
+		}
+		tbl.Render()
+		fmt.Println()
+	}
+	return nil
+}
+
+// maskSentryKey shows only the prefix and last 4 characters of an API key.
+func maskSentryKey(key string) string {
+	if len(key) <= len(sentryapi.KeyPrefix)+4 {
+		return sentryapi.KeyPrefix + "****"
+	}
+	return sentryapi.KeyPrefix + "****" + key[len(key)-4:]
+}

--- a/cmd/commands/sentry_monitors.go
+++ b/cmd/commands/sentry_monitors.go
@@ -1,0 +1,192 @@
+package commands
+
+// sentry_monitors.go — 'nself sentry monitors list|add|rm|pause|resume'.
+//
+// Purpose: Manage uptime monitors on the ɳSentry API (SaaS or self-hosted).
+// Inputs:  cloud flag trio + per-subcommand flags (--url, --name, --kind, --interval).
+// Outputs: ui.Table (human) or --json.
+// Constraints: quota errors (402/429) surface the server message + upgrade hint.
+// SPORT: CLI-CMD-SENTRY-005
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nself-org/cli/internal/sentryapi"
+	"github.com/nself-org/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var sentryMonitorsCmd = &cobra.Command{
+	Use:   "monitors",
+	Short: "Manage ɳSentry uptime monitors",
+	Long: `Manage uptime monitors on ɳSentry.
+
+Examples:
+  nself sentry monitors list
+  nself sentry monitors add --name api --url https://api.example.com --interval 60s
+  nself sentry monitors rm <id>
+  nself sentry monitors pause <id>
+  nself sentry monitors resume <id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var sentryMonitorsListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List monitors",
+	SilenceUsage: true,
+	RunE:         runSentryMonitorsList,
+}
+
+var sentryMonitorsAddCmd = &cobra.Command{
+	Use:          "add",
+	Short:        "Add a monitor",
+	SilenceUsage: true,
+	RunE:         runSentryMonitorsAdd,
+}
+
+var sentryMonitorsRmCmd = &cobra.Command{
+	Use:          "rm <id>",
+	Short:        "Remove a monitor",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE:         runSentryMonitorsRm,
+}
+
+var sentryMonitorsPauseCmd = &cobra.Command{
+	Use:          "pause <id>",
+	Short:        "Pause a monitor (stops checks, keeps history)",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSentryMonitorsPause(cmd, args[0], true)
+	},
+}
+
+var sentryMonitorsResumeCmd = &cobra.Command{
+	Use:          "resume <id>",
+	Short:        "Resume a paused monitor",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSentryMonitorsPause(cmd, args[0], false)
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{
+		sentryMonitorsListCmd, sentryMonitorsAddCmd, sentryMonitorsRmCmd,
+		sentryMonitorsPauseCmd, sentryMonitorsResumeCmd,
+	} {
+		addSentryCloudFlags(c)
+		sentryMonitorsCmd.AddCommand(c)
+	}
+
+	sentryMonitorsAddCmd.Flags().String("name", "", "Monitor display name (defaults to the URL host)")
+	sentryMonitorsAddCmd.Flags().String("url", "", "Target URL or host to monitor (required)")
+	sentryMonitorsAddCmd.Flags().String("kind", "http", "Monitor kind: http, tcp, or ping")
+	sentryMonitorsAddCmd.Flags().Duration("interval", 60*time.Second, "Check interval (tier floors apply: free 5m, bundle 1m, nself-plus 30s)")
+	_ = sentryMonitorsAddCmd.MarkFlagRequired("url")
+
+	sentryCmd.AddCommand(sentryMonitorsCmd)
+}
+
+// runSentryMonitorsList implements 'nself sentry monitors list'.
+func runSentryMonitorsList(cmd *cobra.Command, _ []string) error {
+	client := sentryClientFromCmd(cmd)
+	monitors, err := client.ListMonitors(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if sentryJSONFlag(cmd) {
+		if monitors == nil {
+			monitors = []sentryapi.Monitor{}
+		}
+		return printSentryJSON(cmd, monitors)
+	}
+
+	if len(monitors) == 0 {
+		ui.Info("No monitors yet. Add one: nself sentry monitors add --url https://example.com")
+		return nil
+	}
+
+	tbl := ui.NewTable("ID", "Name", "URL", "Kind", "Interval", "Status")
+	for _, m := range monitors {
+		status := m.Status
+		if m.Paused {
+			status = "paused"
+		}
+		tbl.AddRow(m.ID, dashIfEmpty(m.Name), m.URL, dashIfEmpty(m.Kind),
+			(time.Duration(m.IntervalSeconds) * time.Second).String(), dashIfEmpty(status))
+	}
+	tbl.Render()
+	fmt.Printf("\n%d monitors\n", len(monitors))
+	return nil
+}
+
+// runSentryMonitorsAdd implements 'nself sentry monitors add'.
+func runSentryMonitorsAdd(cmd *cobra.Command, _ []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	target, _ := cmd.Flags().GetString("url")
+	kind, _ := cmd.Flags().GetString("kind")
+	interval, _ := cmd.Flags().GetDuration("interval")
+
+	if kind != "http" && kind != "tcp" && kind != "ping" {
+		return fmt.Errorf("invalid --kind %q (use http, tcp, or ping)", kind)
+	}
+	if name == "" {
+		name = target
+	}
+
+	client := sentryClientFromCmd(cmd)
+	m, err := client.CreateMonitor(cmd.Context(), sentryapi.CreateMonitorRequest{
+		Name:            name,
+		URL:             target,
+		Kind:            kind,
+		IntervalSeconds: int(interval.Seconds()),
+	})
+	if err != nil {
+		return err
+	}
+
+	if sentryJSONFlag(cmd) {
+		return printSentryJSON(cmd, m)
+	}
+	ui.Success(fmt.Sprintf("Monitor created: %s (%s every %s) — id %s", m.Name, m.URL,
+		(time.Duration(m.IntervalSeconds) * time.Second).String(), m.ID))
+	return nil
+}
+
+// runSentryMonitorsRm implements 'nself sentry monitors rm <id>'.
+func runSentryMonitorsRm(cmd *cobra.Command, args []string) error {
+	client := sentryClientFromCmd(cmd)
+	if err := client.DeleteMonitor(cmd.Context(), args[0]); err != nil {
+		return err
+	}
+	if sentryJSONFlag(cmd) {
+		return printSentryJSON(cmd, map[string]string{"deleted": args[0]})
+	}
+	ui.Success(fmt.Sprintf("Monitor %s deleted.", args[0]))
+	return nil
+}
+
+// runSentryMonitorsPause implements pause/resume.
+func runSentryMonitorsPause(cmd *cobra.Command, id string, pause bool) error {
+	client := sentryClientFromCmd(cmd)
+	m, err := client.PauseMonitor(cmd.Context(), id, pause)
+	if err != nil {
+		return err
+	}
+	if sentryJSONFlag(cmd) {
+		return printSentryJSON(cmd, m)
+	}
+	verb := "paused"
+	if !pause {
+		verb = "resumed"
+	}
+	ui.Success(fmt.Sprintf("Monitor %s %s.", id, verb))
+	return nil
+}

--- a/cmd/commands/sentry_pages_alerts.go
+++ b/cmd/commands/sentry_pages_alerts.go
@@ -1,0 +1,198 @@
+package commands
+
+// sentry_pages_alerts.go — 'nself sentry status-pages list|create' and
+// 'nself sentry alerts channels|test'.
+//
+// Purpose: Status-page and alert-channel management against the ɳSentry API.
+// Inputs:  cloud flag trio; create takes --name/--slug; test takes <channel-id>.
+// Outputs: ui.Table (human) or --json.
+// Constraints: tier limits (free 1 page, bundle 3, nself-plus 10) enforced
+//   server-side; 402/429 surfaces the upgrade hint.
+// SPORT: CLI-CMD-SENTRY-007
+
+import (
+	"fmt"
+
+	"github.com/nself-org/cli/internal/sentryapi"
+	"github.com/nself-org/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// ── status-pages ─────────────────────────────────────────────────────────────
+
+var sentryStatusPagesCmd = &cobra.Command{
+	Use:   "status-pages",
+	Short: "Manage ɳSentry status pages",
+	Long: `List and create public status pages.
+
+Examples:
+  nself sentry status-pages list
+  nself sentry status-pages create --name "Public Status" --slug public`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var sentryStatusPagesListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List status pages",
+	SilenceUsage: true,
+	RunE:         runSentryStatusPagesList,
+}
+
+var sentryStatusPagesCreateCmd = &cobra.Command{
+	Use:          "create",
+	Short:        "Create a status page",
+	SilenceUsage: true,
+	RunE:         runSentryStatusPagesCreate,
+}
+
+// ── alerts ───────────────────────────────────────────────────────────────────
+
+var sentryAlertsCmd = &cobra.Command{
+	Use:   "alerts",
+	Short: "Manage ɳSentry alert channels",
+	Long: `List alert channels and send test notifications.
+
+Examples:
+  nself sentry alerts channels
+  nself sentry alerts test <channel-id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var sentryAlertsChannelsCmd = &cobra.Command{
+	Use:          "channels",
+	Short:        "List alert channels",
+	SilenceUsage: true,
+	RunE:         runSentryAlertsChannels,
+}
+
+var sentryAlertsTestCmd = &cobra.Command{
+	Use:          "test <channel-id>",
+	Short:        "Send a test notification through a channel",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE:         runSentryAlertsTest,
+}
+
+func init() {
+	for _, c := range []*cobra.Command{sentryStatusPagesListCmd, sentryStatusPagesCreateCmd} {
+		addSentryCloudFlags(c)
+		sentryStatusPagesCmd.AddCommand(c)
+	}
+	sentryStatusPagesCreateCmd.Flags().String("name", "", "Status page display name (required)")
+	sentryStatusPagesCreateCmd.Flags().String("slug", "", "URL slug — page served at sentry.nself.org/s/<slug> (required)")
+	_ = sentryStatusPagesCreateCmd.MarkFlagRequired("name")
+	_ = sentryStatusPagesCreateCmd.MarkFlagRequired("slug")
+
+	for _, c := range []*cobra.Command{sentryAlertsChannelsCmd, sentryAlertsTestCmd} {
+		addSentryCloudFlags(c)
+		sentryAlertsCmd.AddCommand(c)
+	}
+
+	sentryCmd.AddCommand(sentryStatusPagesCmd, sentryAlertsCmd)
+}
+
+// runSentryStatusPagesList implements 'nself sentry status-pages list'.
+func runSentryStatusPagesList(cmd *cobra.Command, _ []string) error {
+	client := sentryClientFromCmd(cmd)
+	pages, err := client.ListStatusPages(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if sentryJSONFlag(cmd) {
+		if pages == nil {
+			pages = []sentryapi.StatusPage{}
+		}
+		return printSentryJSON(cmd, pages)
+	}
+
+	if len(pages) == 0 {
+		ui.Info("No status pages. Create one: nself sentry status-pages create --name <name> --slug <slug>")
+		return nil
+	}
+
+	tbl := ui.NewTable("ID", "Name", "Slug", "URL", "Public")
+	for _, p := range pages {
+		public := "no"
+		if p.Public {
+			public = "yes"
+		}
+		tbl.AddRow(p.ID, dashIfEmpty(p.Name), dashIfEmpty(p.Slug), dashIfEmpty(p.URL), public)
+	}
+	tbl.Render()
+	fmt.Printf("\n%d status pages\n", len(pages))
+	return nil
+}
+
+// runSentryStatusPagesCreate implements 'nself sentry status-pages create'.
+func runSentryStatusPagesCreate(cmd *cobra.Command, _ []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	slug, _ := cmd.Flags().GetString("slug")
+
+	client := sentryClientFromCmd(cmd)
+	page, err := client.CreateStatusPage(cmd.Context(), sentryapi.CreateStatusPageRequest{Name: name, Slug: slug})
+	if err != nil {
+		return err
+	}
+
+	if sentryJSONFlag(cmd) {
+		return printSentryJSON(cmd, page)
+	}
+	ui.Success(fmt.Sprintf("Status page created: %s — %s", page.Name, dashIfEmpty(page.URL)))
+	return nil
+}
+
+// runSentryAlertsChannels implements 'nself sentry alerts channels'.
+func runSentryAlertsChannels(cmd *cobra.Command, _ []string) error {
+	client := sentryClientFromCmd(cmd)
+	channels, err := client.ListAlertChannels(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if sentryJSONFlag(cmd) {
+		if channels == nil {
+			channels = []sentryapi.AlertChannel{}
+		}
+		return printSentryJSON(cmd, channels)
+	}
+
+	if len(channels) == 0 {
+		ui.Info("No alert channels configured. Add channels in the ɳSentry dashboard.")
+		return nil
+	}
+
+	tbl := ui.NewTable("ID", "Kind", "Target", "Enabled")
+	for _, ch := range channels {
+		enabled := "no"
+		if ch.Enabled {
+			enabled = "yes"
+		}
+		tbl.AddRow(ch.ID, dashIfEmpty(ch.Kind), dashIfEmpty(ch.Target), enabled)
+	}
+	tbl.Render()
+	fmt.Printf("\n%d channels\n", len(channels))
+	return nil
+}
+
+// runSentryAlertsTest implements 'nself sentry alerts test <channel-id>'.
+func runSentryAlertsTest(cmd *cobra.Command, args []string) error {
+	client := sentryClientFromCmd(cmd)
+	res, err := client.TestAlertChannel(cmd.Context(), args[0])
+	if err != nil {
+		return err
+	}
+
+	if sentryJSONFlag(cmd) {
+		return printSentryJSON(cmd, res)
+	}
+	if res.Delivered {
+		ui.Success(fmt.Sprintf("Test notification delivered: %s", dashIfEmpty(res.Detail)))
+		return nil
+	}
+	return fmt.Errorf("test notification NOT delivered: %s", dashIfEmpty(res.Detail))
+}

--- a/internal/doctor/sdk_version_test.go
+++ b/internal/doctor/sdk_version_test.go
@@ -179,16 +179,17 @@ func TestCheckOneSDK_NetworkError(t *testing.T) {
 	}
 }
 
-// TestCheckSDKVersions_Smoke ensures CheckSDKVersions returns exactly 4 results
-// and that all names start with "SDK-VERSION-01/".
-// In pre-publication state all 4 SDKs return warn (404); that is expected.
+// TestCheckSDKVersions_Smoke ensures CheckSDKVersions returns exactly 3 results
+// (go, py, ts — Flutter SDK removed 2026-06-30 per ASI Policy 2) and that all
+// names start with "SDK-VERSION-01/".
+// In pre-publication state all 3 SDKs return warn (404); that is expected.
 func TestCheckSDKVersions_Smoke(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	results := CheckSDKVersions(ctx)
-	if len(results) != 4 {
-		t.Fatalf("expected 4 CheckResults, got %d", len(results))
+	if len(results) != 3 {
+		t.Fatalf("expected 3 CheckResults, got %d", len(results))
 	}
 	for i, r := range results {
 		if r.Section != "sdk" {

--- a/internal/sentryapi/client.go
+++ b/internal/sentryapi/client.go
@@ -1,0 +1,263 @@
+// Package sentryapi is the typed REST client for the ɳSentry cloud API.
+//
+// Purpose: One client for both worlds — the hosted SaaS (api.sentry.nself.org)
+//
+//	and a self-hosted / local sentry bundle (NSELF_SENTRY_API_URL).
+//
+// Contract (v1, consumed by `nself sentry *` and the MCP sentry tools):
+//
+//	Auth:   Authorization: Bearer nsk_<key>   (API keys issued per tenant, W1)
+//	GET    /v1/me                              → {"tenant_id","email","tier","quotas":{dim:{"used","limit"}}}
+//	GET    /v1/monitors                        → {"monitors":[Monitor]}
+//	POST   /v1/monitors                        → 201 {"monitor":Monitor}
+//	DELETE /v1/monitors/{id}                   → 204
+//	POST   /v1/monitors/{id}/pause|resume      → {"monitor":Monitor}
+//	GET    /v1/incidents?status=<s>            → {"incidents":[Incident]}
+//	POST   /v1/incidents/{id}/ack|resolve      → {"incident":Incident}
+//	GET    /v1/status-pages                    → {"status_pages":[StatusPage]}
+//	POST   /v1/status-pages                    → 201 {"status_page":StatusPage}
+//	GET    /v1/alerts/channels                 → {"channels":[AlertChannel]}
+//	POST   /v1/alerts/channels/{id}/test       → {"delivered":bool,"detail":string}
+//	Errors: non-2xx {"error":{"code","message"}}; 401 → ErrUnauthorized,
+//	        402/429 → ErrQuotaExceeded (upgrade hint).
+//
+// Constraints: no cobra imports here; pure HTTP + JSON so MCP and commands share it.
+// SPORT: CLI-PKG-SENTRYAPI-001
+package sentryapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultAPIURL is the hosted ɳSentry SaaS API endpoint.
+const DefaultAPIURL = "https://api.sentry.nself.org"
+
+// KeyPrefix is the required prefix for ɳSentry API keys.
+const KeyPrefix = "nsk_"
+
+// ErrUnauthorized is returned on HTTP 401 — the caller should suggest
+// `nself sentry login`.
+var ErrUnauthorized = errors.New("unauthorized: invalid or missing API key — run 'nself sentry login'")
+
+// ErrQuotaExceeded is returned on HTTP 402/429 quota responses.
+var ErrQuotaExceeded = errors.New("quota exceeded for your tier — upgrade at https://sentry.nself.org/billing")
+
+// Client is a typed REST client for the ɳSentry API.
+type Client struct {
+	BaseURL string
+	APIKey  string
+	HTTP    *http.Client
+}
+
+// New returns a Client for baseURL/apiKey with a sane default timeout.
+func New(baseURL, apiKey string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultAPIURL
+	}
+	return &Client{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		APIKey:  apiKey,
+		HTTP:    &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// WhoAmI returns the authenticated account (tier + quota usage).
+func (c *Client) WhoAmI(ctx context.Context) (*Account, error) {
+	var acct Account
+	if err := c.do(ctx, http.MethodGet, "/v1/me", nil, &acct); err != nil {
+		return nil, err
+	}
+	return &acct, nil
+}
+
+// ListMonitors returns all monitors for the tenant.
+func (c *Client) ListMonitors(ctx context.Context) ([]Monitor, error) {
+	var env monitorsEnvelope
+	if err := c.do(ctx, http.MethodGet, "/v1/monitors", nil, &env); err != nil {
+		return nil, err
+	}
+	return env.Monitors, nil
+}
+
+// CreateMonitor creates a monitor and returns the created record.
+func (c *Client) CreateMonitor(ctx context.Context, req CreateMonitorRequest) (*Monitor, error) {
+	var env monitorEnvelope
+	if err := c.do(ctx, http.MethodPost, "/v1/monitors", req, &env); err != nil {
+		return nil, err
+	}
+	return &env.Monitor, nil
+}
+
+// DeleteMonitor removes a monitor by id.
+func (c *Client) DeleteMonitor(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodDelete, "/v1/monitors/"+url.PathEscape(id), nil, nil)
+}
+
+// PauseMonitor pauses (paused=true) or resumes (paused=false) a monitor.
+func (c *Client) PauseMonitor(ctx context.Context, id string, pause bool) (*Monitor, error) {
+	action := "pause"
+	if !pause {
+		action = "resume"
+	}
+	var env monitorEnvelope
+	path := "/v1/monitors/" + url.PathEscape(id) + "/" + action
+	if err := c.do(ctx, http.MethodPost, path, nil, &env); err != nil {
+		return nil, err
+	}
+	return &env.Monitor, nil
+}
+
+// ListIncidents returns incidents, optionally filtered by status
+// (open | acknowledged | resolved; empty = all).
+func (c *Client) ListIncidents(ctx context.Context, status string) ([]Incident, error) {
+	path := "/v1/incidents"
+	if status != "" {
+		path += "?status=" + url.QueryEscape(status)
+	}
+	var env incidentsEnvelope
+	if err := c.do(ctx, http.MethodGet, path, nil, &env); err != nil {
+		return nil, err
+	}
+	return env.Incidents, nil
+}
+
+// AckIncident acknowledges an open incident.
+func (c *Client) AckIncident(ctx context.Context, id string) (*Incident, error) {
+	return c.incidentAction(ctx, id, "ack")
+}
+
+// ResolveIncident resolves an incident.
+func (c *Client) ResolveIncident(ctx context.Context, id string) (*Incident, error) {
+	return c.incidentAction(ctx, id, "resolve")
+}
+
+// incidentAction POSTs /v1/incidents/{id}/{action} and returns the incident.
+func (c *Client) incidentAction(ctx context.Context, id, action string) (*Incident, error) {
+	var env incidentEnvelope
+	path := "/v1/incidents/" + url.PathEscape(id) + "/" + action
+	if err := c.do(ctx, http.MethodPost, path, nil, &env); err != nil {
+		return nil, err
+	}
+	return &env.Incident, nil
+}
+
+// ListStatusPages returns the tenant's status pages.
+func (c *Client) ListStatusPages(ctx context.Context) ([]StatusPage, error) {
+	var env statusPagesEnvelope
+	if err := c.do(ctx, http.MethodGet, "/v1/status-pages", nil, &env); err != nil {
+		return nil, err
+	}
+	return env.StatusPages, nil
+}
+
+// CreateStatusPage creates a status page.
+func (c *Client) CreateStatusPage(ctx context.Context, req CreateStatusPageRequest) (*StatusPage, error) {
+	var env statusPageEnvelope
+	if err := c.do(ctx, http.MethodPost, "/v1/status-pages", req, &env); err != nil {
+		return nil, err
+	}
+	return &env.StatusPage, nil
+}
+
+// ListAlertChannels returns the tenant's alert channels.
+func (c *Client) ListAlertChannels(ctx context.Context) ([]AlertChannel, error) {
+	var env channelsEnvelope
+	if err := c.do(ctx, http.MethodGet, "/v1/alerts/channels", nil, &env); err != nil {
+		return nil, err
+	}
+	return env.Channels, nil
+}
+
+// TestAlertChannel sends a test notification through a channel.
+func (c *Client) TestAlertChannel(ctx context.Context, id string) (*TestChannelResult, error) {
+	var res TestChannelResult
+	path := "/v1/alerts/channels/" + url.PathEscape(id) + "/test"
+	if err := c.do(ctx, http.MethodPost, path, nil, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// do executes one API request: marshal body → set auth header → decode into out.
+//
+// Purpose:  Single choke point for auth, error mapping, and JSON codec.
+// Inputs:   ctx, method, path (starting with /), body (nil = no body), out (nil = discard).
+// Outputs:  Typed errors: ErrUnauthorized (401), ErrQuotaExceeded (402/429),
+//
+//	otherwise a wrapped error carrying the server's error.message when present.
+func (c *Client) do(ctx context.Context, method, path string, body, out interface{}) error {
+	var rdr io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		rdr = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, rdr)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("sentry api unreachable (%s): %w", c.BaseURL, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		return ErrUnauthorized
+	case resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode == http.StatusTooManyRequests:
+		return fmt.Errorf("%w: %s", ErrQuotaExceeded, serverMessage(respBody))
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		return fmt.Errorf("sentry api HTTP %d: %s", resp.StatusCode, serverMessage(respBody))
+	}
+
+	if out == nil || len(respBody) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	return nil
+}
+
+// serverMessage extracts error.message from the wire envelope, falling back
+// to the (truncated) raw body.
+func serverMessage(body []byte) string {
+	var e apiError
+	if err := json.Unmarshal(body, &e); err == nil && e.Error.Message != "" {
+		return e.Error.Message
+	}
+	s := strings.TrimSpace(string(body))
+	if len(s) > 200 {
+		s = s[:200] + "..."
+	}
+	if s == "" {
+		s = "(empty body)"
+	}
+	return s
+}

--- a/internal/sentryapi/client_test.go
+++ b/internal/sentryapi/client_test.go
@@ -1,0 +1,289 @@
+package sentryapi
+
+// client_test.go — httptest-backed unit tests for the sentryapi client.
+//
+// Purpose: Verify auth header wiring, envelope decoding, typed error mapping
+//   (401 → ErrUnauthorized, 402/429 → ErrQuotaExceeded), and config resolution.
+// Constraints: no network; every test runs against net/http/httptest.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newTestServer returns a server that asserts the Bearer key and serves
+// canned responses per path.
+func newTestServer(t *testing.T, wantKey string, routes map[string]func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if wantKey != "" {
+			if got := r.Header.Get("Authorization"); got != "Bearer "+wantKey {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":{"code":"unauthorized","message":"bad key"}}`))
+				return
+			}
+		}
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"no route"}}`))
+	}))
+}
+
+func jsonHandler(status int, body string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+func TestListMonitors(t *testing.T) {
+	srv := newTestServer(t, "nsk_testkey123", map[string]func(http.ResponseWriter, *http.Request){
+		"GET /v1/monitors": jsonHandler(200, `{"monitors":[
+			{"id":"m1","name":"api","url":"https://api.example.com","kind":"http","interval_seconds":60,"status":"up","paused":false},
+			{"id":"m2","name":"web","url":"https://example.com","kind":"http","interval_seconds":300,"status":"paused","paused":true}
+		]}`),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "nsk_testkey123")
+	mons, err := c.ListMonitors(context.Background())
+	if err != nil {
+		t.Fatalf("ListMonitors: %v", err)
+	}
+	if len(mons) != 2 {
+		t.Fatalf("want 2 monitors, got %d", len(mons))
+	}
+	if mons[0].ID != "m1" || mons[0].Kind != "http" || mons[0].IntervalSeconds != 60 {
+		t.Errorf("monitor[0] decoded wrong: %+v", mons[0])
+	}
+	if !mons[1].Paused {
+		t.Errorf("monitor[1] should be paused")
+	}
+}
+
+func TestCreateMonitor(t *testing.T) {
+	srv := newTestServer(t, "nsk_testkey123", map[string]func(http.ResponseWriter, *http.Request){
+		"POST /v1/monitors": func(w http.ResponseWriter, r *http.Request) {
+			var req CreateMonitorRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode create body: %v", err)
+			}
+			if req.Name != "api" || req.URL != "https://api.example.com" || req.IntervalSeconds != 60 {
+				t.Errorf("unexpected create body: %+v", req)
+			}
+			jsonHandler(201, `{"monitor":{"id":"m9","name":"api","url":"https://api.example.com","kind":"http","interval_seconds":60,"status":"pending"}}`)(w, r)
+		},
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "nsk_testkey123")
+	m, err := c.CreateMonitor(context.Background(), CreateMonitorRequest{
+		Name: "api", URL: "https://api.example.com", Kind: "http", IntervalSeconds: 60,
+	})
+	if err != nil {
+		t.Fatalf("CreateMonitor: %v", err)
+	}
+	if m.ID != "m9" || m.Status != "pending" {
+		t.Errorf("created monitor decoded wrong: %+v", m)
+	}
+}
+
+func TestDeleteAndPauseMonitor(t *testing.T) {
+	srv := newTestServer(t, "nsk_testkey123", map[string]func(http.ResponseWriter, *http.Request){
+		"DELETE /v1/monitors/m1":      jsonHandler(204, ""),
+		"POST /v1/monitors/m1/pause":  jsonHandler(200, `{"monitor":{"id":"m1","status":"paused","paused":true}}`),
+		"POST /v1/monitors/m1/resume": jsonHandler(200, `{"monitor":{"id":"m1","status":"pending","paused":false}}`),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "nsk_testkey123")
+	if err := c.DeleteMonitor(context.Background(), "m1"); err != nil {
+		t.Fatalf("DeleteMonitor: %v", err)
+	}
+	m, err := c.PauseMonitor(context.Background(), "m1", true)
+	if err != nil {
+		t.Fatalf("PauseMonitor: %v", err)
+	}
+	if !m.Paused {
+		t.Errorf("expected paused=true, got %+v", m)
+	}
+	m, err = c.PauseMonitor(context.Background(), "m1", false)
+	if err != nil {
+		t.Fatalf("ResumeMonitor: %v", err)
+	}
+	if m.Paused {
+		t.Errorf("expected paused=false after resume, got %+v", m)
+	}
+}
+
+func TestIncidentsLifecycle(t *testing.T) {
+	srv := newTestServer(t, "nsk_testkey123", map[string]func(http.ResponseWriter, *http.Request){
+		"GET /v1/incidents": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("status") != "open" {
+				t.Errorf("want status=open filter, got %q", r.URL.RawQuery)
+			}
+			jsonHandler(200, `{"incidents":[{"id":"i1","monitor_id":"m1","title":"api down","status":"open","severity":"critical","started_at":"2026-07-01T00:00:00Z"}]}`)(w, r)
+		},
+		"POST /v1/incidents/i1/ack":     jsonHandler(200, `{"incident":{"id":"i1","status":"acknowledged"}}`),
+		"POST /v1/incidents/i1/resolve": jsonHandler(200, `{"incident":{"id":"i1","status":"resolved"}}`),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "nsk_testkey123")
+	incs, err := c.ListIncidents(context.Background(), "open")
+	if err != nil {
+		t.Fatalf("ListIncidents: %v", err)
+	}
+	if len(incs) != 1 || incs[0].Title != "api down" {
+		t.Fatalf("incidents decoded wrong: %+v", incs)
+	}
+	if inc, err := c.AckIncident(context.Background(), "i1"); err != nil || inc.Status != "acknowledged" {
+		t.Errorf("AckIncident: inc=%+v err=%v", inc, err)
+	}
+	if inc, err := c.ResolveIncident(context.Background(), "i1"); err != nil || inc.Status != "resolved" {
+		t.Errorf("ResolveIncident: inc=%+v err=%v", inc, err)
+	}
+}
+
+func TestStatusPagesAndChannels(t *testing.T) {
+	srv := newTestServer(t, "nsk_testkey123", map[string]func(http.ResponseWriter, *http.Request){
+		"GET /v1/status-pages":             jsonHandler(200, `{"status_pages":[{"id":"s1","name":"Public","slug":"public","url":"https://sentry.nself.org/s/public","public":true}]}`),
+		"POST /v1/status-pages":            jsonHandler(201, `{"status_page":{"id":"s2","name":"API","slug":"api","public":true}}`),
+		"GET /v1/alerts/channels":          jsonHandler(200, `{"channels":[{"id":"c1","kind":"email","target":"ops@example.com","enabled":true}]}`),
+		"POST /v1/alerts/channels/c1/test": jsonHandler(200, `{"delivered":true,"detail":"test email sent"}`),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "nsk_testkey123")
+	pages, err := c.ListStatusPages(context.Background())
+	if err != nil || len(pages) != 1 || pages[0].Slug != "public" {
+		t.Fatalf("ListStatusPages: pages=%+v err=%v", pages, err)
+	}
+	sp, err := c.CreateStatusPage(context.Background(), CreateStatusPageRequest{Name: "API", Slug: "api"})
+	if err != nil || sp.ID != "s2" {
+		t.Fatalf("CreateStatusPage: sp=%+v err=%v", sp, err)
+	}
+	chans, err := c.ListAlertChannels(context.Background())
+	if err != nil || len(chans) != 1 || chans[0].Kind != "email" {
+		t.Fatalf("ListAlertChannels: chans=%+v err=%v", chans, err)
+	}
+	res, err := c.TestAlertChannel(context.Background(), "c1")
+	if err != nil || !res.Delivered {
+		t.Fatalf("TestAlertChannel: res=%+v err=%v", res, err)
+	}
+}
+
+func TestWhoAmI(t *testing.T) {
+	srv := newTestServer(t, "nsk_testkey123", map[string]func(http.ResponseWriter, *http.Request){
+		"GET /v1/me": jsonHandler(200, `{"tenant_id":"t1","email":"dev@example.com","tier":"bundle","quotas":{"monitors":{"used":3,"limit":50}}}`),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "nsk_testkey123")
+	acct, err := c.WhoAmI(context.Background())
+	if err != nil {
+		t.Fatalf("WhoAmI: %v", err)
+	}
+	if acct.Tier != "bundle" || acct.Quotas["monitors"].Limit != 50 {
+		t.Errorf("account decoded wrong: %+v", acct)
+	}
+}
+
+func TestErrorMapping(t *testing.T) {
+	srv := newTestServer(t, "nsk_rightkey12", map[string]func(http.ResponseWriter, *http.Request){
+		"GET /v1/monitors": jsonHandler(429, `{"error":{"code":"quota_exceeded","message":"monitor limit reached (10/10)"}}`),
+	})
+	defer srv.Close()
+
+	// Wrong key → 401 → ErrUnauthorized.
+	c := New(srv.URL, "nsk_wrongkey12")
+	if _, err := c.ListMonitors(context.Background()); !errors.Is(err, ErrUnauthorized) {
+		t.Errorf("want ErrUnauthorized, got %v", err)
+	}
+
+	// Right key but 429 → ErrQuotaExceeded with server message.
+	c = New(srv.URL, "nsk_rightkey12")
+	_, err := c.ListMonitors(context.Background())
+	if !errors.Is(err, ErrQuotaExceeded) {
+		t.Errorf("want ErrQuotaExceeded, got %v", err)
+	}
+}
+
+func TestResolvePrecedence(t *testing.T) {
+	// Isolate HOME so no real credentials file leaks in.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv(EnvAPIURL, "")
+	t.Setenv(EnvAPIKey, "")
+
+	// Defaults.
+	u, k := Resolve("", "")
+	if u != DefaultAPIURL || k != "" {
+		t.Errorf("defaults: got url=%q key=%q", u, k)
+	}
+
+	// Credentials file.
+	if err := WriteCredentials(&Credentials{APIURL: "http://localhost:3848", APIKey: "nsk_filekey123"}); err != nil {
+		t.Fatalf("WriteCredentials: %v", err)
+	}
+	u, k = Resolve("", "")
+	if u != "http://localhost:3848" || k != "nsk_filekey123" {
+		t.Errorf("file: got url=%q key=%q", u, k)
+	}
+
+	// File permissions must be 0600.
+	info, err := os.Stat(filepath.Join(tmp, ".nself", "sentry.json"))
+	if err != nil {
+		t.Fatalf("stat credentials: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("credentials mode = %v, want 0600", info.Mode().Perm())
+	}
+
+	// Env beats file.
+	t.Setenv(EnvAPIURL, "http://envhost:9999")
+	t.Setenv(EnvAPIKey, "nsk_envkey1234")
+	u, k = Resolve("", "")
+	if u != "http://envhost:9999" || k != "nsk_envkey1234" {
+		t.Errorf("env: got url=%q key=%q", u, k)
+	}
+
+	// Flag beats env.
+	u, k = Resolve("http://flaghost:1111", "nsk_flagkey123")
+	if u != "http://flaghost:1111" || k != "nsk_flagkey123" {
+		t.Errorf("flag: got url=%q key=%q", u, k)
+	}
+
+	// Logout removes the file.
+	if err := DeleteCredentials(); err != nil {
+		t.Fatalf("DeleteCredentials: %v", err)
+	}
+	t.Setenv(EnvAPIURL, "")
+	t.Setenv(EnvAPIKey, "")
+	if _, err := ReadCredentials(); !errors.Is(err, ErrNotLoggedIn) {
+		t.Errorf("want ErrNotLoggedIn after delete, got %v", err)
+	}
+}
+
+func TestValidateKeyFormat(t *testing.T) {
+	if err := ValidateKeyFormat("nsk_devlocal0000"); err != nil {
+		t.Errorf("valid key rejected: %v", err)
+	}
+	if err := ValidateKeyFormat("sk_wrongprefix"); err == nil {
+		t.Errorf("wrong prefix accepted")
+	}
+	if err := ValidateKeyFormat("nsk_a"); err == nil {
+		t.Errorf("short key accepted")
+	}
+}

--- a/internal/sentryapi/credentials.go
+++ b/internal/sentryapi/credentials.go
@@ -1,0 +1,138 @@
+package sentryapi
+
+// credentials.go — local credential storage + config resolution.
+//
+// Purpose: Persist the ɳSentry API key at ~/.nself/sentry.json (0600) and
+//   resolve the effective api-url/api-key across flag → env → file → default.
+// Inputs:  NSELF_SENTRY_API_URL / NSELF_SENTRY_API_KEY env vars, credentials file.
+// Outputs: Credentials struct; Resolve() precedence result.
+// Constraints: file mode 0600 (P15 env-perms lesson); never log the key.
+// SPORT: CLI-PKG-SENTRYAPI-001
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EnvAPIURL / EnvAPIKey are the environment overrides for the client config.
+const (
+	EnvAPIURL = "NSELF_SENTRY_API_URL"
+	EnvAPIKey = "NSELF_SENTRY_API_KEY"
+)
+
+// ErrNotLoggedIn is returned when no credentials file exists.
+var ErrNotLoggedIn = errors.New("not logged in to ɳSentry — run 'nself sentry login'")
+
+// Credentials is the on-disk shape of ~/.nself/sentry.json.
+type Credentials struct {
+	APIURL string `json:"api_url"`
+	APIKey string `json:"api_key"`
+}
+
+// credentialsPath returns ~/.nself/sentry.json (honors HOME for tests).
+func credentialsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".nself", "sentry.json"), nil
+}
+
+// ReadCredentials loads the stored credentials, or ErrNotLoggedIn.
+func ReadCredentials() (*Credentials, error) {
+	path, err := credentialsPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotLoggedIn
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var c Credentials
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &c, nil
+}
+
+// WriteCredentials persists credentials at 0600 (dir 0700).
+func WriteCredentials(c *Credentials) error {
+	path, err := credentialsPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal credentials: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	// Defence-in-depth: enforce 0600 even if the file pre-existed.
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	return nil
+}
+
+// DeleteCredentials removes the stored credentials (no-op when absent).
+func DeleteCredentials() error {
+	path, err := credentialsPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %s: %w", path, err)
+	}
+	return nil
+}
+
+// Resolve computes the effective (apiURL, apiKey) using precedence:
+// explicit args (flags) → env vars → credentials file → defaults.
+// A missing key is not an error here — the API returns 401 and the client
+// maps it to ErrUnauthorized with the login hint.
+func Resolve(flagURL, flagKey string) (apiURL, apiKey string) {
+	apiURL = flagURL
+	apiKey = flagKey
+	if apiURL == "" {
+		apiURL = os.Getenv(EnvAPIURL)
+	}
+	if apiKey == "" {
+		apiKey = os.Getenv(EnvAPIKey)
+	}
+	if apiURL == "" || apiKey == "" {
+		if creds, err := ReadCredentials(); err == nil {
+			if apiURL == "" {
+				apiURL = creds.APIURL
+			}
+			if apiKey == "" {
+				apiKey = creds.APIKey
+			}
+		}
+	}
+	if apiURL == "" {
+		apiURL = DefaultAPIURL
+	}
+	return apiURL, apiKey
+}
+
+// ValidateKeyFormat checks the nsk_ prefix without hitting the network.
+func ValidateKeyFormat(key string) error {
+	if !strings.HasPrefix(key, KeyPrefix) {
+		return fmt.Errorf("invalid API key: must start with %q", KeyPrefix)
+	}
+	if len(key) < len(KeyPrefix)+8 {
+		return errors.New("invalid API key: too short")
+	}
+	return nil
+}

--- a/internal/sentryapi/types.go
+++ b/internal/sentryapi/types.go
@@ -1,0 +1,119 @@
+package sentryapi
+
+// types.go — typed request/response shapes for the ɳSentry cloud API.
+//
+// Purpose: Single source of the CLI↔API wire contract (v1) shared by the
+//   `nself sentry` cloud subcommands and the MCP sentry tools.
+// Inputs:  JSON bodies from api.sentry.nself.org (or a self-hosted bundle).
+// Outputs: Go structs used for table + --json output.
+// Constraints: Field names are the contract — W1 (tenantization/API) builds
+//   the server to THIS shape. Change only with a matching plugins-pro change.
+// SPORT: CLI-PKG-SENTRYAPI-001
+
+// Monitor is an uptime monitor owned by the authenticated tenant.
+type Monitor struct {
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	URL             string `json:"url"`
+	Kind            string `json:"kind"` // http | tcp | ping
+	IntervalSeconds int    `json:"interval_seconds"`
+	Status          string `json:"status"` // up | down | paused | pending
+	Paused          bool   `json:"paused"`
+	CreatedAt       string `json:"created_at"`
+}
+
+// Incident is a monitoring incident (open → acknowledged → resolved).
+type Incident struct {
+	ID             string `json:"id"`
+	MonitorID      string `json:"monitor_id"`
+	Title          string `json:"title"`
+	Status         string `json:"status"` // open | acknowledged | resolved
+	Severity       string `json:"severity"`
+	StartedAt      string `json:"started_at"`
+	AcknowledgedAt string `json:"acknowledged_at,omitempty"`
+	ResolvedAt     string `json:"resolved_at,omitempty"`
+}
+
+// StatusPage is a public status page owned by the tenant.
+type StatusPage struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Slug      string `json:"slug"`
+	URL       string `json:"url"`
+	Public    bool   `json:"public"`
+	CreatedAt string `json:"created_at"`
+}
+
+// AlertChannel is a notification target (email/webhook/slack/telegram).
+type AlertChannel struct {
+	ID      string `json:"id"`
+	Kind    string `json:"kind"` // email | webhook | slack | telegram
+	Target  string `json:"target"`
+	Enabled bool   `json:"enabled"`
+}
+
+// QuotaUsage is used/limit for a single quota dimension.
+type QuotaUsage struct {
+	Used  int64 `json:"used"`
+	Limit int64 `json:"limit"`
+}
+
+// Account is the response of GET /v1/me — identity, tier, and quota usage.
+type Account struct {
+	TenantID string                `json:"tenant_id"`
+	Email    string                `json:"email"`
+	Tier     string                `json:"tier"` // free | bundle | nself-plus
+	Quotas   map[string]QuotaUsage `json:"quotas"`
+}
+
+// CreateMonitorRequest is the body of POST /v1/monitors.
+type CreateMonitorRequest struct {
+	Name            string `json:"name"`
+	URL             string `json:"url"`
+	Kind            string `json:"kind"`
+	IntervalSeconds int    `json:"interval_seconds"`
+}
+
+// CreateStatusPageRequest is the body of POST /v1/status-pages.
+type CreateStatusPageRequest struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// TestChannelResult is the response of POST /v1/alerts/channels/{id}/test.
+type TestChannelResult struct {
+	Delivered bool   `json:"delivered"`
+	Detail    string `json:"detail"`
+}
+
+// apiError is the wire error envelope: {"error":{"code":"...","message":"..."}}.
+type apiError struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// Wrapper envelopes — every list/detail response is a named-key object so the
+// contract can grow (pagination, meta) without breaking clients.
+type monitorsEnvelope struct {
+	Monitors []Monitor `json:"monitors"`
+}
+type monitorEnvelope struct {
+	Monitor Monitor `json:"monitor"`
+}
+type incidentsEnvelope struct {
+	Incidents []Incident `json:"incidents"`
+}
+type incidentEnvelope struct {
+	Incident Incident `json:"incident"`
+}
+type statusPagesEnvelope struct {
+	StatusPages []StatusPage `json:"status_pages"`
+}
+type statusPageEnvelope struct {
+	StatusPage StatusPage `json:"status_page"`
+}
+type channelsEnvelope struct {
+	Channels []AlertChannel `json:"channels"`
+}


### PR DESCRIPTION
## W7+W8 — ɳSentry cloud CLI, MCP tools, nsentry alias, local-first preset

Part of the ɳSentry SaaS program (`.claude/docs/nsentry-saas-plan.md`, W7 CLI+API+MCP surface, W8 local-first dev env).

### Commands (new)

- `nself sentry login | logout | whoami` — API key (`nsk_*`) stored at `~/.nself/sentry.json` (0600), validated via `GET /v1/me`; whoami shows tier + quota usage
- `nself sentry monitors list | add | rm | pause | resume`
- `nself sentry incidents list [--status] | ack | resolve`
- `nself sentry status-pages list | create`
- `nself sentry alerts channels | test <id>`
- All cloud subcommands take `--api-url` / `--api-key` / `--json`; resolution: flag → `NSELF_SENTRY_API_URL`/`NSELF_SENTRY_API_KEY` → `~/.nself/sentry.json` → `https://api.sentry.nself.org`
- `nsentry` binary alias: symlink to `nself` routes to the sentry group (argv0 shim in Execute, per aliases.go)

### MCP tools (the AI-operates-monitoring moat)

`nself mcp` now also serves: `sentry_monitors_list`, `sentry_monitors_add`, `sentry_incidents_list`, `sentry_incidents_ack`, `sentry_status`. Same client pkg as the CLI. Example prompts documented in `cmd-mcp.md`.

### Client pkg

`internal/sentryapi` — typed REST client, contract v1 documented in the package doc (Bearer nsk_*, enveloped JSON, 401→ErrUnauthorized with login hint, 402/429→ErrQuotaExceeded). httptest unit tests.

### W8 local-first

`nself init --preset sentry` — 13 sentry bundle plugins, notes documenting the seeded dev tenant + dev API key (`nsk_dev_local_…`) and local API `http://localhost:3848` (port reserved in SPORT F10 as `nself-sentry-api`, pending W1 plugin implementation).

### Also

- Fixed stale `TestCheckSDKVersions_Smoke` (expected 4 SDKs; Flutter SDK was removed in #159 → 3). Pre-existing failure on main.
- Wiki: new `cmd-sentry.md`, updated `cmd-mcp.md`, `COMMANDS.md`, `_Sidebar.md`. SPORT F02/F10 updated in project tree.

No version bump. No new vendored deps. `go build ./...` + affected tests green.
