### PR TITLE
feat(db): migrate status --migration-dir + postgres/migrations auto-detect (G-008)

### DIFF
--- a/cmd/commands/db.go
+++ b/cmd/commands/db.go
@@ -525,6 +525,9 @@ func init() {
 	dbMigrateUpCmd.Flags().Bool("dry-run", false, "List pending migrations without applying them")
 	// --migration-dir flag on migrate up (G-008)
 	dbMigrateUpCmd.Flags().String("migration-dir", "", "Apply all .sql files in this directory in lexicographic order (skips already-applied)")
+	// --migration-dir flag on migrate status (G-008): repos with non-standard
+	// layouts (e.g. ntask postgres/migrations) otherwise report "No migrations found"
+	dbMigrateStatusCmd.Flags().String("migration-dir", "", "Report status for migrations in this directory instead of the auto-detected one")
 	// --env/--server: remote targeting (gap #9) — default local, opt-in remote.
 	addDBRemoteFlags(dbMigrateUpCmd)
 	addDBRemoteFlags(dbMigrateStatusCmd)
@@ -689,7 +692,18 @@ func runDBMigrateDown(cmd *cobra.Command, _ []string) error {
 }
 
 func runDBMigrateStatus(cmd *cobra.Command, _ []string) error {
-	if handled, err := dispatchRemoteIfNeeded(cmd, "db", "migrate", "status"); handled {
+	migrationDir := ""
+	if f := cmd.Flags().Lookup("migration-dir"); f != nil {
+		migrationDir = f.Value.String()
+	}
+
+	// Forward --migration-dir to the remote CLI: the pre-flight version-drift
+	// check (#162) guarantees the remote binary understands the flag.
+	remoteArgs := []string{"db", "migrate", "status"}
+	if migrationDir != "" {
+		remoteArgs = append(remoteArgs, "--migration-dir", migrationDir)
+	}
+	if handled, err := dispatchRemoteIfNeeded(cmd, remoteArgs...); handled {
 		return err
 	}
 
@@ -697,7 +711,7 @@ func runDBMigrateStatus(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	statuses, err := database.MigrateStatus(cmd.Context(), cfg)
+	statuses, err := database.MigrateStatus(cmd.Context(), cfg, migrationDir)
 	if err != nil {
 		return fmt.Errorf("migrate status: %w", err)
 	}

--- a/cmd/commands/db_migrate_test.go
+++ b/cmd/commands/db_migrate_test.go
@@ -224,3 +224,36 @@ func TestDBMigrateApply_ExistingFile_ReachesConfigLoad(t *testing.T) {
 		t.Errorf("file guard failed for a file that exists: %v", err)
 	}
 }
+
+// newMigrateStatusCmd mirrors dbMigrateStatusCmd's flag setup for unit tests
+// exercising --migration-dir on `db migrate status` (G-008) without a live
+// nSelf project.
+func newMigrateStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "status", RunE: runDBMigrateStatus}
+	cmd.Flags().String("migration-dir", "", "Report status for migrations in this directory instead of the auto-detected one")
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+// TestDBMigrateStatusCmd_HasMigrationDirFlag verifies the real wired command
+// registers --migration-dir, so non-standard layouts (ntask postgres/migrations)
+// can be inspected instead of reporting "No migrations found" (G-008).
+func TestDBMigrateStatusCmd_HasMigrationDirFlag(t *testing.T) {
+	if dbMigrateStatusCmd.Flags().Lookup("migration-dir") == nil {
+		t.Fatal("dbMigrateStatusCmd is missing the --migration-dir flag")
+	}
+}
+
+// TestDBMigrateStatus_MigrationDirFlag_MissingDir verifies that a non-existent
+// --migration-dir surfaces an error rather than silently falling back to the
+// auto-detected directory.
+func TestDBMigrateStatus_MigrationDirFlag_MissingDir(t *testing.T) {
+	cmd := newMigrateStatusCmd()
+	if err := cmd.Flags().Set("migration-dir", "/nonexistent/path/does-not-exist-99999"); err != nil {
+		t.Fatalf("setting --migration-dir flag: %v", err)
+	}
+	err := runDBMigrateStatus(cmd, nil)
+	if err == nil {
+		t.Fatal("expected an error for non-existent --migration-dir, got nil")
+	}
+}

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -182,6 +182,7 @@ func ensureSchemaVersions(ctx context.Context, cfg *config.Config) error {
 //  1. hasura/migrations/default/ (standard Hasura layout)
 //  2. hasura/migrations/         (flat Hasura layout)
 //  3. migrations/                (legacy fallback)
+//  4. postgres/migrations/       (repo-local layout, e.g. ntask)
 //
 // If none exist on disk, it returns "hasura/migrations/default/" so error
 // messages point the user at the canonical location.
@@ -199,6 +200,7 @@ func migrationsDir(cfg *config.Config, plugin string) string {
 		"hasura/migrations/default",
 		"hasura/migrations",
 		"migrations",
+		"postgres/migrations",
 	}
 	for _, c := range candidates {
 		if _, err := os.Stat(c); err == nil {
@@ -805,7 +807,12 @@ func ApplyDir(ctx context.Context, cfg *config.Config, dirPath string) (int, err
 // MigrateStatus returns the status of all known migrations (applied and pending).
 // It merges on-disk migration files with the schema_versions table, so orphaned
 // migrations (applied but no longer on disk) are also reported.
-func MigrateStatus(ctx context.Context, cfg *config.Config) ([]MigrationStatus, error) {
+//
+// dir overrides the auto-detected migrations directory (the --migration-dir
+// companion to MigrateUpDir, G-008): repos with non-standard layouts, e.g.
+// ntask's postgres/migrations, would otherwise report "No migrations found".
+// Pass "" to auto-detect via migrationsDir.
+func MigrateStatus(ctx context.Context, cfg *config.Config, dir string) ([]MigrationStatus, error) {
 	if err := ensureSchemaVersions(ctx, cfg); err != nil {
 		return nil, fmt.Errorf("ensure schema_versions: %w", err)
 	}
@@ -813,7 +820,10 @@ func MigrateStatus(ctx context.Context, cfg *config.Config) ([]MigrationStatus, 
 		return nil, fmt.Errorf("ensure migrations table: %w", err)
 	}
 
-	files, err := scanMigrations(migrationsDir(cfg, ""))
+	if dir == "" {
+		dir = migrationsDir(cfg, "")
+	}
+	files, err := scanMigrations(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -448,3 +448,32 @@ func TestIsNonTransactional_AddAttributeIsTransactional(t *testing.T) {
 		t.Errorf("ALTER TYPE ... ADD ATTRIBUTE should be transactional, isNonTransactional returned %v", got)
 	}
 }
+
+// TestMigrationsDir_PostgresLayout: only postgres/migrations/ exists (ntask
+// repo layout) → it is auto-detected as the 4th candidate (G-008).
+func TestMigrationsDir_PostgresLayout(t *testing.T) {
+	tmp := t.TempDir()
+	mkdirAll(t, tmp, "postgres/migrations")
+	withCwd(t, tmp)
+
+	cfg := &config.Config{}
+	got := migrationsDir(cfg, "")
+	if got != "postgres/migrations" {
+		t.Errorf("expected postgres/migrations, got %q", got)
+	}
+}
+
+// TestMigrationsDir_LegacyBeatsPostgres: candidate order is preserved —
+// migrations/ (3rd) wins over postgres/migrations (4th) when both exist.
+func TestMigrationsDir_LegacyBeatsPostgres(t *testing.T) {
+	tmp := t.TempDir()
+	mkdirAll(t, tmp, "migrations")
+	mkdirAll(t, tmp, "postgres/migrations")
+	withCwd(t, tmp)
+
+	cfg := &config.Config{}
+	got := migrationsDir(cfg, "")
+	if got != "migrations" {
+		t.Errorf("expected migrations to win over postgres/migrations, got %q", got)
+	}
+}


### PR DESCRIPTION
Closes the G-008 status gap: `up` had `--migration-dir` but `status` didn't, so repos with non-standard layouts (ntask `postgres/migrations`) reported "No migrations found".

- `nself db migrate status --migration-dir <dir>` reports status for that directory (also forwarded on `--env staging|prod` remote dispatch — safe per the #162 version-drift pre-flight).
- `migrationsDir()` gains `postgres/migrations` as a 4th auto-detect candidate.
- Tests: postgres-layout detection, candidate ordering, status flag wiring, missing-dir error.