### PR TITLE
feat(sdk): implement missing @nself/sdk client

### DIFF
--- a/sdk/ts-sdk/src/index.ts
+++ b/sdk/ts-sdk/src/index.ts
@@ -1,0 +1,63 @@
+/**
+ * @nself/sdk — TypeScript consumer SDK for a running nSelf instance.
+ *
+ * Purpose: Thin typed HTTP client over a local nSelf backend's admin API
+ *          (health checks, plugin status). Not a GraphQL client — for
+ *          Hasura GraphQL access, use @nself/graphql-client instead.
+ * Inputs: NselfClientOptions (baseUrl + optional adminSecret).
+ * Outputs: Typed HealthStatus / Plugin results; throws on non-2xx responses.
+ * Constraints: Requires a global `fetch` (Node 18+ or browser).
+ * SPORT: F13-CROSS-REPO-DEPS.md — @nself/sdk consumer SDK.
+ */
+
+export interface NselfClientOptions {
+  baseUrl: string
+  adminSecret?: string
+}
+
+export interface HealthStatus {
+  status: string
+  version: string
+  uptime: number
+}
+
+export interface Plugin {
+  name: string
+  version: string
+  status: string
+  tier: string
+}
+
+export class NselfClient {
+  private readonly baseUrl: string
+  private readonly adminSecret?: string
+
+  constructor(options: NselfClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
+    this.adminSecret = options.adminSecret
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { 'content-type': 'application/json' }
+    if (this.adminSecret) {
+      headers['x-hasura-admin-secret'] = this.adminSecret
+    }
+    return headers
+  }
+
+  private async request<T>(path: string): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${path}`, { headers: this.buildHeaders() })
+    if (!response.ok) {
+      throw new Error(`nSelf API error: ${response.status}`)
+    }
+    return response.json() as Promise<T>
+  }
+
+  async health(): Promise<HealthStatus> {
+    return this.request<HealthStatus>('/health')
+  }
+
+  async listPlugins(): Promise<Plugin[]> {
+    return this.request<Plugin[]>('/plugins')
+  }
+}

--- a/sdk/ts-sdk/tsconfig.json
+++ b/sdk/ts-sdk/tsconfig.json
@@ -17,5 +17,5 @@
     "moduleResolution": "node16"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- `sdk/ts-sdk/src/index.ts` was never implemented — only its test file existed (from ticket P4-E1-W4-S15-T15). The publish workflow's `pnpm typecheck` failed with `Cannot find module './index'`.
- Implements `NselfClient` (`health()`, `listPlugins()`) exactly per the pre-existing test contract in `src/index.test.ts` — no test changes needed.
- Also excludes `*.test.ts` from `tsconfig.json` build output, matching the sibling `sdk/ts` package's convention — without this, `index.test.js` would ship inside the published npm tarball.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 6 existing tests pass unmodified
- [x] `pnpm build` — dist/ contains only `index.js`/`index.d.ts` (no test artifacts)
- [ ] Rerun `Publish @nself/sdk to npm` workflow post-merge and confirm `@nself/sdk@1.1.9` lands on npm