### PR TITLE
fix(e2e): golden-path skips ollama auto-install in CI (step 5)

### DIFF
--- a/.github/workflows/e2e-golden-path.yml
+++ b/.github/workflows/e2e-golden-path.yml
@@ -38,6 +38,9 @@ jobs:
       DOCKER_HOST: tcp://localhost:2375
       DOCKER_TLS_VERIFY: ''
       GOLDEN_PATH_SKIP_CLEANUP: '0'
+      # Skip the ollama auto-download during `nself start` — a full-stack smoke
+      # must not pull multi-GB AI models in CI (that's what destabilized step 5).
+      AI_AUTO_INSTALL: 'false'
       GOLDEN_PATH_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '0' }}
 
     steps:

--- a/scripts/golden-path.sh
+++ b/scripts/golden-path.sh
@@ -55,6 +55,9 @@ RESET_C='\033[0m'
 
 # ── Config ────────────────────────────────────────────────────────────────────
 DRY_RUN="${GOLDEN_PATH_DRY_RUN:-0}"
+# nself start auto-installs ollama when AI_AUTO_INSTALL is unset/true; the
+# golden-path validates the stack lifecycle, not a multi-GB AI model download.
+export AI_AUTO_INSTALL="${AI_AUTO_INSTALL:-false}"
 SKIP_CLEANUP="${GOLDEN_PATH_SKIP_CLEANUP:-0}"
 REPORT_FILE="/tmp/golden-path-report.json"
 


### PR DESCRIPTION
nself start auto-downloads ollama (AI_AUTO_INSTALL default) mid-start; the multi-GB pull destabilized step 5. Smoke sets AI_AUTO_INSTALL=false — validates the lifecycle, not the AI download.