### PR TITLE
fix(scripts): bump-version --homebrew phase for dual-arch darwin formula

### DIFF
--- a/internal/build/secrets_template_test.go
+++ b/internal/build/secrets_template_test.go
@@ -8,6 +8,7 @@ package build
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -144,7 +145,9 @@ func TestWriteComposeEnv_ContentAndPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if perm := info.Mode().Perm(); perm != 0o600 {
+	// Windows os.Chmod cannot represent POSIX owner-only bits (NTFS ACLs, not
+	// mode bits) — same exception as internal/build/hasura_config_test.go.
+	if perm := info.Mode().Perm(); runtime.GOOS != "windows" && perm != 0o600 {
 		t.Errorf("compose.env permissions = %o, want 0600", perm)
 	}
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -20,7 +20,8 @@
 #   8.  admin/Dockerfile                      ARG NSELF_VERSION=x.y.z
 #   9.  admin/Dockerfile                      ENV ADMIN_VERSION=x.y.z
 #   10. admin/Dockerfile                      LABEL org.opencontainers.image.version="x.y.z"
-# +11. homebrew-nself/Formula/nself.rb       url/sha256/version (--homebrew only)
+# +11. homebrew-nself/Formula/nself.rb       version + darwin arm64/amd64 sha256
+#                                             from release checksums.txt (--homebrew only)
 #
 # Exit codes:
 #   0 — success (all changes applied, or all already at target in idempotent run)
@@ -328,49 +329,98 @@ update_admin_dockerfile() {
   report "${f} (LABEL image.version)" "${old_label:-?}" "${NEW_VERSION}"
 }
 
+# formula_sha <file> <arm|intel>
+#   Extract the current sha256 inside the formula's on_arm or on_intel block.
+formula_sha() {
+  awk -v want="$2" '
+    /^[[:space:]]*on_arm do/        { block = "arm" }
+    /^[[:space:]]*on_intel do/      { block = "intel" }
+    /^[[:space:]]*end[[:space:]]*$/ { block = "" }
+    block == want && /^[[:space:]]*sha256[[:space:]]*"/ {
+      sub(/^[^"]*"/, ""); sub(/".*$/, ""); print; exit
+    }
+  ' "$1"
+}
+
+# The formula uses dual-arch darwin binary release assets
+# (nself-<ver>-darwin-{arm64,amd64}.tar.gz) whose urls interpolate #{version},
+# so only the version line and the two per-arch sha256 lines change. The
+# sha256 values come from the release's checksums.txt, never computed locally.
 update_homebrew_formula() {
   local f="${HOMEBREW_FORMULA}"
   if [ ! -f "${f}" ]; then
     printf 'ERROR: Missing file: %s\n' "${f}" >&2; exit 1
   fi
 
-  local tarball_url="https://github.com/nself-org/cli/archive/refs/tags/v${NEW_VERSION}.tar.gz"
+  local checksums_url="https://github.com/nself-org/cli/releases/download/v${NEW_VERSION}/checksums.txt"
+  local asset_arm="nself-${NEW_VERSION}-darwin-arm64.tar.gz"
+  local asset_amd="nself-${NEW_VERSION}-darwin-amd64.tar.gz"
 
   if [ "${DRY_RUN}" = "true" ]; then
-    printf '  [dry-run] Would fetch SHA256 from %s\n' "${tarball_url}"
-    printf '  [dry-run] Would update url, sha256, and version lines in %s\n' "${f}"
+    printf '  [dry-run] Would fetch %s\n' "${checksums_url}"
+    printf '  [dry-run] Would update version + darwin arm64/amd64 sha256 lines in %s\n' "${f}"
     return
   fi
 
-  printf '  Checking release exists: %s\n' "${tarball_url}"
-  local http_code
-  http_code="$(curl -o /dev/null -sL -w '%{http_code}' "${tarball_url}")"
-  if [ "${http_code}" != "200" ]; then
-    printf 'ERROR: Release not found on GitHub (HTTP %s).\n' "${http_code}" >&2
+  printf '  Fetching release checksums: %s\n' "${checksums_url}"
+  local checksums
+  if ! checksums="$(curl -fsSL "${checksums_url}")"; then
+    printf 'ERROR: checksums.txt not found for v%s on GitHub.\n' "${NEW_VERSION}" >&2
     printf '  Push the tag and wait for the GitHub release before running --homebrew.\n' >&2
-    printf '  URL checked: %s\n' "${tarball_url}" >&2
+    printf '  URL checked: %s\n' "${checksums_url}" >&2
     exit 1
   fi
 
-  printf '  Computing SHA256 (downloading tarball)...\n'
-  local sha256
-  sha256="$(curl -sL "${tarball_url}" | shasum -a 256 | cut -d' ' -f1)"
-  if [ -z "${sha256}" ]; then
-    printf 'ERROR: Could not compute SHA256 for %s\n' "${tarball_url}" >&2
+  # checksums.txt shape: `<64-hex-sha256>  <asset-filename>` per line.
+  local sha_arm sha_amd
+  sha_arm="$(printf '%s\n' "${checksums}" | awk -v a="${asset_arm}" '$2 == a { print $1; exit }')"
+  sha_amd="$(printf '%s\n' "${checksums}" | awk -v a="${asset_amd}" '$2 == a { print $1; exit }')"
+
+  if ! printf '%s' "${sha_arm}" | grep -qE '^[0-9a-f]{64}$'; then
+    printf 'ERROR: No valid sha256 for %s in checksums.txt\n' "${asset_arm}" >&2
     exit 1
   fi
-  printf '  SHA256: %s\n' "${sha256}"
+  if ! printf '%s' "${sha_amd}" | grep -qE '^[0-9a-f]{64}$'; then
+    printf 'ERROR: No valid sha256 for %s in checksums.txt\n' "${asset_amd}" >&2
+    exit 1
+  fi
 
-  local old_ver
-  old_ver="$(grep -E '^[[:space:]]*version[[:space:]]+"' "${f}" | sed 's/.*"\(.*\)".*/\1/' | head -1)"
+  local old_ver old_sha_arm old_sha_amd
+  old_ver="$(extract_semver "${f}" '^[[:space:]]*version[[:space:]]+"')"
+  old_sha_arm="$(formula_sha "${f}" arm)"
+  old_sha_amd="$(formula_sha "${f}" intel)"
 
-  sed \
-    -e "s|url \"https://github.com/nself-org/cli/archive/refs/tags/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.tar\.gz\"|url \"https://github.com/nself-org/cli/archive/refs/tags/v${NEW_VERSION}.tar.gz\"|" \
-    -e "s|# sha256 computed from https://github.com/nself-org/cli/archive/refs/tags/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.tar\.gz|# sha256 computed from https://github.com/nself-org/cli/archive/refs/tags/v${NEW_VERSION}.tar.gz|" \
-    -e "s/^\([[:space:]]*sha256[[:space:]]*\"\)[0-9a-f]*/\1${sha256}/" \
-    -e "s/^\([[:space:]]*version[[:space:]]*\"\)[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/\1${NEW_VERSION}/" \
-    "${f}" | atomic_write "${f}"
-  report "${f}" "${old_ver}" "${NEW_VERSION}"
+  if [ -z "${old_ver}" ] || [ -z "${old_sha_arm}" ] || [ -z "${old_sha_amd}" ]; then
+    printf 'ERROR: %s does not match the dual-arch formula shape\n' "${f}" >&2
+    printf '  (need a version "X.Y.Z" line plus sha256 lines inside on_arm and on_intel blocks)\n' >&2
+    exit 1
+  fi
+
+  if [ "${old_ver}" = "${NEW_VERSION}" ] && [ "${old_sha_arm}" = "${sha_arm}" ] && [ "${old_sha_amd}" = "${sha_amd}" ]; then
+    printf '  SKIP  %s  (already %s with matching sha256 values)\n' "${f}" "${NEW_VERSION}"
+    return
+  fi
+
+  awk -v newv="${NEW_VERSION}" -v arm="${sha_arm}" -v amd="${sha_amd}" '
+    /^[[:space:]]*version[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"/ {
+      sub(/"[0-9]+\.[0-9]+\.[0-9]+"/, "\"" newv "\"")
+    }
+    /^[[:space:]]*on_arm do/        { block = "arm" }
+    /^[[:space:]]*on_intel do/      { block = "intel" }
+    /^[[:space:]]*end[[:space:]]*$/ { block = "" }
+    block == "arm"   && /^[[:space:]]*sha256[[:space:]]*"/ { sub(/"[0-9a-f]*"/, "\"" arm "\"") }
+    block == "intel" && /^[[:space:]]*sha256[[:space:]]*"/ { sub(/"[0-9a-f]*"/, "\"" amd "\"") }
+    { print }
+  ' "${f}" | atomic_write "${f}"
+
+  if [ "$(formula_sha "${f}" arm)" != "${sha_arm}" ] || [ "$(formula_sha "${f}" intel)" != "${sha_amd}" ]; then
+    printf 'ERROR: sha256 replacement did not land in %s — check formula shape\n' "${f}" >&2
+    exit 1
+  fi
+
+  report "${f} (version)" "${old_ver}" "${NEW_VERSION}"
+  report "${f} (darwin-arm64 sha256)" "${old_sha_arm:0:12}..." "${sha_arm:0:12}..."
+  report "${f} (darwin-amd64 sha256)" "${old_sha_amd:0:12}..." "${sha_amd:0:12}..."
 }
 
 # ── Main ───────────────────────────────────────────────────────────────────────

--- a/scripts/bump-version_test.sh
+++ b/scripts/bump-version_test.sh
@@ -11,6 +11,7 @@
 #   7. pubspec.yaml (YAML — `version: X.Y.Z`)
 #   8. cli-version.ts (TS const)
 #   9. Dockerfile (three lines: ARG, ENV, LABEL)
+#   10. Formula/nself.rb (dual-arch darwin: version + per-arch sha256 from checksums.txt)
 #
 # Run: bash scripts/bump-version_test.sh
 # Exit 0 = all pass, 1 = any failure.
@@ -247,6 +248,104 @@ EOF
   fi
 }
 
+# Shape: Homebrew formula — dual-arch darwin blocks. Mirrors update_homebrew_formula:
+# extract per-arch sha256 from a checksums.txt fixture, then rewrite the version
+# line + both sha256 lines keyed by on_arm/on_intel block. URLs interpolate
+# #{version} and must NOT change.
+test_homebrew_formula() {
+  local f="${TMP_BASE}/nself.rb"
+  cat > "${f}" <<'EOF'
+class Nself < Formula
+  desc "Self-hosted backend CLI"
+  homepage "https://nself.org"
+  version "1.2.1"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/nself-org/cli/releases/download/v#{version}/nself-#{version}-darwin-arm64.tar.gz"
+      sha256 "f0f69a7ec6291f85b4fdb1d7ea13fe0e9ba3e8e077aa979f599f33acdd685ac5"
+    end
+
+    on_intel do
+      url "https://github.com/nself-org/cli/releases/download/v#{version}/nself-#{version}-darwin-amd64.tar.gz"
+      sha256 "2586e1d5aa1583212f4eedfa91b3e20fccb4dafb717264221b22c61fc3d6066b"
+    end
+  end
+
+  def install
+    bin.install "nself"
+  end
+end
+EOF
+
+  # checksums.txt fixture in release format: `<sha256>  <asset>` (sorted by name,
+  # so amd64 precedes arm64 — extraction must key on filename, not line order).
+  local sha_arm_want="beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef"
+  local sha_amd_want="cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe"
+  local checksums="${TMP_BASE}/checksums.txt"
+  cat > "${checksums}" <<EOF
+${sha_amd_want}  nself-${NEW}-darwin-amd64.tar.gz
+${sha_arm_want}  nself-${NEW}-darwin-arm64.tar.gz
+1111111111111111111111111111111111111111111111111111111111111111  nself-${NEW}-linux-amd64.tar.gz
+2222222222222222222222222222222222222222222222222222222222222222  nself-${NEW}-linux-arm64.tar.gz
+EOF
+
+  # Extraction (mirrors the script's checksums.txt parse)
+  local sha_arm sha_amd
+  sha_arm="$(awk -v a="nself-${NEW}-darwin-arm64.tar.gz" '$2 == a { print $1; exit }' "${checksums}")"
+  sha_amd="$(awk -v a="nself-${NEW}-darwin-amd64.tar.gz" '$2 == a { print $1; exit }' "${checksums}")"
+  if [ "${sha_arm}" = "${sha_arm_want}" ] && [ "${sha_amd}" = "${sha_amd_want}" ]; then
+    ok "checksums.txt per-arch extraction (keyed by filename)"
+  else
+    bad "checksums.txt extraction" "arm=${sha_arm} amd=${sha_amd}"
+  fi
+
+  # Transform (mirrors the script's formula rewrite)
+  awk -v newv="${NEW}" -v arm="${sha_arm}" -v amd="${sha_amd}" '
+    /^[[:space:]]*version[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"/ {
+      sub(/"[0-9]+\.[0-9]+\.[0-9]+"/, "\"" newv "\"")
+    }
+    /^[[:space:]]*on_arm do/        { block = "arm" }
+    /^[[:space:]]*on_intel do/      { block = "intel" }
+    /^[[:space:]]*end[[:space:]]*$/ { block = "" }
+    block == "arm"   && /^[[:space:]]*sha256[[:space:]]*"/ { sub(/"[0-9a-f]*"/, "\"" arm "\"") }
+    block == "intel" && /^[[:space:]]*sha256[[:space:]]*"/ { sub(/"[0-9a-f]*"/, "\"" amd "\"") }
+    { print }
+  ' "${f}" > "${f}.new"
+  mv "${f}.new" "${f}"
+
+  if grep -q "^  version \"${NEW}\"" "${f}"; then
+    ok "formula version line"
+  else
+    bad "formula version line" "got: $(grep 'version "' "${f}" | head -1)"
+  fi
+
+  # Each block must carry ITS OWN sha (the old single-sha sed clobbered both)
+  local got_arm got_amd
+  got_arm="$(awk '/on_arm do/{b=1} b && /sha256/{sub(/^[^"]*"/,""); sub(/".*$/,""); print; exit}' "${f}")"
+  got_amd="$(awk '/on_intel do/{b=1} b && /sha256/{sub(/^[^"]*"/,""); sub(/".*$/,""); print; exit}' "${f}")"
+  if [ "${got_arm}" = "${sha_arm_want}" ]; then
+    ok "formula on_arm sha256 (from checksums.txt)"
+  else
+    bad "formula on_arm sha256" "got: ${got_arm}"
+  fi
+  if [ "${got_amd}" = "${sha_amd_want}" ]; then
+    ok "formula on_intel sha256 (distinct from arm)"
+  else
+    bad "formula on_intel sha256" "got: ${got_amd}"
+  fi
+
+  # URLs interpolate #{version} and must remain untouched
+  local url_count
+  url_count="$(grep -c 'releases/download/v#{version}/nself-#{version}-darwin-' "${f}")"
+  if [ "${url_count}" = "2" ]; then
+    ok "formula urls preserved (#{version} interpolation)"
+  else
+    bad "formula urls" "expected 2 interpolated urls, found ${url_count}"
+  fi
+}
+
 # Integration smoke: run the actual bump-version.sh --dry-run and assert
 # it covers all 11 known lockstep files without errors.
 test_dry_run_smoke() {
@@ -285,6 +384,7 @@ test_cargo_toml
 test_pubspec_yaml
 test_cli_version_ts
 test_dockerfile
+test_homebrew_formula
 test_dry_run_smoke
 
 printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"


### PR DESCRIPTION
## Problem

`update_homebrew_formula` was stale: it computed a single sha256 from the **source archive** (`archive/refs/tags/v<ver>.tar.gz`) and sed-replaced **every** `sha256` line. `Formula/nself.rb` moved to dual-arch darwin **binary release assets** (`nself-<ver>-darwin-{arm64,amd64}.tar.gz`) with per-arch sha256 values from the release's `checksums.txt`. Running `--homebrew` today would corrupt the formula: both arch shas overwritten with the wrong source-tarball hash, and the url-rewrite patterns no longer match anything.

For v1.2.2 the refresh was done manually (nself-org/homebrew-nself#21).

## Fix

- Fetch `releases/download/v<ver>/checksums.txt` (also serves as the release-exists guard: 404 → exit 1 with the old "push the tag first" hint).
- Extract darwin-arm64 / darwin-amd64 sha256 keyed by **asset filename** (checksums.txt is name-sorted, amd64 first — line order is not trusted), validated as 64-hex.
- Rewrite the `version` line plus each `sha256` inside its `on_arm` / `on_intel` block via an awk block tracker. Urls interpolate `#{version}` and are left untouched.
- Shape validation before, landing check after, idempotent SKIP when already current.
- Bash-3.2-safe per cli rules: no `declare -A`, POSIX classes, awk for context-scoped edits (same pattern as the TOML updater).

## Tests

`scripts/bump-version_test.sh` gains the dual-arch formula fixture: checksums.txt per-arch extraction, per-block sha replacement (each block gets **its own** sha — the old failure mode), version line, url preservation. **17/17 passing.**

Sandbox end-to-end against the live v1.2.2 release: seeded the formula with pre-#21 values, ran `bump-version.sh 1.2.2 --homebrew` → output **byte-identical** to the merged #21 formula; re-run SKIPs; `9.9.9 --homebrew` exits 1.