### PR TITLE
feat(bundle): add sentry -> nsentry slug alias

### DIFF
--- a/internal/bundle/bundles.go
+++ b/internal/bundle/bundles.go
@@ -108,13 +108,28 @@ var DisplayOrder = []string{
 	"nclaw", "nchat", "nfamily", "ntv", "clawde", "nsentry", "ntask", "nself-plus",
 }
 
+// bundleAliases maps informal/marketing slugs to their canonical bundle slug.
+// Aliases are resolved only as a fallback in Get() after the canonical lookup
+// misses — they never appear in Names() or DisplayOrder, so listings and
+// completions stay canonical-only.
+var bundleAliases = map[string]string{
+	"sentry": "nsentry",
+}
+
 // Get returns the Bundle for the given slug. The slug is case-insensitive and
-// trimmed. Returns ok=false when the slug is unknown; callers can call Names()
-// to render a useful error hint.
+// trimmed. Falls back to bundleAliases when there is no canonical match.
+// Returns ok=false when the slug is unknown; callers can call Names() to
+// render a useful error hint.
 func Get(slug string) (Bundle, bool) {
 	key := strings.ToLower(strings.TrimSpace(slug))
-	b, ok := canonicalBundles[key]
-	return b, ok
+	if b, ok := canonicalBundles[key]; ok {
+		return b, ok
+	}
+	if canonical, ok := bundleAliases[key]; ok {
+		b, ok := canonicalBundles[canonical]
+		return b, ok
+	}
+	return Bundle{}, false
 }
 
 // Names returns every known bundle slug sorted alphabetically. Useful for

--- a/internal/bundle/bundles_test.go
+++ b/internal/bundle/bundles_test.go
@@ -16,6 +16,8 @@ func TestGet_KnownBundles(t *testing.T) {
 		{"  nchat  ", true, "ɳChat", true},
 		{"nself-plus", true, "ɳSelf+", false}, // meta, not installable
 		{"ntask", true, "ɳTask", false},       // free, not installable as a unit
+		{"sentry", true, "ɳSentry", true},     // alias -> nsentry
+		{"SENTRY ", true, "ɳSentry", true},    // alias case-insensitive + trimmed
 		{"bogus", false, "", false},
 	}
 	for _, tc := range cases {
@@ -56,6 +58,18 @@ func TestNames_SortedAndComplete(t *testing.T) {
 	for _, r := range required {
 		if !have[r] {
 			t.Errorf("Names() missing required bundle %q", r)
+		}
+	}
+	// Aliases must never leak into Names()
+	if have["sentry"] {
+		t.Errorf("Names() must not include alias %q", "sentry")
+	}
+}
+
+func TestAliases_NotInDisplayOrder(t *testing.T) {
+	for _, slug := range DisplayOrder {
+		if slug == "sentry" {
+			t.Errorf("DisplayOrder must not include alias %q", "sentry")
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `nself bundle install sentry` now resolves to the canonical `nsentry` bundle via a new case-insensitive, trimmed alias lookup in `Get()`.
- `Names()` and `DisplayOrder` remain canonical-only — the alias never appears in listings or shell completions.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/bundle/...` (39 passed, incl. new `Get("sentry")`, `Get("SENTRY ")`, and DisplayOrder/Names non-leak assertions)
- [x] `go vet ./internal/bundle/...`, `gofmt -l` clean