### PR TITLE
fix(db): migration identity no longer collapses nested up.sql names (ledger PK collision)

### DIFF
--- a/internal/database/checksum.go
+++ b/internal/database/checksum.go
@@ -140,19 +140,27 @@ func appliedMigrationsOps(ctx context.Context, cfg *config.Config) (map[string]M
 // VerifyChecksums compares on-disk migration checksums against stored values.
 // Returns a list of mismatches (empty means all good).
 func VerifyChecksums(ctx context.Context, cfg *config.Config, plugin string) ([]ChecksumMismatch, error) {
+	if err := ensureSchemaVersions(ctx, cfg); err != nil {
+		return nil, fmt.Errorf("ensure schema_versions: %w", err)
+	}
 	if err := ensureMigrationsTable(ctx, cfg); err != nil {
 		return nil, fmt.Errorf("ensure migrations table: %w", err)
-	}
-
-	applied, err := appliedMigrationsOps(ctx, cfg)
-	if err != nil {
-		return nil, fmt.Errorf("query applied migrations: %w", err)
 	}
 
 	dir := migrationsDir(cfg, plugin)
 	files, err := scanMigrations(dir)
 	if err != nil {
 		return nil, err
+	}
+
+	// Upgrade prefix-style ids first so lookups by the new unique id resolve.
+	if err := upgradeLedger(ctx, cfg, files); err != nil {
+		return nil, fmt.Errorf("upgrade migration ledger: %w", err)
+	}
+
+	applied, err := appliedMigrationsOps(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("query applied migrations: %w", err)
 	}
 
 	var mismatches []ChecksumMismatch
@@ -228,17 +236,23 @@ func ResetChecksum(ctx context.Context, cfg *config.Config, migrationID string) 
 	return fmt.Errorf("migration %s not found on disk", migrationID)
 }
 
-// extractMigrationID extracts the YYYYMMDDHHMMSS portion from a migration filename.
+// extractMigrationID derives the unique nself_ops.migrations id for a
+// migration file.
+//
+// Flat layout:   "20260701_add_users.sql"        -> "20260701_add_users"
+// Nested layout: "20260701_add_users/up.sql"     -> "20260701_add_users"
+//
+// WHY full name, not the timestamp prefix: the old implementation truncated
+// at the first underscore, so two migrations sharing a date-derived version
+// (e.g. 20260701_add_users.sql and 20260701_add_orders.sql) collided on the
+// ledger PRIMARY KEY and the second row was silently dropped by
+// ON CONFLICT (id) DO NOTHING (Unity PCI, "ledger outlives DDL" family).
+// The full name keeps same-day migrations distinct. Existing ledgers with
+// prefix-style ids are upgraded in place by upgradeLedger.
 func extractMigrationID(path string) string {
-	base := strings.TrimSuffix(strings.TrimSuffix(filepath.Base(path), ".sql"), ".down")
-	// For flat layout: YYYYMMDDHHMMSS_name.sql -> YYYYMMDDHHMMSS
-	// For nested layout: YYYYMMDDHHMMSS_name/up.sql -> parent dir name
 	if filepath.Base(path) == "up.sql" {
-		base = filepath.Base(filepath.Dir(path))
+		return filepath.Base(filepath.Dir(path))
 	}
-	parts := strings.SplitN(base, "_", 2)
-	if len(parts) > 0 {
-		return parts[0]
-	}
-	return base
+	base := strings.TrimSuffix(filepath.Base(path), ".sql")
+	return strings.TrimSuffix(base, ".down")
 }

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -237,10 +237,190 @@ func scanMigrations(dir string) ([]string, error) {
 		}
 	}
 
+	// Sort by ledger key, not raw basename: in the nested Hasura layout every
+	// basename is "up.sql", which made the old basename sort a no-op and left
+	// the apply order undefined. The key (parent dir name / filename) carries
+	// the version prefix, so this yields the intended version ordering.
 	sort.Slice(files, func(i, j int) bool {
-		return filepath.Base(files[i]) < filepath.Base(files[j])
+		return migrationKey(files[i]) < migrationKey(files[j])
 	})
 	return files, nil
+}
+
+// migrationKey returns the unique ledger identity for a migration file.
+// This is the value recorded in np_common.schema_versions.name and used to
+// decide whether a migration has already been applied.
+//
+// Flat layout:   "hasura/migrations/20260701_add_users.sql" -> "20260701_add_users.sql"
+// Nested layout: "hasura/migrations/default/20260701_add_users/up.sql" -> "20260701_add_users"
+//
+// WHY: the old code used filepath.Base(path) for both layouts, which collapsed
+// every nested migration to the literal name "up.sql". Since schema_versions
+// keys on name, the first nested migration recorded "up.sql" and every later
+// migration was silently skipped while reporting as applied (ledger PK
+// collision, Unity PCI). The parent directory name is the migration's identity
+// in the Hasura layout and is unique within the migrations directory.
+func migrationKey(path string) string {
+	if filepath.Base(path) == "up.sql" {
+		return filepath.Base(filepath.Dir(path))
+	}
+	return filepath.Base(path)
+}
+
+// pendingMigrationFiles returns the subset of files whose ledger key is not in
+// the applied set, preserving input order. Pure function: unit-tested against
+// the same-day / nested collision regressions.
+func pendingMigrationFiles(files []string, applied map[string]time.Time) []string {
+	var pending []string
+	for _, f := range files {
+		if _, ok := applied[migrationKey(f)]; !ok {
+			pending = append(pending, f)
+		}
+	}
+	return pending
+}
+
+// migrationRecordSQL builds the two ledger INSERT statements for a migration.
+//
+// Legacy ledger (np_common.schema_versions): plain INSERT. Keys are unique per
+// migration now, so a conflict means the ledger and the gate disagree — that
+// must ERROR the transaction, never silently no-op.
+//
+// Ops ledger (nself_ops.migrations): ON CONFLICT (id) DO UPDATE. IDs are unique
+// per migration (full filename / dir name, not the date prefix), so a conflict
+// can only be the SAME migration being re-recorded (e.g. forced re-run) —
+// updating checksum/applied_at is "apply" semantics. The old
+// ON CONFLICT (id) DO NOTHING paired with a date-prefix id silently dropped
+// the ledger row of the second migration on the same day.
+func migrationRecordSQL(migrationID, name, checksum string) (legacy string, ops string) {
+	legacy = fmt.Sprintf("INSERT INTO np_common.schema_versions (name) VALUES ('%s');",
+		strings.ReplaceAll(name, "'", "''"))
+	ops = fmt.Sprintf(
+		"INSERT INTO nself_ops.migrations (id, name, checksum) VALUES ('%s', '%s', '%s') "+
+			"ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, checksum = EXCLUDED.checksum, applied_at = now(), rolled_back_at = NULL;",
+		strings.ReplaceAll(migrationID, "'", "''"),
+		strings.ReplaceAll(name, "'", "''"),
+		checksum,
+	)
+	return legacy, ops
+}
+
+// legacyOpsIDBackfillSQL upgrades pre-existing nself_ops.migrations rows whose
+// id was the old date/timestamp prefix (extractMigrationID used to truncate at
+// the first underscore) to the new unique id (full name minus ".sql").
+// Idempotent: the `id <>` guard makes re-runs a no-op; the NOT EXISTS guard
+// avoids PK conflicts if a new-style row already exists. Rows named 'up.sql'
+// (legacy nested layout) are handled separately by legacyNestedRenameSQL.
+const legacyOpsIDBackfillSQL = `UPDATE nself_ops.migrations m
+SET id = left(m.name, length(m.name) - 4)
+WHERE m.name LIKE '%.sql'
+  AND m.name <> 'up.sql'
+  AND m.id <> left(m.name, length(m.name) - 4)
+  AND NOT EXISTS (
+    SELECT 1 FROM nself_ops.migrations m2
+    WHERE m2.id = left(m.name, length(m.name) - 4)
+  );`
+
+// legacyNestedRenameSQL rewrites the single legacy nested-layout ledger row
+// (name = 'up.sql') to the resolved migration key. Idempotent: after the first
+// run no 'up.sql' rows remain, so every statement is a no-op. The trailing
+// DELETEs clean up only when the target key already exists (never loses the
+// applied fact — the UPDATE runs first).
+func legacyNestedRenameSQL(key string) string {
+	k := strings.ReplaceAll(key, "'", "''")
+	return fmt.Sprintf(`BEGIN;
+UPDATE np_common.schema_versions SET name = '%s' WHERE name = 'up.sql' AND NOT EXISTS (SELECT 1 FROM np_common.schema_versions sv2 WHERE sv2.name = '%s');
+DELETE FROM np_common.schema_versions WHERE name = 'up.sql';
+UPDATE nself_ops.migrations SET id = '%s', name = '%s' WHERE name = 'up.sql' AND NOT EXISTS (SELECT 1 FROM nself_ops.migrations m2 WHERE m2.id = '%s');
+DELETE FROM nself_ops.migrations WHERE name = 'up.sql';
+COMMIT;
+`, k, k, k, k, k)
+}
+
+// resolveLegacyNestedKey decides which on-disk nested migration a legacy
+// 'up.sql' ledger row belongs to. opsIDs are the old prefix-style ids of
+// nself_ops.migrations rows named 'up.sql' (recorded in the same transaction
+// as the legacy row, so they identify the directory that actually ran).
+// Falls back to the first nested migration in sorted order — under the old
+// code only the lexicographically first nested migration could ever have been
+// applied (all later ones were skipped by the name collision).
+// Returns "" when no nested migrations exist on disk.
+func resolveLegacyNestedKey(files []string, opsIDs []string) string {
+	var nested []string
+	for _, f := range files {
+		if filepath.Base(f) == "up.sql" {
+			nested = append(nested, migrationKey(f))
+		}
+	}
+	if len(nested) == 0 {
+		return ""
+	}
+	sort.Strings(nested)
+
+	for _, id := range opsIDs {
+		var matches []string
+		for _, k := range nested {
+			if k == id || strings.SplitN(k, "_", 2)[0] == id {
+				matches = append(matches, k)
+			}
+		}
+		if len(matches) == 1 {
+			return matches[0]
+		}
+	}
+	return nested[0]
+}
+
+// upgradeLedger migrates legacy ledger rows (written before the unique-key
+// scheme) in place so already-deployed boxes upgrade cleanly without
+// re-running applied migrations:
+//  1. nself_ops.migrations rows keyed by the old date prefix get their id
+//     rewritten to the full unique id (SQL-side, idempotent).
+//  2. The legacy nested-layout 'up.sql' row in both ledgers is renamed to the
+//     directory-derived key of the migration that actually ran.
+//
+// Must be called after ensureSchemaVersions + ensureMigrationsTable.
+func upgradeLedger(ctx context.Context, cfg *config.Config, files []string) error {
+	if err := pipeSQLToContainer(ctx, cfg, legacyOpsIDBackfillSQL); err != nil {
+		return fmt.Errorf("ledger id backfill: %w", err)
+	}
+
+	db := cfg.Postgres.DB
+	if db == "" {
+		db = "nself"
+	}
+
+	out, err := querySQL(ctx, cfg, db, "SELECT count(*) FROM np_common.schema_versions WHERE name = 'up.sql'")
+	if err != nil {
+		return fmt.Errorf("ledger legacy row check: %w", err)
+	}
+	if strings.TrimSpace(out) == "0" || strings.TrimSpace(out) == "" {
+		return nil
+	}
+
+	opsOut, err := querySQL(ctx, cfg, db, "SELECT id FROM nself_ops.migrations WHERE name = 'up.sql' ORDER BY id")
+	if err != nil {
+		return fmt.Errorf("ledger legacy ops rows: %w", err)
+	}
+	var opsIDs []string
+	for _, line := range strings.Split(opsOut, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			opsIDs = append(opsIDs, line)
+		}
+	}
+
+	key := resolveLegacyNestedKey(files, opsIDs)
+	if key == "" {
+		// No nested migrations on disk: nothing the row could collide with.
+		return nil
+	}
+	if err := validateMigrationName(key); err != nil {
+		return fmt.Errorf("ledger upgrade key: %w", err)
+	}
+	if err := pipeSQLToContainer(ctx, cfg, legacyNestedRenameSQL(key)); err != nil {
+		return fmt.Errorf("ledger legacy row rename: %w", err)
+	}
+	return nil
 }
 
 // appliedMigrations returns the set of migration names already recorded.
@@ -340,19 +520,23 @@ func MigrateUp(ctx context.Context, cfg *config.Config, plugin string) (int, err
 		return 0, nil
 	}
 
+	// Upgrade legacy ledger rows (prefix ids / nested 'up.sql' collision)
+	// before computing the applied set, so old boxes neither re-run applied
+	// migrations nor keep skipping never-applied ones.
+	if err := upgradeLedger(ctx, cfg, files); err != nil {
+		return 0, fmt.Errorf("upgrade migration ledger: %w", err)
+	}
+
 	applied, err := appliedMigrations(ctx, cfg)
 	if err != nil {
 		return 0, fmt.Errorf("check applied migrations: %w", err)
 	}
 
 	count := 0
-	for _, f := range files {
-		name := filepath.Base(f)
+	for _, f := range pendingMigrationFiles(files, applied) {
+		name := migrationKey(f)
 		if err := validateMigrationName(name); err != nil {
 			return count, err
-		}
-		if _, ok := applied[name]; ok {
-			continue
 		}
 
 		data, readErr := os.ReadFile(f)
@@ -370,17 +554,7 @@ func MigrateUp(ctx context.Context, cfg *config.Config, plugin string) (int, err
 			return count, fmt.Errorf("migration id from %s: %w", name, err)
 		}
 
-		// Record in legacy schema_versions for backward compat.
-		legacyRecord := fmt.Sprintf("INSERT INTO np_common.schema_versions (name) VALUES ('%s');",
-			strings.ReplaceAll(name, "'", "''"))
-
-		// Record in nself_ops.migrations with checksum.
-		opsRecord := fmt.Sprintf(
-			"INSERT INTO nself_ops.migrations (id, name, checksum) VALUES ('%s', '%s', '%s') ON CONFLICT (id) DO NOTHING;",
-			strings.ReplaceAll(migrationID, "'", "''"),
-			strings.ReplaceAll(name, "'", "''"),
-			checksum,
-		)
+		legacyRecord, opsRecord := migrationRecordSQL(migrationID, name, checksum)
 
 		sqlContent := string(data)
 
@@ -439,9 +613,15 @@ func MigrateDown(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("migration name from schema_versions: %w", err)
 	}
 
-	// Derive the down file path: foo.sql -> foo.down.sql
-	downName := strings.TrimSuffix(name, ".sql") + ".down.sql"
-	downPath := filepath.Join(migrationsDir(cfg, ""), downName)
+	// Derive the down file path from the ledger key:
+	//   flat   "foo.sql"          -> <dir>/foo.down.sql
+	//   nested "20260701_foo"     -> <dir>/20260701_foo/down.sql
+	var downPath string
+	if strings.HasSuffix(name, ".sql") {
+		downPath = filepath.Join(migrationsDir(cfg, ""), strings.TrimSuffix(name, ".sql")+".down.sql")
+	} else {
+		downPath = filepath.Join(migrationsDir(cfg, ""), name, "down.sql")
+	}
 
 	data, readErr := os.ReadFile(downPath)
 	if readErr != nil {
@@ -464,21 +644,24 @@ func PendingMigrations(ctx context.Context, cfg *config.Config, plugin string) (
 	if err := ensureSchemaVersions(ctx, cfg); err != nil {
 		return nil, fmt.Errorf("ensure schema_versions: %w", err)
 	}
+	if err := ensureMigrationsTable(ctx, cfg); err != nil {
+		return nil, fmt.Errorf("ensure migrations table: %w", err)
+	}
 	dir := migrationsDir(cfg, plugin)
 	files, err := scanMigrations(dir)
 	if err != nil {
 		return nil, err
+	}
+	if err := upgradeLedger(ctx, cfg, files); err != nil {
+		return nil, fmt.Errorf("upgrade migration ledger: %w", err)
 	}
 	applied, err := appliedMigrations(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("check applied migrations: %w", err)
 	}
 	var pending []string
-	for _, f := range files {
-		name := filepath.Base(f)
-		if _, ok := applied[name]; !ok {
-			pending = append(pending, name)
-		}
+	for _, f := range pendingMigrationFiles(files, applied) {
+		pending = append(pending, migrationKey(f))
 	}
 	return pending, nil
 }
@@ -530,21 +713,14 @@ func ApplyFile(ctx context.Context, cfg *config.Config, filePath string) (skippe
 
 	migrationID := extractMigrationID(filePath)
 	if migrationID == "" {
-		// Fall back to the full filename as ID when no timestamp prefix is found.
+		// Fall back to the full filename as ID when nothing could be derived.
 		migrationID = name
 	}
 	if err := validateMigrationName(migrationID); err != nil {
 		return false, fmt.Errorf("migration id from %s: %w", name, err)
 	}
 
-	legacyRecord := fmt.Sprintf("INSERT INTO np_common.schema_versions (name) VALUES ('%s');",
-		strings.ReplaceAll(name, "'", "''"))
-	opsRecord := fmt.Sprintf(
-		"INSERT INTO nself_ops.migrations (id, name, checksum) VALUES ('%s', '%s', '%s') ON CONFLICT (id) DO NOTHING;",
-		strings.ReplaceAll(migrationID, "'", "''"),
-		strings.ReplaceAll(name, "'", "''"),
-		checksum,
-	)
+	legacyRecord, opsRecord := migrationRecordSQL(migrationID, name, checksum)
 
 	sqlContent := string(data)
 
@@ -611,10 +787,17 @@ func MigrateStatus(ctx context.Context, cfg *config.Config) ([]MigrationStatus, 
 	if err := ensureSchemaVersions(ctx, cfg); err != nil {
 		return nil, fmt.Errorf("ensure schema_versions: %w", err)
 	}
+	if err := ensureMigrationsTable(ctx, cfg); err != nil {
+		return nil, fmt.Errorf("ensure migrations table: %w", err)
+	}
 
 	files, err := scanMigrations(migrationsDir(cfg, ""))
 	if err != nil {
 		return nil, err
+	}
+
+	if err := upgradeLedger(ctx, cfg, files); err != nil {
+		return nil, fmt.Errorf("upgrade migration ledger: %w", err)
 	}
 
 	applied, err := appliedMigrations(ctx, cfg)
@@ -626,7 +809,7 @@ func MigrateStatus(ctx context.Context, cfg *config.Config) ([]MigrationStatus, 
 	onDisk := make(map[string]bool)
 
 	for _, f := range files {
-		name := filepath.Base(f)
+		name := migrationKey(f)
 		onDisk[name] = true
 		ts, ok := applied[name]
 		statuses = append(statuses, MigrationStatus{

--- a/internal/database/migrate_ledger_test.go
+++ b/internal/database/migrate_ledger_test.go
@@ -1,0 +1,256 @@
+package database
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression tests for the migrate-ledger primary-key collision (Unity PCI):
+// the ledger id used to be the date-derived prefix before the first "_", so
+// two migrations sharing a day collided on the PK and the second was recorded
+// (or skipped) without its DDL ever running. The nested Hasura layout had the
+// same family of bug through name = filepath.Base(f) = "up.sql" for every
+// migration.
+
+// --- migrationKey ---
+
+func TestMigrationKey_FlatAndNested(t *testing.T) {
+	cases := map[string]string{
+		"hasura/migrations/20260701_add_users.sql":            "20260701_add_users.sql",
+		"migrations/001_init.sql":                             "001_init.sql",
+		"hasura/migrations/default/20260701_add_users/up.sql": "20260701_add_users",
+		"hasura/migrations/default/1000_init/up.sql":          "1000_init",
+	}
+	for path, want := range cases {
+		if got := migrationKey(filepath.FromSlash(path)); got != want {
+			t.Errorf("migrationKey(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// TestMigrationKey_NestedSameDayDistinct is the core regression: two nested
+// migrations must never collapse to the same ledger key ("up.sql" under the
+// old code), which silently skipped the second while reporting it applied.
+func TestMigrationKey_NestedSameDayDistinct(t *testing.T) {
+	a := migrationKey(filepath.FromSlash("m/20260701_add_users/up.sql"))
+	b := migrationKey(filepath.FromSlash("m/20260701_add_orders/up.sql"))
+	if a == b {
+		t.Fatalf("nested same-day migrations share ledger key %q — second would be silently skipped", a)
+	}
+}
+
+// --- extractMigrationID ---
+
+// TestExtractMigrationID_SameDayDistinct verifies that two migrations sharing
+// the same date-derived version prefix get DISTINCT ledger ids. The old code
+// returned "20260701" for both, and ON CONFLICT (id) DO NOTHING dropped the
+// second row from nself_ops.migrations.
+func TestExtractMigrationID_SameDayDistinct(t *testing.T) {
+	a := extractMigrationID("hasura/migrations/20260701_add_users.sql")
+	b := extractMigrationID("hasura/migrations/20260701_add_orders.sql")
+	if a == b {
+		t.Fatalf("same-day migrations share ledger id %q — second ledger row would be a silent no-op", a)
+	}
+	if a != "20260701_add_users" || b != "20260701_add_orders" {
+		t.Errorf("ids = %q, %q; want full-name ids", a, b)
+	}
+
+	// Nested layout: id is the parent dir name, distinct per migration.
+	na := extractMigrationID(filepath.FromSlash("m/20260701_add_users/up.sql"))
+	nb := extractMigrationID(filepath.FromSlash("m/20260701_add_orders/up.sql"))
+	if na == nb {
+		t.Fatalf("nested same-day migrations share ledger id %q", na)
+	}
+
+	// Down files strip the .down suffix.
+	if got := extractMigrationID("m/20260701_add_users.down.sql"); got != "20260701_add_users" {
+		t.Errorf("down file id = %q, want 20260701_add_users", got)
+	}
+}
+
+// --- pendingMigrationFiles (apply gating) ---
+
+// TestPendingMigrationFiles_SameDayPairBothApply: with an empty ledger both
+// same-day migrations are pending; after the first applies, the second is
+// STILL pending (regression: must not be treated as applied).
+func TestPendingMigrationFiles_SameDayPairBothApply(t *testing.T) {
+	files := []string{
+		"m/20260701_add_users.sql",
+		"m/20260701_add_orders.sql",
+	}
+
+	pending := pendingMigrationFiles(files, map[string]time.Time{})
+	if len(pending) != 2 {
+		t.Fatalf("empty ledger: want 2 pending, got %d (%v)", len(pending), pending)
+	}
+
+	applied := map[string]time.Time{migrationKey(files[0]): time.Now()}
+	pending = pendingMigrationFiles(files, applied)
+	if len(pending) != 1 || pending[0] != files[1] {
+		t.Fatalf("after first applied: want [%s] pending, got %v", files[1], pending)
+	}
+}
+
+// TestPendingMigrationFiles_NestedNotCollapsed: nested layout, second same-day
+// migration must stay pending after the first is applied.
+func TestPendingMigrationFiles_NestedNotCollapsed(t *testing.T) {
+	files := []string{
+		filepath.FromSlash("m/20260701_add_orders/up.sql"),
+		filepath.FromSlash("m/20260701_add_users/up.sql"),
+	}
+	applied := map[string]time.Time{"20260701_add_orders": time.Now()}
+
+	pending := pendingMigrationFiles(files, applied)
+	if len(pending) != 1 || migrationKey(pending[0]) != "20260701_add_users" {
+		t.Fatalf("want only 20260701_add_users pending, got %v", pending)
+	}
+}
+
+// TestPendingMigrationFiles_ReRunIdempotent: when every migration is recorded,
+// nothing is pending (re-run of `nself db migrate up` is a no-op).
+func TestPendingMigrationFiles_ReRunIdempotent(t *testing.T) {
+	files := []string{
+		"m/20260701_add_users.sql",
+		filepath.FromSlash("m/20260702_add_orders/up.sql"),
+	}
+	applied := map[string]time.Time{
+		"20260701_add_users.sql": time.Now(),
+		"20260702_add_orders":    time.Now(),
+	}
+	if pending := pendingMigrationFiles(files, applied); len(pending) != 0 {
+		t.Fatalf("fully applied ledger: want 0 pending, got %v", pending)
+	}
+}
+
+// --- migrationRecordSQL (on-conflict semantics) ---
+
+// TestMigrationRecordSQL_NeverSilentNoop: the ops-ledger record must APPLY on
+// conflict (DO UPDATE — ids are unique per migration now, so a conflict can
+// only be the same migration re-recorded) and the legacy record must ERROR on
+// conflict (plain INSERT). Neither may silently DO NOTHING.
+func TestMigrationRecordSQL_NeverSilentNoop(t *testing.T) {
+	legacy, ops := migrationRecordSQL("20260701_add_users", "20260701_add_users.sql", "abc")
+
+	if strings.Contains(ops, "DO NOTHING") || strings.Contains(legacy, "DO NOTHING") {
+		t.Fatal("ledger record SQL must never use ON CONFLICT DO NOTHING (silent no-op)")
+	}
+	if !strings.Contains(ops, "ON CONFLICT (id) DO UPDATE") {
+		t.Errorf("ops record must apply on conflict, got: %s", ops)
+	}
+	if strings.Contains(legacy, "ON CONFLICT") {
+		t.Errorf("legacy record must be a plain INSERT that errors on conflict, got: %s", legacy)
+	}
+	if !strings.Contains(ops, "'20260701_add_users'") || !strings.Contains(legacy, "'20260701_add_users.sql'") {
+		t.Errorf("record SQL missing expected key/name:\n%s\n%s", legacy, ops)
+	}
+}
+
+func TestMigrationRecordSQL_EscapesQuotes(t *testing.T) {
+	legacy, ops := migrationRecordSQL("o'id", "o'name.sql", "abc")
+	if !strings.Contains(legacy, "o''name.sql") || !strings.Contains(ops, "o''id") {
+		t.Errorf("single quotes must be doubled:\n%s\n%s", legacy, ops)
+	}
+}
+
+// --- ledger upgrade path ---
+
+// TestResolveLegacyNestedKey covers mapping the legacy 'up.sql' ledger row to
+// the migration that actually ran on an already-deployed box.
+func TestResolveLegacyNestedKey(t *testing.T) {
+	files := []string{
+		filepath.FromSlash("m/1000_init/up.sql"),
+		filepath.FromSlash("m/2000_users/up.sql"),
+		"m/9999_flat.sql", // flat file must be ignored
+	}
+
+	// Ops row id (old prefix style) uniquely identifies the dir that ran.
+	if got := resolveLegacyNestedKey(files, []string{"2000"}); got != "2000_users" {
+		t.Errorf("ops-id match: want 2000_users, got %q", got)
+	}
+
+	// No ops rows: fall back to the first sorted nested migration — the only
+	// one the old collided code could ever have applied.
+	if got := resolveLegacyNestedKey(files, nil); got != "1000_init" {
+		t.Errorf("fallback: want 1000_init, got %q", got)
+	}
+
+	// Ambiguous prefix (two dirs same day): fall back to first sorted.
+	amb := []string{
+		filepath.FromSlash("m/20260701_a/up.sql"),
+		filepath.FromSlash("m/20260701_b/up.sql"),
+	}
+	if got := resolveLegacyNestedKey(amb, []string{"20260701"}); got != "20260701_a" {
+		t.Errorf("ambiguous prefix: want 20260701_a, got %q", got)
+	}
+
+	// No nested migrations on disk: nothing to map.
+	if got := resolveLegacyNestedKey([]string{"m/only_flat.sql"}, []string{"1000"}); got != "" {
+		t.Errorf("flat-only: want empty key, got %q", got)
+	}
+}
+
+// TestLegacyOpsIDBackfillSQL_Guards: the in-place id rewrite must be
+// idempotent (skip rows already on the new id), never touch the legacy nested
+// 'up.sql' rows, and never create a PK conflict.
+func TestLegacyOpsIDBackfillSQL_Guards(t *testing.T) {
+	sql := legacyOpsIDBackfillSQL
+	for _, want := range []string{
+		"m.id <> left(m.name, length(m.name) - 4)", // idempotence guard
+		"m.name <> 'up.sql'",                       // nested rows handled separately
+		"NOT EXISTS",                               // PK-conflict guard
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("backfill SQL missing guard %q:\n%s", want, sql)
+		}
+	}
+}
+
+// TestLegacyNestedRenameSQL_IdempotentShape: the rename targets only rows
+// literally named 'up.sql' (so a second run is a no-op), updates before it
+// deletes, and escapes the key.
+func TestLegacyNestedRenameSQL_IdempotentShape(t *testing.T) {
+	sql := legacyNestedRenameSQL("20260701_add_users")
+
+	if !strings.Contains(sql, "WHERE name = 'up.sql'") {
+		t.Error("rename must only touch legacy 'up.sql' rows")
+	}
+	if !strings.Contains(sql, "NOT EXISTS") {
+		t.Error("rename must guard against an existing new-style row")
+	}
+	updIdx := strings.Index(sql, "UPDATE np_common.schema_versions")
+	delIdx := strings.Index(sql, "DELETE FROM np_common.schema_versions")
+	if updIdx == -1 || delIdx == -1 || updIdx > delIdx {
+		t.Error("rename must UPDATE the applied fact before DELETE cleanup")
+	}
+
+	esc := legacyNestedRenameSQL("o'brien")
+	if strings.Contains(esc, "'o'brien'") || !strings.Contains(esc, "o''brien") {
+		t.Error("rename key must have single quotes doubled")
+	}
+}
+
+// TestScanMigrations_NestedOrderByKey: with the nested layout the sort must
+// order by the version-bearing directory name, not the constant "up.sql"
+// basename (which left the apply order undefined).
+func TestScanMigrations_NestedOrderByKey(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, tmp, "3000_orders/up.sql", "-- orders")
+	writeFile(t, tmp, "1000_init/up.sql", "-- init")
+	writeFile(t, tmp, "2000_users/up.sql", "-- users")
+
+	files, err := scanMigrations(tmp)
+	if err != nil {
+		t.Fatalf("scanMigrations: %v", err)
+	}
+	want := []string{"1000_init", "2000_users", "3000_orders"}
+	if len(files) != len(want) {
+		t.Fatalf("want %d files, got %d", len(want), len(files))
+	}
+	for i, f := range files {
+		if migrationKey(f) != want[i] {
+			t.Errorf("files[%d] key = %q, want %q", i, migrationKey(f), want[i])
+		}
+	}
+}

--- a/internal/database/migration_audit.go
+++ b/internal/database/migration_audit.go
@@ -40,6 +40,10 @@ func AuditMigrations(ctx context.Context, cfg *config.Config) ([]MigrationAuditR
 		return nil, fmt.Errorf("scan migrations: %w", err)
 	}
 
+	if err := upgradeLedger(ctx, cfg, files); err != nil {
+		return nil, fmt.Errorf("upgrade migration ledger: %w", err)
+	}
+
 	applied, err := appliedMigrations(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("check applied migrations: %w", err)
@@ -54,7 +58,7 @@ func AuditMigrations(ctx context.Context, cfg *config.Config) ([]MigrationAuditR
 	var results []MigrationAuditResult
 
 	for _, f := range files {
-		name := filepath.Base(f)
+		name := migrationKey(f)
 		migID := extractMigrationID(f)
 
 		result := MigrationAuditResult{

--- a/internal/database/pure_functions_test.go
+++ b/internal/database/pure_functions_test.go
@@ -42,16 +42,18 @@ func TestChecksumBytes_Deterministic(t *testing.T) {
 	}
 }
 
-// TestExtractMigrationID_FlatLayout verifies YYYYMMDDHHMMSS_name.sql parsing.
+// TestExtractMigrationID_FlatLayout verifies flat-layout id derivation.
+// The id is the FULL name minus ".sql" — not just the timestamp prefix, which
+// collided for migrations sharing a date-derived version (ledger PK bug).
 func TestExtractMigrationID_FlatLayout(t *testing.T) {
 	cases := []struct {
 		path string
 		want string
 	}{
-		{"migrations/20260101000000_create_users.sql", "20260101000000"},
-		{"migrations/20251231235959_add_index.sql", "20251231235959"},
-		{"migrations/20260115120000_init.sql", "20260115120000"},
-		{"/absolute/path/20260501083000_plugin_schema.sql", "20260501083000"},
+		{"migrations/20260101000000_create_users.sql", "20260101000000_create_users"},
+		{"migrations/20251231235959_add_index.sql", "20251231235959_add_index"},
+		{"migrations/20260115120000_init.sql", "20260115120000_init"},
+		{"/absolute/path/20260501083000_plugin_schema.sql", "20260501083000_plugin_schema"},
 	}
 	for _, tc := range cases {
 		got := extractMigrationID(tc.path)
@@ -61,14 +63,15 @@ func TestExtractMigrationID_FlatLayout(t *testing.T) {
 	}
 }
 
-// TestExtractMigrationID_NestedLayout verifies YYYYMMDDHHMMSS_name/up.sql parsing.
+// TestExtractMigrationID_NestedLayout verifies nested-layout id derivation:
+// the parent directory name in full (unique per migration).
 func TestExtractMigrationID_NestedLayout(t *testing.T) {
 	cases := []struct {
 		path string
 		want string
 	}{
-		{"migrations/20260101000000_create_users/up.sql", "20260101000000"},
-		{"migrations/20260515090000_add_column/up.sql", "20260515090000"},
+		{"migrations/20260101000000_create_users/up.sql", "20260101000000_create_users"},
+		{"migrations/20260515090000_add_column/up.sql", "20260515090000_add_column"},
 	}
 	for _, tc := range cases {
 		got := extractMigrationID(tc.path)


### PR DESCRIPTION
## Problem

For nested Hasura-style migration layouts (`migrations/<timestamp>_<name>/up.sql`), migration identity was derived via `filepath.Base` — so every migration was keyed `up.sql`. Consequences:

- `nself db migrate status` listed every row as generic `up.sql` instead of real names
- ledger primary-key collisions: `ON CONFLICT DO NOTHING` silently dropped records, so applied migrations were re-counted as pending
- pending counts were non-deterministic (observed 7 then 12 on back-to-back runs against identical DB state; true count was 0)

Companion to #162 (which makes a version-drifted remote error loudly; this fixes the underlying name collapse in the CLI itself).

## Fix

- New `migrationKey()` is the single identity source for scan ordering, pending computation, status listing, and ledger writes: nested `up.sql` → parent dir name (`002_add_task_approval_system`), flat files → filename.
- `extractMigrationID` (ops-table id / checksum audit) uses the full name instead of first-underscore truncation, so same-day migrations stay distinct.
- Ledger writes: `ON CONFLICT DO UPDATE` (ops table) / erroring INSERT (legacy table) — a PK conflict can only mean the same migration re-recorded, never a silent drop.
- `upgradeLedger()` runs before every applied-set read: idempotently rewrites old prefix-style ops ids in place and renames the single legacy `up.sql` row to its resolved key. No DB schema change.

## Tests

20 new/updated targeted tests (key derivation flat+nested, same-day distinctness, pending determinism + idempotent re-run, never-silent-noop record SQL, legacy upgrade SQL guards, scan ordering) — all green; full `go test ./internal/database/` passes. `gofmt`/`go build`/`go vet` clean.

No version bump.