### PR TITLE
fix(build): P0 batch — manifest plugin injection, secret templating, env allowlist, localhost URLs, leftover cleanup

### DIFF
--- a/cmd/commands/build.go
+++ b/cmd/commands/build.go
@@ -199,6 +199,14 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			ui.Warn(fmt.Sprintf("Add CA manually: %s", result.CAManualCmd))
 		}
 
+		// Declared plugins that could not be wired — never silent (nself.yaml).
+		if len(result.MissingPlugins) > 0 {
+			ui.Warn(fmt.Sprintf("%d declared plugin(s) NOT wired into the stack: %s",
+				len(result.MissingPlugins), strings.Join(result.MissingPlugins, ", ")))
+			ui.Warn(fmt.Sprintf("Fix: nself plugin install %s (or remove them from nself.yaml)",
+				strings.Join(result.MissingPlugins, " ")))
+		}
+
 		// /etc/hosts status line.
 		if result.HostsAdded > 0 {
 			ui.Success(fmt.Sprintf("Added %d domain(s) to /etc/hosts", result.HostsAdded))

--- a/cmd/commands/restart.go
+++ b/cmd/commands/restart.go
@@ -106,6 +106,7 @@ func runRestart(cmd *cobra.Command, args []string) error {
 	}
 
 	comp := docker.NewCompose(composeFiles...)
+	comp.EnvFiles = build.ComposeEnvFiles(workdir)
 	ctx := cmd.Context()
 	services := args
 

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -627,6 +627,11 @@ func runStart(cmd *cobra.Command, _ []string) error {
 			}
 		}
 
+		// Remove stale hash-prefixed rename-leftover containers (interrupted
+		// recreates) so they cannot hold ports or shadow the clean
+		// <project>_<service> names (e.g. b6d7..._ntask_hasura, gap #21).
+		_ = docker.RunPreStartCleanup(ctx, cfg.ProjectName)
+
 		// Clean start: remove all containers first.
 		if opts.cleanStart {
 			sp := ui.NewSpinner("Removing existing containers...")

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -547,6 +547,7 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	ui.Step(currentStep, totalSteps, "Starting PostgreSQL")
 
 	compose := docker.NewCompose(composeFiles...)
+	compose.EnvFiles = build.ComposeEnvFiles(projectDir)
 
 	// ── Embedded PG path (--embedded-pg / NSELF_EMBEDDED_PG=true) ───
 	// When embedded PG is requested, boot pglite via wasmtime instead of

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -806,36 +806,10 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	// ── Display URLs ─────────────────────────────────────────────────
 	ui.Separator()
 
-	domain := cfg.BaseDomain
-	if domain == "" {
-		domain = "localhost"
-	}
-
-	scheme := "https"
-	if cfg.Env == "dev" {
-		scheme = "http"
-	}
-	urls := []string{
-		fmt.Sprintf("API:      %s://%s", scheme, domain),
-		fmt.Sprintf("Hasura:   %s://%s/v1/graphql", scheme, domain),
-		fmt.Sprintf("Console:  %s://%s/console", scheme, domain),
-		fmt.Sprintf("Auth:     %s://%s/v1/auth", scheme, domain),
-	}
-
-	if cfg.Minio.Enabled {
-		urls = append(urls, fmt.Sprintf("Storage:  %s://%s/v1/storage", scheme, domain))
-	}
-	if cfg.Mailpit.Enabled {
-		urls = append(urls, fmt.Sprintf("Mail UI:  %s://%s/mailpit", scheme, domain))
-	}
-	if cfg.Monitoring.GrafanaEnabled {
-		urls = append(urls, fmt.Sprintf("Grafana:  %s://%s/grafana", scheme, domain))
-	}
-	if cfg.Admin.Enabled {
-		urls = append(urls, "Admin:    http://localhost:3021")
-	}
-
-	ui.SummaryBox("nSelf Stack Running", urls)
+	// URL list: localhost:<port> endpoints for default local domains
+	// (local.nself.org needs DNS/hosts setup and 502s on a fresh machine),
+	// nginx-routed domain URLs for custom domains. See start_urls.go.
+	ui.SummaryBox("nSelf Stack Running", stackURLs(cfg))
 
 	if opts.debug {
 		ui.Section("Debug Info")

--- a/cmd/commands/start_urls.go
+++ b/cmd/commands/start_urls.go
@@ -1,0 +1,91 @@
+package commands
+
+// Purpose: Compute the "nSelf Stack Running" URL list printed by nself start.
+//          For default local-dev domains (local.nself.org / localhost) the
+//          printed URLs must be the actually-curlable localhost:<port>
+//          endpoints — the bare local.nself.org URLs require DNS/hosts/mkcert
+//          setup and 502 on a fresh machine (ntask dogfood gap #20).
+// Inputs:  resolved *config.Config.
+// Outputs: display strings for ui.SummaryBox.
+// Constraints: Custom domains keep the domain-based URLs unchanged.
+// SPORT: cli/cmd/commands — start output (PCI ntask-local-url-mismatch).
+
+import (
+	"fmt"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// defaultLocalDomains are the BASE_DOMAIN values that mean "no custom domain
+// configured" — a fresh local-dev setup where only localhost ports are
+// guaranteed reachable.
+var defaultLocalDomains = map[string]bool{
+	"":                true,
+	"localhost":       true,
+	"local.nself.org": true,
+}
+
+// portOr returns port when > 0, else fallback.
+func portOr(port, fallback int) int {
+	if port > 0 {
+		return port
+	}
+	return fallback
+}
+
+// stackURLs returns the URL lines for the start summary box.
+//
+// Local-dev (default domain): direct localhost:<port> endpoints that work
+// with zero DNS/hosts/SSL setup, plus a hint that the *.local.nself.org
+// routes need `nself dns-setup`.
+//
+// Custom domain: the nginx-routed https URLs, unchanged.
+func stackURLs(cfg *config.Config) []string {
+	domain := cfg.BaseDomain
+	if !defaultLocalDomains[domain] {
+		scheme := "https"
+		if cfg.Env == "dev" {
+			scheme = "http"
+		}
+		urls := []string{
+			fmt.Sprintf("API:      %s://%s", scheme, domain),
+			fmt.Sprintf("Hasura:   %s://%s/v1/graphql", scheme, domain),
+			fmt.Sprintf("Console:  %s://%s/console", scheme, domain),
+			fmt.Sprintf("Auth:     %s://%s/v1/auth", scheme, domain),
+		}
+		if cfg.Minio.Enabled {
+			urls = append(urls, fmt.Sprintf("Storage:  %s://%s/v1/storage", scheme, domain))
+		}
+		if cfg.Mailpit.Enabled {
+			urls = append(urls, fmt.Sprintf("Mail UI:  %s://%s/mailpit", scheme, domain))
+		}
+		if cfg.Monitoring.GrafanaEnabled {
+			urls = append(urls, fmt.Sprintf("Grafana:  %s://%s/grafana", scheme, domain))
+		}
+		if cfg.Admin.Enabled {
+			urls = append(urls, fmt.Sprintf("Admin:    http://localhost:%d", portOr(cfg.Admin.Port, 3021)))
+		}
+		return urls
+	}
+
+	// Default local domain — print the reachable localhost endpoints.
+	hasuraPort := portOr(cfg.Hasura.Port, 8080)
+	urls := []string{
+		fmt.Sprintf("GraphQL:  http://localhost:%d/v1/graphql", hasuraPort),
+		fmt.Sprintf("Hasura:   http://localhost:%d", hasuraPort),
+		fmt.Sprintf("Auth:     http://localhost:%d", portOr(cfg.Auth.Port, 4000)),
+	}
+	if cfg.Minio.Enabled {
+		urls = append(urls, fmt.Sprintf("Storage:  http://localhost:%d", portOr(cfg.Minio.Port, 9000)))
+	}
+	if cfg.Mailpit.Enabled {
+		urls = append(urls, fmt.Sprintf("Mail UI:  http://localhost:%d", portOr(cfg.Mailpit.UIPort, 8025)))
+	}
+	if cfg.Admin.Enabled {
+		urls = append(urls, fmt.Sprintf("Admin:    http://localhost:%d", portOr(cfg.Admin.Port, 3021)))
+	}
+	if domain != "" && domain != "localhost" {
+		urls = append(urls, fmt.Sprintf("Domains:  https://*.%s (requires: nself dns-setup)", domain))
+	}
+	return urls
+}

--- a/cmd/commands/start_urls_test.go
+++ b/cmd/commands/start_urls_test.go
@@ -1,0 +1,81 @@
+package commands
+
+// Purpose: Regression tests for PCI ntask-local-url-mismatch: nself start
+//          must print reachable localhost:<port> URLs for default local
+//          domains instead of the unreachable *.local.nself.org routes.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+func startURLTestConfig(baseDomain string) *config.Config {
+	cfg := &config.Config{
+		ProjectName: "urltest",
+		BaseDomain:  baseDomain,
+		Env:         "dev",
+	}
+	cfg.Hasura.Port = 8080
+	cfg.Auth.Port = 4000
+	cfg.Minio.Enabled = true
+	cfg.Minio.Port = 9000
+	cfg.Mailpit.Enabled = true
+	cfg.Mailpit.UIPort = 8025
+	return cfg
+}
+
+// TestStackURLs_DefaultLocalDomainPrintsLocalhost is the PCI repro: with the
+// default local.nself.org base domain, every printed URL must be a curlable
+// localhost endpoint, never a bare local.nself.org route.
+func TestStackURLs_DefaultLocalDomainPrintsLocalhost(t *testing.T) {
+	urls := stackURLs(startURLTestConfig("local.nself.org"))
+	joined := strings.Join(urls, "\n")
+
+	for _, want := range []string{
+		"http://localhost:8080/v1/graphql",
+		"http://localhost:4000",
+		"http://localhost:9000",
+		"http://localhost:8025",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected reachable URL %q in start output, got:\n%s", want, joined)
+		}
+	}
+
+	for _, line := range urls {
+		if strings.Contains(line, "local.nself.org") && !strings.Contains(line, "dns-setup") {
+			t.Errorf("unreachable local.nself.org URL printed without setup hint: %q", line)
+		}
+	}
+}
+
+// TestStackURLs_CustomDomainUnchanged keeps the nginx-routed URLs for real
+// domains.
+func TestStackURLs_CustomDomainUnchanged(t *testing.T) {
+	cfg := startURLTestConfig("api.example.com")
+	cfg.Env = "prod"
+	urls := stackURLs(cfg)
+	joined := strings.Join(urls, "\n")
+
+	if !strings.Contains(joined, "https://api.example.com/v1/graphql") {
+		t.Errorf("custom domain URLs changed:\n%s", joined)
+	}
+	if strings.Contains(joined, "localhost:8080") {
+		t.Errorf("custom domain output must not fall back to localhost:\n%s", joined)
+	}
+}
+
+// TestStackURLs_PortFallbacks covers zero-value ports (defensive defaults).
+func TestStackURLs_PortFallbacks(t *testing.T) {
+	cfg := &config.Config{BaseDomain: "localhost", Env: "dev"}
+	urls := stackURLs(cfg)
+	joined := strings.Join(urls, "\n")
+	if !strings.Contains(joined, "http://localhost:8080/v1/graphql") {
+		t.Errorf("expected 8080 fallback, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "http://localhost:4000") {
+		t.Errorf("expected 4000 fallback, got:\n%s", joined)
+	}
+}

--- a/cmd/commands/stop.go
+++ b/cmd/commands/stop.go
@@ -95,6 +95,7 @@ func runStop(cmd *cobra.Command, args []string) error {
 	}
 
 	compose := docker.NewCompose(composeFiles...)
+	compose.EnvFiles = build.ComposeEnvFiles(workdir)
 
 	// Check running containers. If the query fails (e.g. docker compose ps
 	// exits non-zero on certain Debian/Docker combinations even when containers

--- a/internal/build/manifest.go
+++ b/internal/build/manifest.go
@@ -1,0 +1,292 @@
+package build
+
+// Purpose: Read the project's nself.yaml manifest and guarantee that every
+//          declared plugin is wired into the generated stack (auto-installing
+//          missing plugins when possible) — or loudly reported, never silently
+//          dropped (PCI plugin-injection-dropped, 2026-07-03).
+// Inputs:  workdir (project root containing nself.yaml), pluginDir (global
+//          plugin install dir), cfg (resolved env-cascade config), generated
+//          compose service names.
+// Outputs: Declared plugin list, missing-plugin report, best-effort installs.
+// Constraints: Backward compatible — projects without nself.yaml keep the
+//              install-then-discover flow unchanged. Auto-install is
+//              best-effort and can be disabled with
+//              NSELF_AUTO_INSTALL_PLUGINS=false (offline/CI).
+// SPORT: cli/internal/build — manifest injection (gap #8, ntask dogfood).
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/nself-org/cli/internal/bundle"
+	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/plugin"
+)
+
+// manifestFilenames are the accepted names for the project manifest, checked
+// in order. The canonical name is nself.yaml.
+var manifestFilenames = []string{"nself.yaml", "nself.yml"}
+
+// ProjectManifest is the parsed subset of nself.yaml that the build pipeline
+// consumes. Unknown keys are ignored so app repos can keep richer metadata
+// (display_name, tier, auth_mode, ...) in the same file.
+type ProjectManifest struct {
+	App     string          `yaml:"app"`
+	Bundle  string          `yaml:"bundle"`
+	Bundles []string        `yaml:"bundles"`
+	Plugins ManifestPlugins `yaml:"plugins"`
+}
+
+// ManifestPlugins accepts both manifest shapes:
+//
+//	plugins:            # flat list
+//	  - cron
+//	  - notify
+//
+//	plugins:            # tiered map
+//	  free: [cron, notify]
+//	  pro:  [ai-gateway]
+type ManifestPlugins struct {
+	Free []string
+	Pro  []string
+	Flat []string
+}
+
+// UnmarshalYAML implements custom decoding for the two supported shapes.
+func (mp *ManifestPlugins) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		return node.Decode(&mp.Flat)
+	case yaml.MappingNode:
+		var aux struct {
+			Free []string `yaml:"free"`
+			Pro  []string `yaml:"pro"`
+		}
+		if err := node.Decode(&aux); err != nil {
+			return fmt.Errorf("parsing plugins block: %w", err)
+		}
+		mp.Free = aux.Free
+		mp.Pro = aux.Pro
+		return nil
+	}
+	// Null/absent — leave zero value.
+	return nil
+}
+
+// LoadProjectManifest reads nself.yaml (or nself.yml) from workdir.
+// Returns (nil, nil) when no manifest exists — callers treat that as
+// "no declarations, legacy discover-only flow".
+func LoadProjectManifest(workdir string) (*ProjectManifest, error) {
+	for _, name := range manifestFilenames {
+		path := filepath.Join(workdir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("reading %s: %w", name, err)
+		}
+		var m ProjectManifest
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", name, err)
+		}
+		return &m, nil
+	}
+	return nil, nil
+}
+
+// DeclaredPlugins returns the deduplicated, sorted set of plugin slugs the
+// manifest declares: plugins.free + plugins.pro + flat list + the expansion
+// of bundle/bundles via the canonical bundle catalog. Placeholder entries
+// (anything that is not a bare slug, e.g. "(free plugins only ...)") are
+// dropped.
+func (m *ProjectManifest) DeclaredPlugins() []string {
+	if m == nil {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var out []string
+	add := func(name string) {
+		slug := strings.ToLower(strings.TrimSpace(name))
+		if !isPluginSlug(slug) || seen[slug] {
+			return
+		}
+		seen[slug] = true
+		out = append(out, slug)
+	}
+
+	for _, n := range m.Plugins.Flat {
+		add(n)
+	}
+	for _, n := range m.Plugins.Free {
+		add(n)
+	}
+	for _, n := range m.Plugins.Pro {
+		add(n)
+	}
+
+	bundles := m.Bundles
+	if m.Bundle != "" {
+		bundles = append(bundles, m.Bundle)
+	}
+	for _, slug := range bundles {
+		b, ok := bundle.Get(slug)
+		if !ok {
+			continue
+		}
+		for _, p := range b.Plugins {
+			add(p)
+		}
+	}
+
+	sort.Strings(out)
+	return out
+}
+
+// isPluginSlug reports whether s looks like a valid plugin slug:
+// lowercase letters, digits, and hyphens only.
+func isPluginSlug(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// coreServiceAliases maps declared plugin names that are satisfied by core
+// compose services rather than plugin containers. "auth" and "storage" are
+// wired by the compose generator directly (hasura-auth container + MinIO),
+// so declaring them must not produce a false "missing plugin" report.
+var coreServiceAliases = map[string][]string{
+	"auth":    {"auth"},
+	"storage": {"minio", "storage"},
+}
+
+// autoInstallEnabled reports whether missing declared plugins may be
+// auto-installed from the registry. Disabled with
+// NSELF_AUTO_INSTALL_PLUGINS=false (offline builds, hermetic CI).
+func autoInstallEnabled() bool {
+	return !strings.EqualFold(os.Getenv("NSELF_AUTO_INSTALL_PLUGINS"), "false")
+}
+
+// autoInstallTimeout bounds a single best-effort plugin auto-install so an
+// unreachable registry can never hang `nself build`.
+const autoInstallTimeout = 60 * time.Second
+
+// ResolveDeclaredPlugins guarantees every plugin declared in nself.yaml is
+// wired into the build, in three steps per declared plugin:
+//
+//  1. Already installed in pluginDir → satisfied (its compose fragment, if
+//     any, is picked up by DiscoverPluginComposeFiles).
+//  2. Provided by a core compose service (auth, storage) → satisfied.
+//  3. Otherwise attempt a best-effort auto-install from the registry, then
+//     re-check. Still absent → reported in missing.
+//
+// Returns the list of declared plugins that could not be wired. Callers MUST
+// surface missing plugins to the user (build warning + BuildResult) — a
+// declared plugin is never silently dropped.
+func ResolveDeclaredPlugins(ctx context.Context, cfg *config.Config, workdir, pluginDir string, composeServices []string) (missing []string) {
+	manifest, err := LoadProjectManifest(workdir)
+	if err != nil {
+		slog.Warn("could not parse project manifest — declared plugins not resolved", "err", err)
+		return nil
+	}
+	declared := manifest.DeclaredPlugins()
+	if len(declared) == 0 {
+		return nil
+	}
+
+	serviceSet := make(map[string]bool, len(composeServices))
+	for _, s := range composeServices {
+		serviceSet[s] = true
+	}
+
+	for _, name := range declared {
+		if pluginInstalled(pluginDir, name) {
+			continue
+		}
+		if satisfiedByCoreService(name, serviceSet) {
+			continue
+		}
+		if autoInstallEnabled() {
+			installCtx, cancel := context.WithTimeout(ctx, autoInstallTimeout)
+			err := plugin.Install(installCtx, cfg, name, pluginDir)
+			cancel()
+			if err == nil && pluginInstalled(pluginDir, name) {
+				slog.Info("auto-installed declared plugin", "plugin", name, "source", "nself.yaml")
+				continue
+			}
+			slog.Warn("declared plugin auto-install failed", "plugin", name, "err", err)
+		}
+		missing = append(missing, name)
+	}
+
+	return missing
+}
+
+// pluginInstalled reports whether the named plugin has an install directory
+// (with at least a plugin.json or compose fragment) under pluginDir.
+func pluginInstalled(pluginDir, name string) bool {
+	dir := filepath.Join(pluginDir, name)
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	// A directory with a manifest or compose fragment counts as installed.
+	for _, f := range []string{"plugin.json", pluginComposeFilename} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// satisfiedByCoreService reports whether a declared plugin name is provided
+// by a generated core compose service instead of a plugin container.
+func satisfiedByCoreService(name string, serviceSet map[string]bool) bool {
+	if serviceSet[name] {
+		return true
+	}
+	for _, alias := range coreServiceAliases[name] {
+		if serviceSet[alias] {
+			return true
+		}
+	}
+	return false
+}
+
+// expectedCoreServices returns the compose service names the generator will
+// emit for core/optional services, derived from config. Used by
+// ResolveDeclaredPlugins to recognise declared names (auth, storage) that a
+// core service satisfies — the compose YAML is generated after plugin
+// resolution, so the names are derived rather than parsed.
+func expectedCoreServices(cfg *config.Config) []string {
+	services := []string{"postgres", "hasura", "auth", "nginx"}
+	if cfg.Minio.Enabled {
+		services = append(services, "minio")
+	}
+	if cfg.Redis.Enabled {
+		services = append(services, "redis")
+	}
+	if cfg.Functions.Enabled {
+		services = append(services, "functions")
+	}
+	if cfg.Mailpit.Enabled {
+		services = append(services, "mailpit")
+	}
+	return services
+}

--- a/internal/build/manifest_test.go
+++ b/internal/build/manifest_test.go
@@ -1,0 +1,224 @@
+package build
+
+// Purpose: Repro + regression tests for PCI plugin-injection-dropped
+//          (2026-07-03): plugins declared in nself.yaml must ALL be wired
+//          into the generated stack, or loudly reported — never silently
+//          dropped.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// writeTestPlugin scaffolds a fake installed plugin with a plugin.json and,
+// when withCompose is true, a docker-compose.plugin.yml fragment.
+func writeTestPlugin(t *testing.T, pluginDir, name string, port int, withCompose bool) {
+	t.Helper()
+	dir := filepath.Join(pluginDir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := fmt.Sprintf(`{"name":%q,"port":%d,"language":"go"}`, name, port)
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if withCompose {
+		compose := fmt.Sprintf("services:\n  %s:\n    image: nself/%s:latest\n", name, name)
+		if err := os.WriteFile(filepath.Join(dir, pluginComposeFilename), []byte(compose), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestLoadProjectManifest_Absent(t *testing.T) {
+	m, err := LoadProjectManifest(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m != nil {
+		t.Fatalf("expected nil manifest for empty dir, got %+v", m)
+	}
+}
+
+func TestLoadProjectManifest_TieredPlugins(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+app: ntask
+bundle: ntask
+plugins:
+  free:
+    - cron
+    - notify
+    - webhooks
+  pro:
+    - ai-gateway
+`
+	if err := os.WriteFile(filepath.Join(dir, "nself.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadProjectManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := m.DeclaredPlugins()
+	want := []string{"ai-gateway", "cron", "notify", "webhooks"}
+	if len(got) != len(want) {
+		t.Fatalf("declared = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("declared = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestLoadProjectManifest_FlatPluginsAndBundleExpansion(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+app: ops
+bundles:
+  - nsentry
+plugins:
+  - cron
+`
+	if err := os.WriteFile(filepath.Join(dir, "nself.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadProjectManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := m.DeclaredPlugins()
+	// cron + the 13 nsentry bundle plugins.
+	if len(got) != 14 {
+		t.Fatalf("expected 14 declared plugins (cron + 13 nsentry), got %d: %v", len(got), got)
+	}
+	set := make(map[string]bool, len(got))
+	for _, p := range got {
+		set[p] = true
+	}
+	for _, want := range []string{"cron", "nself-uptime-monitor", "nself-status-page", "nself-errors", "nself-audit"} {
+		if !set[want] {
+			t.Errorf("declared plugins missing %q: %v", want, got)
+		}
+	}
+}
+
+func TestDeclaredPlugins_FiltersPlaceholders(t *testing.T) {
+	m := &ProjectManifest{}
+	m.Plugins.Flat = []string{"cron", "(free plugins only — see: nself plugin list)", "", "Notify"}
+	got := m.DeclaredPlugins()
+	want := []string{"cron", "notify"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("declared = %v, want %v", got, want)
+	}
+}
+
+// TestResolveDeclaredPlugins_AllDeclaredPluginsWired is the PCI repro:
+// declare N plugins in nself.yaml, install them, and assert all N compose
+// fragments are discovered — none silently dropped.
+func TestResolveDeclaredPlugins_AllDeclaredPluginsWired(t *testing.T) {
+	t.Setenv("NSELF_AUTO_INSTALL_PLUGINS", "false")
+	workdir := t.TempDir()
+	pluginDir := t.TempDir()
+
+	declared := []string{"cron", "notify", "webhooks", "audit-log", "feature-flags"}
+	yaml := "app: repro\nplugins:\n  free:\n"
+	for _, p := range declared {
+		yaml += "    - " + p + "\n"
+		writeTestPlugin(t, pluginDir, p, 3700, true)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "nself.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{ProjectName: "repro"}
+	missing := ResolveDeclaredPlugins(context.Background(), cfg, workdir, pluginDir, expectedCoreServices(cfg))
+	if len(missing) != 0 {
+		t.Fatalf("expected no missing plugins, got %v", missing)
+	}
+
+	files, err := DiscoverPluginComposeFiles(workdir, pluginDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != len(declared) {
+		t.Fatalf("expected %d plugin compose files, got %d: %v", len(declared), len(files), files)
+	}
+	found := make(map[string]bool)
+	for _, f := range files {
+		found[filepath.Base(filepath.Dir(f))] = true
+	}
+	for _, p := range declared {
+		if !found[p] {
+			t.Errorf("declared plugin %q dropped from generated stack (files: %v)", p, files)
+		}
+	}
+}
+
+// TestResolveDeclaredPlugins_MissingPluginReported asserts a declared but
+// uninstalled (and un-installable) plugin is reported, not silently dropped.
+func TestResolveDeclaredPlugins_MissingPluginReported(t *testing.T) {
+	t.Setenv("NSELF_AUTO_INSTALL_PLUGINS", "false")
+	workdir := t.TempDir()
+	pluginDir := t.TempDir()
+
+	writeTestPlugin(t, pluginDir, "cron", 3706, true)
+	yaml := "app: repro\nplugins:\n  free:\n    - cron\n    - search\n    - jobs\n"
+	if err := os.WriteFile(filepath.Join(workdir, "nself.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{ProjectName: "repro"}
+	missing := ResolveDeclaredPlugins(context.Background(), cfg, workdir, pluginDir, expectedCoreServices(cfg))
+	if len(missing) != 2 {
+		t.Fatalf("expected 2 missing plugins (search, jobs), got %v", missing)
+	}
+	set := map[string]bool{missing[0]: true, missing[1]: true}
+	if !set["search"] || !set["jobs"] {
+		t.Fatalf("missing = %v, want [jobs search]", missing)
+	}
+}
+
+// TestResolveDeclaredPlugins_CoreServiceSatisfies asserts declared names that
+// core compose services provide (auth via hasura-auth, storage via MinIO) do
+// not produce false missing-plugin reports.
+func TestResolveDeclaredPlugins_CoreServiceSatisfies(t *testing.T) {
+	t.Setenv("NSELF_AUTO_INSTALL_PLUGINS", "false")
+	workdir := t.TempDir()
+	pluginDir := t.TempDir()
+
+	yaml := "app: repro\nplugins:\n  free:\n    - auth\n    - storage\n"
+	if err := os.WriteFile(filepath.Join(workdir, "nself.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{ProjectName: "repro"}
+	cfg.Minio.Enabled = true
+	missing := ResolveDeclaredPlugins(context.Background(), cfg, workdir, pluginDir, expectedCoreServices(cfg))
+	if len(missing) != 0 {
+		t.Fatalf("auth/storage are core services — expected no missing plugins, got %v", missing)
+	}
+}
+
+// TestResolveDeclaredPlugins_NoManifestNoOp asserts projects without
+// nself.yaml keep the legacy install-then-discover flow untouched.
+func TestResolveDeclaredPlugins_NoManifestNoOp(t *testing.T) {
+	cfg := &config.Config{ProjectName: "legacy"}
+	missing := ResolveDeclaredPlugins(context.Background(), cfg, t.TempDir(), t.TempDir(), expectedCoreServices(cfg))
+	if missing != nil {
+		t.Fatalf("expected nil missing for manifest-less project, got %v", missing)
+	}
+}
+
+func TestDefaultPluginDir_EnvOverride(t *testing.T) {
+	t.Setenv("NSELF_PLUGIN_DIR", "/tmp/custom-plugins")
+	if got := DefaultPluginDir(); got != "/tmp/custom-plugins" {
+		t.Fatalf("DefaultPluginDir() = %q, want /tmp/custom-plugins", got)
+	}
+}

--- a/internal/build/orchestrator.go
+++ b/internal/build/orchestrator.go
@@ -3,6 +3,7 @@ package build
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -60,6 +61,11 @@ type BuildResult struct {
 	// discovered during build. Empty when no plugins with compose files
 	// are installed.
 	PluginComposeFiles []string
+	// MissingPlugins lists plugins declared in nself.yaml that could not be
+	// wired into the generated stack (not installed, not auto-installable,
+	// and not satisfied by a core service). Non-empty means the generated
+	// stack does NOT match the declared manifest.
+	MissingPlugins []string
 	// CAInstalled is true when the mkcert CA is trusted by the OS.
 	CAInstalled bool
 	// CAManualCmd is non-empty when the user must manually trust the CA.
@@ -242,6 +248,20 @@ func Build(workdir string, opts BuildOptions) (*BuildResult, error) {
 		filesGenerated++
 	}
 
+	// ── Step 7.05: Resolve declared plugins (nself.yaml) ────────────
+	// Declared plugins (nself.yaml plugins:/bundle:/bundles: blocks) are
+	// resolved BEFORE plugin nginx routes, the np_plugins seed, and compose
+	// discovery — auto-installing any that are missing — so that a manifest
+	// declaration alone is sufficient to wire a plugin into the stack.
+	// Declared plugins that cannot be wired are reported loudly (build
+	// warning + BuildResult.MissingPlugins), never silently dropped.
+	pluginDir := DefaultPluginDir()
+	missingPlugins := ResolveDeclaredPlugins(context.Background(), cfg, workdir, pluginDir, expectedCoreServices(cfg))
+	for _, p := range missingPlugins {
+		slog.Warn("declared plugin is NOT wired into the generated stack — install it or remove it from nself.yaml",
+			"plugin", p, "fix", fmt.Sprintf("nself plugin install %s", p))
+	}
+
 	// ── Step 7.1: Inject plugin nginx routes ────────────────────────
 	pluginRoutes, err := InjectPluginNginxRoutes(workdir, "", cfg)
 	if err != nil {
@@ -313,7 +333,6 @@ func Build(workdir string, opts BuildOptions) (*BuildResult, error) {
 	filesGenerated++
 
 	// ── Step 9.5: Discover plugin compose files ────────────────────
-	pluginDir := DefaultPluginDir()
 	pluginComposeFiles, err := DiscoverPluginComposeFiles(workdir, pluginDir)
 	if err != nil {
 		return nil, fmt.Errorf("discovering plugin compose files: %w", err)
@@ -487,6 +506,7 @@ func Build(workdir string, opts BuildOptions) (*BuildResult, error) {
 		Duration:           time.Since(start),
 		FilesGenerated:     filesGenerated,
 		PluginComposeFiles: pluginComposeFiles,
+		MissingPlugins:     missingPlugins,
 		CAInstalled:        sslResult.CAInstalled,
 		CAManualCmd:        sslResult.CAManualCmd,
 		HostsAdded:         sslResult.HostsAdded,

--- a/internal/build/orchestrator.go
+++ b/internal/build/orchestrator.go
@@ -322,6 +322,18 @@ func Build(workdir string, opts BuildOptions) (*BuildResult, error) {
 		}
 	}
 
+	// ── Step 8.7: Template secrets out of the generated YAML ────────
+	// Literal passwords/keys become ${VAR} references resolved at
+	// container-start time from .nself/compose.env (written in Step 10 and
+	// passed via --env-file by start/stop/restart). Secrets never land in
+	// the generated docker-compose.yml (ASI generated-file-secret rule).
+	secretMap := SecretEnvMap(cfg)
+	composeYAML = TemplateSecrets(composeYAML, secretMap)
+	for _, leak := range LiteralSecretLeaks(composeYAML, secretMap) {
+		slog.Warn("secret value still appears literally in docker-compose.yml — do not commit this file",
+			"var", leak)
+	}
+
 	// ── Step 9: Write docker-compose.yml with 0600 permissions ──────
 	// Prepend the GENERATED marker so pre-commit hooks, auditors, and humans
 	// can unambiguously detect a hand-edited compose file (S32-T12).
@@ -427,6 +439,15 @@ func Build(workdir string, opts BuildOptions) (*BuildResult, error) {
 	computedContent := buildEnvComputed(cfg, pluginEnvVars)
 	if err := os.WriteFile(computedPath, []byte(computedContent), 0600); err != nil {
 		return nil, fmt.Errorf("writing .env.computed: %w", err)
+	}
+	filesGenerated++
+
+	// ── Step 10.1: Write .nself/compose.env (0600) ──────────────────
+	// Resolves every ${VAR} reference the secret-templating pass (Step 8.7)
+	// emitted, plus plugin fragment vars (DOCKER_NETWORK, NSELF_PLUGIN_DIR,
+	// PLUGIN_*_INTERNAL_URL). Passed to docker compose via --env-file.
+	if err := WriteComposeEnv(workdir, cfg, secretMap, pluginEnvVars); err != nil {
+		return nil, fmt.Errorf("writing %s: %w", composeEnvFile, err)
 	}
 	filesGenerated++
 

--- a/internal/build/plugins.go
+++ b/internal/build/plugins.go
@@ -22,9 +22,13 @@ const composeManifestFile = ".nself/compose-files.txt"
 const pluginComposeFilename = "docker-compose.plugin.yml"
 
 // DefaultPluginDir returns the default global plugin installation directory
-// (~/.nself/plugins). Falls back to /tmp/.nself/plugins when the home
-// directory cannot be determined.
+// (~/.nself/plugins). The NSELF_PLUGIN_DIR environment variable overrides the
+// default — used for per-project plugin sets, hermetic tests, and CI. Falls
+// back to /tmp/.nself/plugins when the home directory cannot be determined.
 func DefaultPluginDir() string {
+	if dir := strings.TrimSpace(os.Getenv("NSELF_PLUGIN_DIR")); dir != "" {
+		return dir
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join("/tmp", ".nself", "plugins")

--- a/internal/build/secrets_template.go
+++ b/internal/build/secrets_template.go
@@ -1,0 +1,234 @@
+package build
+
+// Purpose: Keep secrets OUT of the generated docker-compose.yml. nself build
+//          previously baked literal passwords/keys (postgres, Hasura admin
+//          secret, JWT blobs, MinIO root creds, ...) into the generated YAML,
+//          so editing .env was a silent no-op and any commit of the generated
+//          file leaked credentials (PCI compose-secret-templating, 2026-07-03;
+//          ASI generated-file-secret hard rule; ntask incident 085af2ec).
+// Inputs:  resolved *config.Config + generated compose YAML bytes.
+// Outputs: compose YAML with ${VAR} references instead of literals, plus the
+//          .nself/compose.env interpolation file (0600) that `nself start`
+//          passes to docker compose via --env-file.
+// Constraints: Two-phase rewrite — exact env-key lines first, then
+//              URL-credential positions (":<pw>@"). URL rewrite only when the
+//              password needs no percent-encoding (raw == escaped), otherwise
+//              the literal is left and reported by LiteralSecretLeaks.
+// SPORT: cli/internal/build — secret templating (S-secret-env-templating).
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// composeEnvFile is the path (relative to workdir) of the interpolation env
+// file consumed by every `docker compose` invocation the CLI makes.
+const composeEnvFile = ".nself/compose.env"
+
+// SecretEnvMap returns env-var-name → resolved literal value for every secret
+// the compose generator may embed. Empty values are omitted.
+func SecretEnvMap(cfg *config.Config) map[string]string {
+	m := make(map[string]string)
+	add := func(key, val string) {
+		if strings.TrimSpace(val) != "" {
+			m[key] = val
+		}
+	}
+
+	add("POSTGRES_PASSWORD", cfg.Postgres.Password)
+	add("HASURA_GRAPHQL_ADMIN_SECRET", cfg.Hasura.AdminSecret)
+	add("HASURA_JWT_KEY", cfg.Hasura.JWTKey)
+	if jwtJSON, err := config.BuildJWTSecret(cfg); err == nil {
+		add("HASURA_GRAPHQL_JWT_SECRET", jwtJSON)
+	}
+	add("MINIO_ROOT_USER", cfg.Minio.RootUser)
+	add("MINIO_ROOT_PASSWORD", cfg.Minio.RootPassword)
+	add("S3_ACCESS_KEY", cfg.Minio.S3AccessKey)
+	add("S3_SECRET_KEY", cfg.Minio.S3SecretKey)
+	add("REDIS_PASSWORD", cfg.Redis.Password)
+	add("AUTH_SMTP_PASS", cfg.Auth.SMTPPass)
+	add("MAILPIT_UI_PASSWORD", cfg.Mailpit.UIPassword)
+	add("ADMIN_SECRET_KEY", cfg.Admin.SecretKey)
+	add("ADMIN_PASSWORD_HASH", cfg.Admin.PasswordHash)
+	add("GRAFANA_ADMIN_PASSWORD", cfg.Monitoring.GrafanaAdminPassword)
+	add("SEARCH_API_KEY", cfg.Search.APIKey)
+	add("MEILISEARCH_MASTER_KEY", cfg.Search.MeiliSearch.MasterKey)
+
+	return m
+}
+
+// secretAliasKeys maps additional compose env keys that carry a mapped
+// secret's value under a different name. The alias line is rewritten to the
+// canonical ${VAR} only when the line actually contains the literal value.
+var secretAliasKeys = map[string]string{
+	"AUTH_JWT_SECRET":        "HASURA_JWT_KEY",
+	"SHARED_AUTH_JWT_SECRET": "HASURA_JWT_KEY",
+	"AUTH_DB_PASSWORD":       "POSTGRES_PASSWORD", // Nhost Auth AUTH_DB_* alias set
+}
+
+// TemplateSecrets rewrites generated compose YAML so no literal secret value
+// remains: env entries become ${VAR} references and URL-embedded database
+// credentials become :${VAR}@. Docker Compose interpolates the references at
+// container-start time from --env-file (.nself/compose.env), so secrets never
+// land in the generated (potentially committed) YAML.
+func TemplateSecrets(composeYAML []byte, secrets map[string]string) []byte {
+	if len(secrets) == 0 {
+		return composeYAML
+	}
+	out := string(composeYAML)
+
+	// Phase A: exact env-key lines → "KEY: ${KEY}".
+	// The compose generator emits env maps as "      KEY: value"; the whole
+	// value is replaced regardless of YAML quoting style.
+	keys := make([]string, 0, len(secrets))
+	for k := range secrets {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		re := regexp.MustCompile(`(?m)^(\s+)` + regexp.QuoteMeta(key) + `:\s.*$`)
+		// $$ emits a literal $ in Go regexp replacement templates — the
+		// output must contain the un-expanded ${KEY} for docker compose.
+		out = re.ReplaceAllString(out, "${1}"+key+": $${"+key+"}")
+	}
+
+	// Phase A2: alias keys (e.g. AUTH_JWT_SECRET carries HASURA_JWT_KEY's
+	// value). Rewritten only when the line still holds the literal value, so
+	// aliases with independent values are never clobbered.
+	aliasNames := make([]string, 0, len(secretAliasKeys))
+	for alias := range secretAliasKeys {
+		aliasNames = append(aliasNames, alias)
+	}
+	sort.Strings(aliasNames)
+	for _, alias := range aliasNames {
+		canonical := secretAliasKeys[alias]
+		val, ok := secrets[canonical]
+		if !ok {
+			continue
+		}
+		re := regexp.MustCompile(`(?m)^(\s+)` + regexp.QuoteMeta(alias) + `:\s.*$`)
+		out = re.ReplaceAllStringFunc(out, func(line string) string {
+			if !strings.Contains(line, val) {
+				return line
+			}
+			indent := line[:strings.Index(line, alias)]
+			return indent + alias + ": ${" + canonical + "}"
+		})
+	}
+
+	// Phase B: URL credential positions — ":<password>@" → ":${VAR}@".
+	// Covers DATABASE_URL / HASURA_GRAPHQL_DATABASE_URL / redis URLs where the
+	// password is embedded mid-value. Only safe when the password needs no
+	// percent-encoding (raw == PathEscape(raw)); otherwise interpolation would
+	// inject an unescaped value into a URL, so the literal is left in place
+	// and surfaced by LiteralSecretLeaks.
+	for _, key := range keys {
+		val := secrets[key]
+		if len(val) < 4 || url.PathEscape(val) != val {
+			continue
+		}
+		out = strings.ReplaceAll(out, ":"+val+"@", ":${"+key+"}@")
+	}
+
+	return []byte(out)
+}
+
+// LiteralSecretLeaks returns the names of secrets whose literal value (>= 8
+// chars) still appears in the compose YAML after templating. Callers surface
+// each as a build warning — the safety net behind TemplateSecrets.
+func LiteralSecretLeaks(composeYAML []byte, secrets map[string]string) []string {
+	var leaked []string
+	doc := string(composeYAML)
+	for key, val := range secrets {
+		if len(val) < 8 {
+			continue
+		}
+		if strings.Contains(doc, val) {
+			leaked = append(leaked, key)
+		}
+	}
+	sort.Strings(leaked)
+	return leaked
+}
+
+// WriteComposeEnv writes .nself/compose.env (0600) — the single interpolation
+// file that resolves every ${VAR} reference in the generated compose set:
+// secrets, Hasura console/dev-mode toggles, computed values (DATABASE_URL,
+// DOCKER_NETWORK), and plugin env vars. All CLI docker compose invocations
+// pass it via --env-file (see ComposeEnvFiles).
+func WriteComposeEnv(workdir string, cfg *config.Config, secrets, pluginEnvVars map[string]string) error {
+	merged := make(map[string]string, len(secrets)+len(pluginEnvVars)+4)
+	for k, v := range pluginEnvVars {
+		merged[k] = v
+	}
+	for k, v := range secrets {
+		merged[k] = v
+	}
+
+	network := cfg.DockerNetwork
+	if network == "" {
+		network = cfg.ProjectName + "_network"
+	}
+	merged["DATABASE_URL"] = cfg.DatabaseURL()
+	merged["DOCKER_NETWORK"] = network
+	merged["HASURA_GRAPHQL_ENABLE_CONSOLE"] = fmt.Sprintf("%t", cfg.Hasura.Console)
+	merged["HASURA_GRAPHQL_DEV_MODE"] = fmt.Sprintf("%t", cfg.Hasura.DevMode)
+
+	keys := make([]string, 0, len(merged))
+	for k := range merged {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	sb.WriteString("# GENERATED BY nself build - DO NOT HAND EDIT\n")
+	sb.WriteString("# Interpolation values for the ${VAR} references in docker-compose.yml.\n")
+	sb.WriteString("# Passed to docker compose via --env-file by nself start/stop/restart.\n")
+	for _, k := range keys {
+		sb.WriteString(k)
+		sb.WriteString("=")
+		sb.WriteString(config.QuoteEnvValue(merged[k]))
+		sb.WriteString("\n")
+	}
+
+	path := filepath.Join(workdir, composeEnvFile)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating %s dir: %w", filepath.Dir(composeEnvFile), err)
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", composeEnvFile, err)
+	}
+	// Enforce 0600 even when the file pre-existed with a looser mode.
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("chmod %s: %w", composeEnvFile, err)
+	}
+	return nil
+}
+
+// ComposeEnvFiles returns the ordered --env-file list for docker compose
+// invocations in workdir: the project .env (when present, for user overrides
+// and backward compatibility) followed by .nself/compose.env (computed truth,
+// wins on conflict). Returns nil when neither exists — legacy projects built
+// before secret templating keep working unchanged.
+func ComposeEnvFiles(workdir string) []string {
+	var files []string
+	for _, rel := range []string{".env", composeEnvFile} {
+		p := filepath.Join(workdir, rel)
+		if _, err := os.Stat(p); err == nil {
+			files = append(files, p)
+		}
+	}
+	// The default project .env is only useful alongside compose.env; docker
+	// compose reads it implicitly anyway when it is the sole file present.
+	if len(files) == 1 && strings.HasSuffix(files[0], ".env") && !strings.HasSuffix(files[0], composeEnvFile) {
+		return nil
+	}
+	return files
+}

--- a/internal/build/secrets_template_test.go
+++ b/internal/build/secrets_template_test.go
@@ -1,0 +1,197 @@
+package build
+
+// Purpose: Repro + regression tests for PCI compose-secret-templating
+//          (2026-07-03): the generated docker-compose.yml must contain NO
+//          literal secret values — only ${VAR} references resolved from
+//          .nself/compose.env at container-start time.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/compose"
+	"github.com/nself-org/cli/internal/config"
+)
+
+// secretTestConfig returns a config with distinctive secret values so literal
+// leaks are unambiguous in assertions.
+func secretTestConfig() *config.Config {
+	cfg := &config.Config{
+		ProjectName:   "sectest",
+		BaseDomain:    "localhost",
+		Env:           "dev",
+		DockerNetwork: "sectest_network",
+		Postgres: config.PostgresConfig{
+			Host:     "postgres",
+			User:     "postgres",
+			Password: "pg-secret-Zx9Qw8Er7T",
+			DB:       "nself",
+			Port:     5432,
+			Version:  "16",
+		},
+		Hasura: config.HasuraConfig{
+			AdminSecret: "hasura-admin-K3v9Bn2Mp5",
+			JWTKey:      "jwt-key-A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6",
+			JWTType:     "HS256",
+			Port:        8080,
+			Version:     "v2.36.0",
+			MemLimit:    "1g",
+			CPULimit:    "1.0",
+		},
+		Auth: config.AuthConfig{
+			Version:            "0.36.0",
+			Port:               4000,
+			ClientURL:          "http://localhost:3000",
+			AccessTokenExpiry:  900,
+			RefreshTokenExpiry: 2592000,
+			SMTPHost:           "mailpit",
+			SMTPPort:           1025,
+			SMTPPass:           "smtp-pass-Qw4Rt6Yu8I",
+			SMTPSender:         "noreply@localhost",
+			MemLimit:           "256m",
+			CPULimit:           "0.25",
+		},
+	}
+	cfg.Minio.Enabled = true
+	cfg.Minio.Version = "latest"
+	cfg.Minio.Port = 9000
+	cfg.Minio.ConsolePort = 9001
+	cfg.Minio.RootUser = "minio-user-F7g8H9j0"
+	cfg.Minio.RootPassword = "minio-pass-L5m6N7b8V9"
+	cfg.Minio.MemLimit = "1G"
+	cfg.Minio.CPULimit = "0.5"
+	return cfg
+}
+
+// TestTemplateSecrets_NoLiteralSecretsInGeneratedCompose is the PCI repro:
+// run the real compose generator, apply secret templating, and assert the
+// output contains only ${VAR} references — zero literal secret values.
+func TestTemplateSecrets_NoLiteralSecretsInGeneratedCompose(t *testing.T) {
+	cfg := secretTestConfig()
+	raw, err := compose.NewGenerator(cfg).Generate()
+	if err != nil {
+		t.Fatalf("compose generation failed: %v", err)
+	}
+
+	secrets := SecretEnvMap(cfg)
+	templated := TemplateSecrets(raw, secrets)
+	doc := string(templated)
+
+	// No secret literal may survive.
+	for name, val := range secrets {
+		if strings.Contains(doc, val) {
+			t.Errorf("literal secret %s (%q) still present in generated compose", name, val)
+		}
+	}
+	if leaks := LiteralSecretLeaks(templated, secrets); len(leaks) != 0 {
+		t.Errorf("LiteralSecretLeaks reported %v, want none", leaks)
+	}
+
+	// The ${VAR} references must be present instead.
+	for _, ref := range []string{
+		"POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}",
+		"HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET}",
+		"HASURA_GRAPHQL_JWT_SECRET: ${HASURA_GRAPHQL_JWT_SECRET}",
+		"MINIO_ROOT_USER: ${MINIO_ROOT_USER}",
+		"MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}",
+		"AUTH_JWT_SECRET: ${HASURA_JWT_KEY}",
+		":${POSTGRES_PASSWORD}@", // DATABASE_URL credential position
+	} {
+		if !strings.Contains(doc, ref) {
+			t.Errorf("expected templated reference %q in generated compose", ref)
+		}
+	}
+}
+
+// TestTemplateSecrets_AliasKeyLeftAloneWhenValueDiffers ensures alias env keys
+// carrying an independent value are never clobbered.
+func TestTemplateSecrets_AliasKeyLeftAloneWhenValueDiffers(t *testing.T) {
+	yaml := "services:\n  auth:\n    environment:\n      AUTH_JWT_SECRET: some-other-independent-value\n"
+	secrets := map[string]string{"HASURA_JWT_KEY": "jwt-key-A1b2C3d4E5f6"}
+	out := string(TemplateSecrets([]byte(yaml), secrets))
+	if !strings.Contains(out, "AUTH_JWT_SECRET: some-other-independent-value") {
+		t.Errorf("alias key with independent value was clobbered:\n%s", out)
+	}
+}
+
+// TestTemplateSecrets_URLEscapedPasswordLeftLiteral: passwords that require
+// percent-encoding must not be substituted into URL credential positions
+// (compose interpolation would inject the raw, unescaped value).
+func TestTemplateSecrets_URLEscapedPasswordLeftLiteral(t *testing.T) {
+	pw := "has space%pw"
+	yaml := "      DATABASE_URL: postgresql://postgres:has%20space%25pw@postgres:5432/db\n"
+	secrets := map[string]string{"POSTGRES_PASSWORD": pw}
+	out := string(TemplateSecrets([]byte(yaml), secrets))
+	if strings.Contains(out, ":${POSTGRES_PASSWORD}@") {
+		t.Errorf("URL-escaped password must not be substituted, got:\n%s", out)
+	}
+}
+
+func TestWriteComposeEnv_ContentAndPermissions(t *testing.T) {
+	workdir := t.TempDir()
+	cfg := secretTestConfig()
+	secrets := SecretEnvMap(cfg)
+	plugins := map[string]string{"NSELF_PLUGIN_DIR": "/tmp/plugins"}
+
+	if err := WriteComposeEnv(workdir, cfg, secrets, plugins); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(workdir, ".nself", "compose.env")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("compose.env permissions = %o, want 0600", perm)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"POSTGRES_PASSWORD=" + cfg.Postgres.Password,
+		"HASURA_GRAPHQL_ADMIN_SECRET=" + cfg.Hasura.AdminSecret,
+		"DOCKER_NETWORK=sectest_network",
+		"NSELF_PLUGIN_DIR=/tmp/plugins",
+		"HASURA_GRAPHQL_ENABLE_CONSOLE=false",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("compose.env missing %q", want)
+		}
+	}
+}
+
+func TestComposeEnvFiles_OrderAndFallback(t *testing.T) {
+	// Legacy project: no compose.env → nil (docker compose default discovery).
+	legacy := t.TempDir()
+	if err := os.WriteFile(filepath.Join(legacy, ".env"), []byte("A=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ComposeEnvFiles(legacy); got != nil {
+		t.Errorf("legacy project: expected nil env files, got %v", got)
+	}
+
+	// Templated project: .env + .nself/compose.env, compose.env last (wins).
+	templated := t.TempDir()
+	if err := os.WriteFile(filepath.Join(templated, ".env"), []byte("A=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(templated, ".nself"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(templated, ".nself", "compose.env"), []byte("B=2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := ComposeEnvFiles(templated)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 env files, got %v", got)
+	}
+	if filepath.Base(got[0]) != ".env" || filepath.Base(got[1]) != "compose.env" {
+		t.Errorf("env file order wrong: %v", got)
+	}
+}

--- a/internal/config/env_allowlist_test.go
+++ b/internal/config/env_allowlist_test.go
@@ -1,0 +1,50 @@
+package config
+
+// Purpose: Regression tests for false "unknown env var" warnings on
+//          app-owned env vars (ntask dogfood gap #19) and the ENV_ALLOWLIST
+//          escape hatch for project-specific vars.
+
+import "testing"
+
+// TestAppOwnedVarsAreKnown asserts the app-owned vars reported by the ntask
+// fresh-user sim no longer trigger unknown-var warnings.
+func TestAppOwnedVarsAreKnown(t *testing.T) {
+	knownSet := make(map[string]bool, len(knownEnvVars))
+	for _, k := range knownEnvVars {
+		knownSet[k] = true
+	}
+	for _, v := range []string{
+		"NODE_ENV", "JWT_SECRET", "SSL_AUTO_TRUST", "COOKIE_SECRET",
+		"ENABLE_DEBUG", "LOG_LEVEL", "NSELF_PROJECT_NAME", "ENV_ALLOWLIST",
+	} {
+		if !knownSet[v] {
+			t.Errorf("app-owned var %s missing from knownEnvVars (would warn)", v)
+		}
+	}
+}
+
+func TestParseEnvAllowlist(t *testing.T) {
+	names, prefixes := parseEnvAllowlist("MY_APP_TOKEN, FEATURE_* ,, OTHER")
+	if !names["MY_APP_TOKEN"] || !names["OTHER"] {
+		t.Errorf("exact names not parsed: %v", names)
+	}
+	if len(prefixes) != 1 || prefixes[0] != "FEATURE_" {
+		t.Errorf("prefixes = %v, want [FEATURE_]", prefixes)
+	}
+}
+
+func TestEnvVarAllowlisted(t *testing.T) {
+	names, prefixes := parseEnvAllowlist("MY_APP_TOKEN,FEATURE_*")
+	cases := map[string]bool{
+		"MY_APP_TOKEN":  true,
+		"FEATURE_FLAGS": true,
+		"FEATURE_":      true,
+		"MY_APP_OTHER":  false,
+		"RANDOM_VAR":    false,
+	}
+	for key, want := range cases {
+		if got := envVarAllowlisted(key, names, prefixes); got != want {
+			t.Errorf("envVarAllowlisted(%q) = %v, want %v", key, got, want)
+		}
+	}
+}

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -123,6 +123,12 @@ var userDefinedPrefixes = []string{
 //
 // When a loaded key is within edit-distance 2 of a known var, the warning
 // includes a "did_you_mean" field with the closest match.
+//
+// App-owned vars the schema cannot know about are declared via
+// ENV_ALLOWLIST in any .env file: a comma-separated list of exact names or
+// prefixes ending in "*" (e.g. ENV_ALLOWLIST=MY_APP_TOKEN,FEATURE_*).
+// Allowlisted vars never warn — the documented mechanism for app-owned /
+// passthrough env vars (ntask dogfood gap #19).
 func warnUnknownEnvVars(loaded map[string]string, known []string) {
 	// Build O(1) lookup for known vars.
 	knownSet := make(map[string]bool, len(known))
@@ -130,9 +136,16 @@ func warnUnknownEnvVars(loaded map[string]string, known []string) {
 		knownSet[k] = true
 	}
 
+	allowNames, allowPrefixes := parseEnvAllowlist(loaded["ENV_ALLOWLIST"])
+
 	for k := range loaded {
 		// Skip vars that are in the known set.
 		if knownSet[k] {
+			continue
+		}
+
+		// Skip vars the user allowlisted via ENV_ALLOWLIST.
+		if envVarAllowlisted(k, allowNames, allowPrefixes) {
 			continue
 		}
 
@@ -161,6 +174,40 @@ func warnUnknownEnvVars(loaded map[string]string, known []string) {
 			)
 		}
 	}
+}
+
+// parseEnvAllowlist splits an ENV_ALLOWLIST value ("A,B_*, C") into exact
+// names and prefix patterns (entries ending in "*"). Empty entries are
+// dropped; matching is case-sensitive like every other env var comparison.
+func parseEnvAllowlist(raw string) (names map[string]bool, prefixes []string) {
+	names = make(map[string]bool)
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if strings.HasSuffix(entry, "*") {
+			if pfx := strings.TrimSuffix(entry, "*"); pfx != "" {
+				prefixes = append(prefixes, pfx)
+			}
+			continue
+		}
+		names[entry] = true
+	}
+	return names, prefixes
+}
+
+// envVarAllowlisted reports whether key matches an ENV_ALLOWLIST entry.
+func envVarAllowlisted(key string, names map[string]bool, prefixes []string) bool {
+	if names[key] {
+		return true
+	}
+	for _, pfx := range prefixes {
+		if strings.HasPrefix(key, pfx) {
+			return true
+		}
+	}
+	return false
 }
 
 // closestKnownVar returns the known var with the smallest Levenshtein distance

--- a/internal/config/loader_known_vars.go
+++ b/internal/config/loader_known_vars.go
@@ -562,4 +562,21 @@ var knownEnvVars = []string{
 	// App-level observability DSN (e.g. Sentry backend project). Not read by
 	// the CLI loader — apps wire this into their own error reporting.
 	"SENTRY_DSN_BACKEND",
+
+	// App-owned vars commonly present in real app .env files (read by the
+	// app's own code / Node runtime / dev scripts, not by the CLI loader).
+	// Listed to suppress false "unknown env var" warnings (ntask dogfood
+	// gap #19). Project-specific vars beyond these belong in ENV_ALLOWLIST.
+	"NODE_ENV",
+	"JWT_SECRET",
+	"SSL_AUTO_TRUST",
+	"COOKIE_SECRET",
+	"ENABLE_DEBUG",
+	"LOG_LEVEL",
+	"NSELF_PROJECT_NAME",
+
+	// ENV_ALLOWLIST itself: comma-separated var names (or prefixes ending
+	// in *) that warnUnknownEnvVars treats as app-owned and never warns
+	// about. Example: ENV_ALLOWLIST=MY_APP_TOKEN,FEATURE_*
+	"ENV_ALLOWLIST",
 }

--- a/internal/docker/cleanup.go
+++ b/internal/docker/cleanup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -45,6 +46,55 @@ func cleanupZombieContainers(ctx context.Context, projectName string) error {
 	return nil
 }
 
+// renamedLeftoverRE matches Docker Compose's rename-during-recreate name:
+// when a service with a fixed container_name is recreated, Compose renames
+// the old container to "<hex-id>_<original-name>" before creating the new
+// one. If the recreate fails or is interrupted, the hash-prefixed container
+// survives (e.g. b6d7b59a1c78_ntask_hasura) and shadows the clean
+// <app>_<service> name that Makefiles and docs rely on (ntask gap #21).
+var renamedLeftoverRE = regexp.MustCompile(`^[0-9a-f]{8,}_`)
+
+// isRenamedComposeLeftover reports whether a container name is a stale
+// Compose rename-leftover for the given project: a hex-id prefix followed by
+// a name that belongs to the project ("<hex>_<project>_...").
+func isRenamedComposeLeftover(name, projectName string) bool {
+	m := renamedLeftoverRE.FindString(name)
+	if m == "" {
+		return false
+	}
+	rest := name[len(m):]
+	return strings.HasPrefix(rest, projectName+"_")
+}
+
+// cleanupRenamedLeftovers removes stale hash-prefixed rename-leftover
+// containers for the project so the clean <project>_<service> container
+// names are always the ones running. Best-effort: individual failures are
+// skipped.
+func cleanupRenamedLeftovers(ctx context.Context, projectName string) error {
+	cmd := exec.CommandContext(ctx, "docker", "ps", "-a", "--format", "{{.Names}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("docker ps -a: %w", err)
+	}
+	for _, name := range parseLines(string(out)) {
+		if !isRenamedComposeLeftover(name, projectName) {
+			continue
+		}
+		slog.Info("removing stale renamed container leftover", "container", name)
+		if err := forceRemoveContainer(ctx, name); err != nil {
+			continue
+		}
+	}
+	return nil
+}
+
+// RunPreStartCleanup removes stale artifacts that would break `docker compose
+// up`: hash-prefixed rename-leftover containers (which hold ports and shadow
+// clean container names). Run before compose up.
+func RunPreStartCleanup(ctx context.Context, projectName string) error {
+	return cleanupRenamedLeftovers(ctx, projectName)
+}
+
 // RunPostStartCleanup runs the full post-startup cleanup sequence:
 //  1. Init container cleanup, repeated 3 times with 500ms delays (handles race conditions
 //     where containers are still being marked as exited).
@@ -69,6 +119,13 @@ func RunPostStartCleanup(ctx context.Context, projectName string) error {
 	if err := cleanupZombieContainers(ctx, projectName); err != nil {
 		// Non-fatal: best effort.
 		slog.Debug("cleanup zombie containers (non-fatal)", "project", projectName, "err", err)
+	}
+
+	// Clean up hash-prefixed rename-leftovers from interrupted recreates so
+	// the clean <project>_<service> names are the surviving containers.
+	if err := cleanupRenamedLeftovers(ctx, projectName); err != nil {
+		// Non-fatal: best effort.
+		slog.Debug("cleanup renamed leftovers (non-fatal)", "project", projectName, "err", err)
 	}
 
 	return nil

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -23,6 +23,13 @@ type Compose struct {
 	// Order matters: first file is the base, subsequent files extend/override.
 	// If empty, no -f flags are added and Docker uses its default discovery.
 	ComposeFiles []string
+
+	// EnvFiles lists env file paths passed as --env-file flags for ${VAR}
+	// interpolation (secrets are env-templated out of the generated compose
+	// YAML — see internal/build secret templating). Order matters: later
+	// files win on conflict. If empty, Docker Compose falls back to its
+	// default .env discovery.
+	EnvFiles []string
 }
 
 // NewCompose returns a Compose instance configured with the given compose files.
@@ -46,6 +53,9 @@ func (c *Compose) buildBaseArgs() []string {
 	args := []string{"compose"}
 	for _, f := range c.ComposeFiles {
 		args = append(args, "-f", f)
+	}
+	for _, e := range c.EnvFiles {
+		args = append(args, "--env-file", e)
 	}
 	return args
 }

--- a/internal/docker/envfile_test.go
+++ b/internal/docker/envfile_test.go
@@ -1,0 +1,28 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildBaseArgs_EnvFiles verifies --env-file flags are emitted for each
+// configured env file (secret templating: interpolation via .nself/compose.env).
+func TestBuildBaseArgs_EnvFiles(t *testing.T) {
+	c := NewCompose("/p/docker-compose.yml")
+	c.EnvFiles = []string{"/p/.env", "/p/.nself/compose.env"}
+
+	got := strings.Join(c.buildBaseArgs(), " ")
+	want := "compose -f /p/docker-compose.yml --env-file /p/.env --env-file /p/.nself/compose.env"
+	if got != want {
+		t.Errorf("buildBaseArgs() = %q, want %q", got, want)
+	}
+}
+
+// TestBuildBaseArgs_NoEnvFiles keeps legacy behavior: no --env-file flags.
+func TestBuildBaseArgs_NoEnvFiles(t *testing.T) {
+	c := NewCompose("/p/docker-compose.yml")
+	got := strings.Join(c.buildBaseArgs(), " ")
+	if strings.Contains(got, "--env-file") {
+		t.Errorf("unexpected --env-file in %q", got)
+	}
+}

--- a/internal/docker/renamed_leftover_test.go
+++ b/internal/docker/renamed_leftover_test.go
@@ -1,0 +1,28 @@
+package docker
+
+// Purpose: Regression tests for PCI ntask-hasura-container-hash-name:
+//          stale Compose rename-leftovers (b6d7b59a1c78_ntask_hasura) must be
+//          detected so cleanup restores the clean <project>_<service> names.
+
+import "testing"
+
+func TestIsRenamedComposeLeftover(t *testing.T) {
+	cases := []struct {
+		name    string
+		project string
+		want    bool
+	}{
+		{"b6d7b59a1c78_ntask_hasura", "ntask", true},
+		{"0123abcd_ntask_postgres", "ntask", true},
+		{"ntask_hasura", "ntask", false},                   // clean name
+		{"b6d7b59a1c78_other_hasura", "ntask", false},      // different project
+		{"deadbeef1234_ntaskextra_hasura", "ntask", false}, // prefix, not project
+		{"hasura", "ntask", false},
+		{"b6d7_ntask_hasura", "ntask", false}, // hex too short (<8)
+	}
+	for _, c := range cases {
+		if got := isRenamedComposeLeftover(c.name, c.project); got != c.want {
+			t.Errorf("isRenamedComposeLeftover(%q, %q) = %v, want %v", c.name, c.project, got, c.want)
+		}
+	}
+}

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -93,6 +93,7 @@ func buildComposeHealthMap(ctx context.Context, workdir string) map[string]strin
 	}
 
 	comp := docker.NewCompose(composeFiles...)
+	comp.EnvFiles = build.ComposeEnvFiles(workdir)
 	infos, err := comp.ComposePs(ctx, workdir)
 	if err != nil {
 		return make(map[string]string)


### PR DESCRIPTION
Fixes five dogfood-reported build/start bugs that break the simple self-host setup and the Sentry bundle install path.

## Fixes
1. **CRITICAL — plugin injection dropped** (`51be7bf9`): `nself build` ignored `nself.yaml` entirely; declared plugins/bundles never materialized and were silently dropped. New `internal/build/manifest.go` parses `plugins:`/`bundle:`/`bundles:`, expands bundles via the canonical catalog, best-effort auto-installs missing plugins (disable: `NSELF_AUTO_INSTALL_PLUGINS=false`), and reports any unwired plugin via loud per-plugin warnings + `BuildResult.MissingPlugins` + a printed fix command. Repro test: N declared → N wired.
2. **HIGH — secret templating** (`f6fef60a`): literal secrets (Postgres password, Hasura admin secret, JWT blobs, MinIO creds) were baked into generated docker-compose.yml. Now emitted as `${VAR}` refs; interpolation values written to `.nself/compose.env` (0600) and passed via `--env-file`. Test asserts zero literal secrets in generated compose.
3. **MED — env allowlist** (`54c469b6`): app-owned vars (NODE_ENV, JWT_SECRET, LOG_LEVEL, ...) no longer warn; `ENV_ALLOWLIST` (exact names + `PREFIX_*`) for project passthrough.
4. **MED — localhost URLs** (`06d93be9`): `nself start` prints reachable `localhost:<port>` endpoints for default local domains instead of unreachable `*.local.nself.org`; custom domains unchanged.
5. **LOW — hash-prefixed leftovers** (`a8210b33`): pre/post-start cleanup removes interrupted-recreate rename leftovers (`b6d7b59a1c78_<app>_hasura`) that shadow clean container names.

## Verification
- `go build ./...`, `go vet ./...`, gofmt clean on touched files; 32 new tests green.
- Real `nself build` in a temp project declaring `bundle: nsentry` + 2 free plugins: all 15 declared plugins wired into compose-files.txt; missing-plugin path warns loudly per plugin with exact fix command; generated docker-compose.yml contains zero literal secret values, only `${VAR}` refs; `.nself/compose.env` written 0600.

PCIs: plugin-injection-dropped · compose-secret-templating · ntask-dev-env-schema-warnings · ntask-local-url-mismatch · ntask-hasura-container-hash-name