### PR TITLE
fix(sdk): correct provenance repo URL + pin pnpm for Node 20 compat

### DIFF
--- a/.github/workflows/sdk-ts-sdk-publish.yml
+++ b/.github/workflows/sdk-ts-sdk-publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 9
 
       - name: Check preconditions
         id: check

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -61,7 +61,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nself-org/plugin-sdk-ts.git"
+    "url": "https://github.com/nself-org/cli.git",
+    "directory": "sdk/ts"
   },
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- `sdk/ts/package.json` repository.url pointed at a nonexistent `nself-org/plugin-sdk-ts` repo, causing npm sigstore provenance verification (422) to fail against the actual publishing repo `nself-org/cli`.
- `sdk-ts-sdk-publish.yml` pinned pnpm to `latest` (11.9.0), which requires Node >=22.13 and crashed on the workflow's Node 20 runtime (`ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`). Pinned to `9`, matching the sibling `sdk-ts-publish.yml` workflow which already publishes successfully on Node 20 + pnpm 9.

Root-caused via two failed reruns of the publish workflows after the `@nself` npm org was created (npm 404 scope-not-found from before is now resolved).

## Test plan
- [x] Confirmed `@nself` org now resolves on the npm registry
- [ ] Rerun both publish workflows after merge and confirm `@nself/plugin-sdk@1.2.4` + `@nself/sdk@1.2.4` land on npm