### PR TITLE
fix(db): pre-flight remote CLI version-drift check for db --env commands

### DIFF
--- a/cmd/commands/db.go
+++ b/cmd/commands/db.go
@@ -61,9 +61,15 @@ var dbMigrateUpCmd = &cobra.Command{
 Pass --env staging|prod (with NSELF_DEPLOY_HOST_<ENV> set, or an entry in
 .nself/control-plane.yaml) to run this against a deployed target instead of
 the local docker daemon: the command re-invokes 'nself db migrate up' on the
-remote host over SSH. Note: this requires the remote host's nself CLI
-version to support 'db migrate up' — an older remote CLI returns a clear
-error naming the version-drift cause rather than a raw SSH failure.`,
+remote host over SSH, cd'ing into NSELF_REMOTE_PATH_<ENV> (default
+/opt/nself) first.
+
+Before running the remote command, the CLI proactively verifies the remote
+host's nself version matches the local one (running 'nself --version' over
+the same SSH connection). An older or newer remote CLI errors clearly,
+naming both versions and the host, instead of silently trusting output from
+a version-mismatched binary or failing with a raw SSH error. Pass
+--allow-version-drift to skip this check and run anyway.`,
 	RunE: runDBMigrateUp,
 }
 

--- a/cmd/commands/db_remote.go
+++ b/cmd/commands/db_remote.go
@@ -42,6 +42,7 @@ const dbRemoteEnvFlag = "env"
 func addDBRemoteFlags(cmd *cobra.Command) {
 	cmd.Flags().String(dbRemoteEnvFlag, "", "Target environment: local|staging|prod (default: local). Requires NSELF_DEPLOY_HOST_<ENV> or .nself/control-plane.yaml")
 	cmd.Flags().String("server", "", "Run against a specific server name from control-plane inventory (overrides --env's default server selection)")
+	cmd.Flags().Bool("allow-version-drift", false, "skip the local/remote nself version match check for remote --env targets")
 }
 
 // dbRemoteTarget is the resolved destination for a db/hasura command.
@@ -63,6 +64,10 @@ type dbRemoteTarget struct {
 	// RemotePath is the absolute path to the nSelf project on the remote
 	// host, used to `cd` before invoking the remote nself binary.
 	RemotePath string
+
+	// AllowVersionDrift, when true, skips checkRemoteVersionDrift's
+	// pre-flight local/remote nself version match check (--allow-version-drift).
+	AllowVersionDrift bool
 }
 
 // resolveDBRemoteTarget reads --env/--server from cmd and resolves them to a
@@ -173,9 +178,14 @@ func findDBTargetServer(env controlplane.Environment, serverFlag string) (contro
 // here, ssh/bash reports "command not found" or cobra reports "unknown
 // command" — wrapRemoteVersionDriftError turns that into an explicit,
 // actionable message instead of a raw stack trace or bare exit status.
+//
+// Before running the real remote command, this also runs a proactive
+// checkRemoteVersionDrift probe (unless rt.AllowVersionDrift is set) — a
+// mismatched remote CLI can run a subcommand "successfully" while printing
+// untrustworthy output (see checkRemoteVersionDrift's doc comment), which
+// wrapRemoteVersionDriftError's after-the-fact "command not found" sniffing
+// cannot catch.
 func runRemoteNselfCommand(ctx context.Context, rt dbRemoteTarget, args ...string) error {
-	remoteCmd := fmt.Sprintf("cd %s && nself %s", shellQuoteArg(rt.RemotePath), strings.Join(shellQuoteArgs(args), " "))
-
 	keyPath := rt.KeyPath
 	if keyPath == "" {
 		keyPath = defaultSSHKeyPath()
@@ -186,8 +196,16 @@ func runRemoteNselfCommand(ctx context.Context, rt dbRemoteTarget, args ...strin
 		"-o", "BatchMode=yes",
 		"-o", "ForwardAgent=no",
 		"-o", "StrictHostKeyChecking=accept-new",
-		rt.SSHTarget, remoteCmd,
 	}
+
+	if !rt.AllowVersionDrift {
+		if driftErr := checkRemoteVersionDrift(ctx, rt, sshArgs, joinRemoteArgs(args)); driftErr != nil {
+			return driftErr
+		}
+	}
+
+	remoteCmd := fmt.Sprintf("cd %s && nself %s", shellQuoteArg(rt.RemotePath), strings.Join(shellQuoteArgs(args), " "))
+	sshArgs = append(sshArgs, rt.SSHTarget, remoteCmd)
 
 	out, err := runSSHCaptured(ctx, sshArgs)
 	if out != "" {
@@ -248,8 +266,12 @@ func dispatchRemoteIfNeeded(cmd *cobra.Command, remoteArgs ...string) (handled b
 		return false, nil
 	}
 
+	if allowDrift, _ := cmd.Flags().GetBool("allow-version-drift"); allowDrift {
+		target.AllowVersionDrift = true
+	}
+
 	if !cmd.Flags().Changed("json") {
-		fmt.Fprintf(cmd.OutOrStdout(), "Running 'nself %s' on %s (env=%s)...\n", strings.Join(remoteArgs, " "), target.SSHTarget, target.EnvName)
+		fmt.Fprintf(cmd.OutOrStdout(), "Running 'nself %s' on %s:%s (env=%s)...\n", strings.Join(remoteArgs, " "), target.SSHTarget, target.RemotePath, target.EnvName)
 	}
 
 	return true, runRemoteNselfCommand(cmd.Context(), target, remoteArgs...)

--- a/cmd/commands/db_remote_exec.go
+++ b/cmd/commands/db_remote_exec.go
@@ -20,7 +20,12 @@ import (
 // runSSHCaptured runs `ssh <sshArgs...>` and returns combined stdout+stderr
 // plus any error from the process itself (non-zero exit, ssh connection
 // failure, etc.).
-func runSSHCaptured(ctx context.Context, sshArgs []string) (string, error) {
+//
+// This is a package-level var (rather than a plain func) so tests can stub
+// remote SSH execution entirely — save the original, assign a closure,
+// defer restoring it — without spinning up a real ssh process or fixture
+// host. See TestCheckRemoteVersionDrift_* in db_remote_test.go.
+var runSSHCaptured = func(ctx context.Context, sshArgs []string) (string, error) {
 	sc := exec.CommandContext(ctx, "ssh", sshArgs...)
 	out, err := sc.CombinedOutput()
 	return strings.TrimSpace(string(out)), err

--- a/cmd/commands/db_remote_test.go
+++ b/cmd/commands/db_remote_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/nself-org/cli/internal/controlplane"
+	"github.com/nself-org/cli/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -346,5 +347,231 @@ func TestResolveDBRemoteTarget_ProjectRootIsRespected(t *testing.T) {
 	}
 	if target.SSHTarget != "deploy@example.com" {
 		t.Errorf("expected resolution from project root inventory, got SSHTarget=%q", target.SSHTarget)
+	}
+}
+
+// ── checkRemoteVersionDrift / runRemoteNselfCommand pre-flight (gap #16) ──
+
+// withStubbedSSH replaces runSSHCaptured with fn for the duration of the
+// test, restoring the original on cleanup. Callers that need to assert call
+// counts/args should close over their own state inside fn.
+func withStubbedSSH(t *testing.T, fn func(ctx context.Context, sshArgs []string) (string, error)) {
+	t.Helper()
+	orig := runSSHCaptured
+	runSSHCaptured = fn
+	t.Cleanup(func() { runSSHCaptured = orig })
+}
+
+// withLocalVersion overrides version.Version for the duration of the test,
+// restoring the original on cleanup (mirrors internal/version/version_test.go's
+// TestVersion_Overridable pattern).
+func withLocalVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := version.Version
+	version.Version = v
+	t.Cleanup(func() { version.Version = orig })
+}
+
+// TestRunRemoteNselfCommand_VersionDriftBlocksRealCommand verifies that a
+// mismatched remote nself version (1.0.9) against local (1.2.0) produces an
+// error naming both versions and the host, and that the real subcommand is
+// never executed after drift is detected (call count stays at 1 — the
+// version probe — not 2).
+func TestRunRemoteNselfCommand_VersionDriftBlocksRealCommand(t *testing.T) {
+	withLocalVersion(t, "1.2.0")
+
+	calls := 0
+	withStubbedSSH(t, func(ctx context.Context, sshArgs []string) (string, error) {
+		calls++
+		return "nself version 1.0.9", nil
+	})
+
+	rt := dbRemoteTarget{SSHTarget: "deploy@staging.example.com", EnvName: "staging", RemotePath: "/opt/nself"}
+	err := runRemoteNselfCommand(context.Background(), rt, "db", "migrate", "status")
+	if err == nil {
+		t.Fatal("expected a version-drift error")
+	}
+	if !strings.Contains(err.Error(), "1.2.0") || !strings.Contains(err.Error(), "1.0.9") {
+		t.Errorf("expected error to contain both versions, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "deploy@staging.example.com") {
+		t.Errorf("expected error to name the host, got: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 SSH call (the probe only, real command must not run), got %d", calls)
+	}
+}
+
+// TestRunRemoteNselfCommand_MatchingVersionRunsRealCommand verifies that a
+// matching remote/local version lets the probe pass and the real subcommand
+// execute, with the expected remote cd+nself invocation string.
+func TestRunRemoteNselfCommand_MatchingVersionRunsRealCommand(t *testing.T) {
+	withLocalVersion(t, "1.2.0")
+
+	calls := 0
+	var secondCallArgs []string
+	withStubbedSSH(t, func(ctx context.Context, sshArgs []string) (string, error) {
+		calls++
+		if calls == 1 {
+			return "nself version 1.2.0", nil
+		}
+		secondCallArgs = sshArgs
+		return "up to date", nil
+	})
+
+	rt := dbRemoteTarget{SSHTarget: "deploy@staging.example.com", EnvName: "staging", RemotePath: "/opt/nself"}
+	err := runRemoteNselfCommand(context.Background(), rt, "db", "migrate", "status")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 SSH calls (probe + real command), got %d", calls)
+	}
+	joined := strings.Join(secondCallArgs, " ")
+	if !strings.Contains(joined, "cd '/opt/nself' && nself 'db' 'migrate' 'status'") {
+		t.Errorf("expected second call's remote command to cd into RemotePath and run the subcommand, got: %q", joined)
+	}
+}
+
+// TestRunRemoteNselfCommand_ANSINoiseParsedCorrectly verifies that an
+// old bash-era remote's ANSI-escaped banner ("nself v0.9.9" mixed with
+// escape codes) is still correctly parsed as 0.9.9 and compared against a
+// different local version, producing a drift error.
+func TestRunRemoteNselfCommand_ANSINoiseParsedCorrectly(t *testing.T) {
+	withLocalVersion(t, "1.2.0")
+
+	withStubbedSSH(t, func(ctx context.Context, sshArgs []string) (string, error) {
+		return "\x1b[32mnself v0.9.9\x1b[0m (build unknown)", nil
+	})
+
+	rt := dbRemoteTarget{SSHTarget: "deploy@old.example.com", EnvName: "staging", RemotePath: "/opt/nself"}
+	err := runRemoteNselfCommand(context.Background(), rt, "db", "migrate", "status")
+	if err == nil {
+		t.Fatal("expected a version-drift error")
+	}
+	if !strings.Contains(err.Error(), "0.9.9") {
+		t.Errorf("expected the ANSI-noisy remote version 0.9.9 to be parsed out, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "1.2.0") {
+		t.Errorf("expected local version 1.2.0 in error, got: %v", err)
+	}
+}
+
+// TestRunRemoteNselfCommand_ProbeFailureNamesHost verifies that a failed
+// probe SSH call (e.g. "command not found"-style output, or a connection
+// error) surfaces a clear error naming the host rather than a raw/opaque
+// exec error.
+func TestRunRemoteNselfCommand_ProbeFailureNamesHost(t *testing.T) {
+	withLocalVersion(t, "1.2.0")
+
+	withStubbedSSH(t, func(ctx context.Context, sshArgs []string) (string, error) {
+		return "bash: nself: command not found", os.ErrDeadlineExceeded
+	})
+
+	rt := dbRemoteTarget{SSHTarget: "deploy@broken.example.com", EnvName: "staging", RemotePath: "/opt/nself"}
+	err := runRemoteNselfCommand(context.Background(), rt, "db", "migrate", "status")
+	if err == nil {
+		t.Fatal("expected an error when the version probe itself fails")
+	}
+	if !strings.Contains(err.Error(), "deploy@broken.example.com") {
+		t.Errorf("expected error to clearly name the host, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "staging") {
+		t.Errorf("expected error to name the env, got: %v", err)
+	}
+}
+
+// TestRunRemoteNselfCommand_AllowVersionDriftSkipsProbe verifies that
+// AllowVersionDrift=true skips the version probe entirely (no SSH call for
+// it) and goes straight to the real remote command.
+func TestRunRemoteNselfCommand_AllowVersionDriftSkipsProbe(t *testing.T) {
+	withLocalVersion(t, "1.2.0")
+
+	calls := 0
+	withStubbedSSH(t, func(ctx context.Context, sshArgs []string) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	rt := dbRemoteTarget{SSHTarget: "deploy@staging.example.com", EnvName: "staging", RemotePath: "/opt/nself", AllowVersionDrift: true}
+	err := runRemoteNselfCommand(context.Background(), rt, "db", "migrate", "status")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 SSH call (the real command, no probe) when AllowVersionDrift=true, got %d", calls)
+	}
+}
+
+// TestRunRemoteNselfCommand_DevLocalVersionSkipsProbe verifies that an
+// unparseable local version (e.g. "dev" builds) skips the version check
+// silently — no probe call — and runs the command directly.
+func TestRunRemoteNselfCommand_DevLocalVersionSkipsProbe(t *testing.T) {
+	withLocalVersion(t, "dev")
+
+	calls := 0
+	withStubbedSSH(t, func(ctx context.Context, sshArgs []string) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	rt := dbRemoteTarget{SSHTarget: "deploy@staging.example.com", EnvName: "staging", RemotePath: "/opt/nself"}
+	err := runRemoteNselfCommand(context.Background(), rt, "db", "migrate", "status")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 SSH call (the real command, no probe) for unparseable local version, got %d", calls)
+	}
+}
+
+// TestDispatchRemoteIfNeeded_AllowVersionDriftFlagPropagates verifies that
+// --allow-version-drift set on cmd propagates into the resolved
+// dbRemoteTarget.AllowVersionDrift, so runRemoteNselfCommand actually skips
+// the probe end-to-end through dispatchRemoteIfNeeded.
+func TestDispatchRemoteIfNeeded_AllowVersionDriftFlagPropagates(t *testing.T) {
+	withLocalVersion(t, "1.2.0")
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	inv := &controlplane.Inventory{
+		SchemaVersion: 1,
+		Project:       "test",
+		Environments: map[string]controlplane.Environment{
+			"staging": {
+				Name:    "staging",
+				Kind:    "remote",
+				Servers: []controlplane.Server{{Name: "staging-app", Host: "deploy@staging.example.com", RemotePath: "/opt/nself", Primary: true}},
+			},
+		},
+	}
+	if err := controlplane.Write(dir, inv); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+
+	calls := 0
+	withStubbedSSH(t, func(ctx context.Context, sshArgs []string) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	cmd := newDBRemoteTestCmd()
+	if err := cmd.Flags().Set("env", "staging"); err != nil {
+		t.Fatalf("set --env: %v", err)
+	}
+	if err := cmd.Flags().Set("allow-version-drift", "true"); err != nil {
+		t.Fatalf("set --allow-version-drift: %v", err)
+	}
+
+	handled, err := dispatchRemoteIfNeeded(cmd, "db", "migrate", "status")
+	if !handled {
+		t.Fatal("expected handled=true for a remote target")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 SSH call (no probe) with --allow-version-drift, got %d", calls)
 	}
 }

--- a/cmd/commands/db_remote_version.go
+++ b/cmd/commands/db_remote_version.go
@@ -1,0 +1,85 @@
+package commands
+
+// Purpose: Pre-flight local/remote nself CLI version-drift check for
+//          runRemoteNselfCommand (db_remote.go). Split out from
+//          db_remote_exec.go to keep each file under the 300-line cap.
+// Inputs:  A dbRemoteTarget (host/env/remote path), the ssh flag argv
+//          (everything before the target host, e.g. "-i <key> -o ...") used
+//          to reach it, and the subcommand about to be run remotely.
+// Outputs: nil when local and remote nself versions match (or the local
+//          build has no parseable semver, e.g. "dev"); otherwise a clear,
+//          actionable error naming the host, env, and both versions.
+// Constraints: Never blocks the real command silently — a probe failure or
+//              unparseable remote version always surfaces as an explicit
+//              error rather than being swallowed. --allow-version-drift
+//              (handled by the caller) is the only way to skip this check.
+// SPORT: cli/cmd/commands — see gap #16 (version drift).
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/nself-org/cli/internal/version"
+)
+
+// semverPattern extracts the first dotted-triple version token from noisy
+// output (ANSI-colored banners, "nself v0.9.9" prefixes, build suffixes,
+// etc.) on both the local and remote sides.
+var semverPattern = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+// checkRemoteVersionDrift probes the remote host's nself CLI version and
+// compares it against the local build's version before runRemoteNselfCommand
+// trusts that host's output. Real incident: an older remote CLI (v1.0.9) ran
+// a subcommand fine but printed garbage output (migrations misreported as
+// "up.sql" with unstable pending counts) — that passed through silently
+// because no proactive check existed. This closes that gap ahead of time
+// instead of relying solely on wrapRemoteVersionDriftError's after-the-fact
+// "command not found" sniffing.
+//
+// sshFlagArgs is the ssh flag argv only (e.g. "-i <key> -o BatchMode=yes
+// ..."), matching the prefix runRemoteNselfCommand builds before it appends
+// the target host and remote command — the probe reaches the same host the
+// same way the real command will.
+func checkRemoteVersionDrift(ctx context.Context, rt dbRemoteTarget, sshFlagArgs []string, subCmd string) error {
+	localVersion := semverPattern.FindString(version.GetVersion())
+	if localVersion == "" {
+		// Dev builds (Version == "dev") carry no parseable semver — nothing
+		// meaningful to compare against, so skip rather than block.
+		return nil
+	}
+
+	probeArgs := append(append([]string{}, sshFlagArgs...), rt.SSHTarget, "nself --version")
+	out, err := runSSHCaptured(ctx, probeArgs)
+	if err != nil {
+		return fmt.Errorf(
+			"could not determine remote nself version on %s (env=%s): %w\nprobe output: %s\nrun 'ssh %s nself --version' manually to diagnose",
+			rt.SSHTarget, rt.EnvName, err, out, rt.SSHTarget,
+		)
+	}
+
+	remoteVersion := semverPattern.FindString(out)
+	if remoteVersion == "" {
+		return fmt.Errorf(
+			"could not determine remote nself version on %s (env=%s): probe output had no parseable version\nprobe output: %s\nrun 'ssh %s nself --version' manually to diagnose",
+			rt.SSHTarget, rt.EnvName, out, rt.SSHTarget,
+		)
+	}
+
+	if remoteVersion == localVersion {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"version drift: local nself is v%s but %s (env=%s) runs v%s — remote 'nself %s' output cannot be trusted across versions. Upgrade the remote CLI to v%s (e.g. ssh %s 'nself update'), or pass --allow-version-drift to run anyway.",
+		localVersion, rt.SSHTarget, rt.EnvName, remoteVersion, subCmd, localVersion, rt.SSHTarget,
+	)
+}
+
+// joinRemoteArgs mirrors runRemoteNselfCommand's "nself <sub cmd>" string
+// used in drift error messages, without the shell-quoting needed to
+// actually execute it remotely.
+func joinRemoteArgs(args []string) string {
+	return strings.Join(args, " ")
+}


### PR DESCRIPTION
## Problem

`nself db migrate status|up --env <env>` re-invokes nself on the remote host over SSH. The help text promised that an older remote CLI "returns a clear error naming the version-drift cause" — but no such check existed, only after-the-fact "command not found" sniffing. A version-mismatched remote (ntask staging: remote v1.0.9 vs local v1.2.0) ran the subcommand "successfully" and returned garbage (every migration listed as `up.sql`, pending count unstable: 7 then 12 on back-to-back runs against identical DB state) with exit 0.

## Fix

- `checkRemoteVersionDrift()` (new `db_remote_version.go`): before any remote db subcommand runs, probe `nself --version` over the same SSH connection and compare against the local build.
  - Mismatch → clear error naming both versions, the host, and the env, with upgrade + escape-hatch guidance.
  - Probe failure / unparseable output → explicit error (never silently proceeds).
  - Local dev builds (no parseable semver) skip the check.
- `--allow-version-drift` flag to bypass the check deliberately.
- Dispatch banner now shows `host:remotePath` so the target directory is visible.
- `runSSHCaptured` converted to an injectable package var for testing.
- `db migrate up` help text updated to describe the actual behavior.

## Tests

8 new regression tests in `db_remote_test.go` against a stubbed SSH layer: drift blocks the real command (probe-only, 1 SSH call), matching versions run it, ANSI-noisy `v0.9.9` banners parse, probe failure names the host, `--allow-version-drift` skips the probe, dev-version skips, flag propagation through `dispatchRemoteIfNeeded`. Targeted suite 26/26 green; `gofmt`/`go build`/`go vet` clean.

No version bump.