### PR TITLE
fix(ci): run E2E Golden Path on self-hosted runner (real docker)

### DIFF
--- a/.github/workflows/e2e-golden-path.yml
+++ b/.github/workflows/e2e-golden-path.yml
@@ -19,24 +19,21 @@ concurrency:
 jobs:
   golden-path:
     name: 13-step golden path smoke
-    runs-on: ubuntu-latest
+    # Self-hosted (nself-sentry box): ubuntu-latest's docker-24-dind service
+    # cannot run the real multi-container `nself start` compose stack — a
+    # single container (postgres) comes up fine, but `docker compose up` for
+    # the full stack fails after ~50s with a generic "exit status 1" (nested
+    # DinD networking/storage-driver limitation, not an nself bug — verified
+    # 2026-07-07 on run 28823997500: steps 1-4 pass, step 5 dies specifically
+    # at "Starting remaining services"). The self-hosted runner has real host
+    # docker (verified working as the actions-runner user), so the compose
+    # stack runs the same way it would on a real dev machine.
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
     permissions:
       contents: write
 
-    services:
-      # Docker-in-Docker so nself start can spin up containers
-      docker:
-        image: docker:24-dind
-        options: --privileged
-        env:
-          DOCKER_TLS_CERTDIR: ''
-        ports:
-          - 2375:2375
-
     env:
-      DOCKER_HOST: tcp://localhost:2375
-      DOCKER_TLS_VERIFY: ''
       GOLDEN_PATH_SKIP_CLEANUP: '0'
       # Skip the ollama auto-download during `nself start` — a full-stack smoke
       # must not pull multi-GB AI models in CI (that's what destabilized step 5).
@@ -55,11 +52,13 @@ jobs:
 
       - name: Install Homebrew (Linux)
         run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          if ! command -v brew >/dev/null 2>&1; then
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          fi
           echo "/home/linuxbrew/.linuxbrew/bin" >> "${GITHUB_PATH}"
           echo "/home/linuxbrew/.linuxbrew/sbin" >> "${GITHUB_PATH}"
 
-      - name: Wait for Docker daemon
+      - name: Verify Docker daemon
         run: |
           for i in $(seq 1 15); do
             docker info >/dev/null 2>&1 && echo "Docker ready" && break
@@ -72,6 +71,25 @@ jobs:
         env:
           NSELF_PLUGIN_LICENSE_KEY_OWNER: ${{ secrets.NSELF_PLUGIN_LICENSE_KEY_OWNER }}
         run: bash scripts/golden-path.sh
+
+      - name: Clean up docker state (self-hosted runner is shared)
+        if: always()
+        run: |
+          nself stop --force 2>/dev/null || true
+          nself admin stop 2>/dev/null || true
+          # Belt-and-suspenders: golden-path.sh's own trap already does this,
+          # but a hard failure inside the script (e.g. bash -e abort) could
+          # skip its cleanup trap. Prune anything left behind by this run's
+          # test projects so state never leaks into the next job on this
+          # shared self-hosted runner.
+          for d in /tmp/nself-golden-path-*; do
+            [ -d "$d" ] || continue
+            (cd "$d"/testproject 2>/dev/null && docker compose down -v --remove-orphans 2>/dev/null) || true
+          done
+          docker container prune -f 2>/dev/null || true
+          docker volume prune -f 2>/dev/null || true
+          docker network prune -f 2>/dev/null || true
+          rm -rf /tmp/nself-golden-path-* /tmp/golden-path-diag-step*.txt /tmp/golden-path-claw-health.json /tmp/golden-path-ai-health.json 2>/dev/null || true
 
       - name: Upload JSON report
         if: always()


### PR DESCRIPTION
## Summary
- The `E2E Golden Path` workflow fails on `ubuntu-latest` because its `docker:24-dind` service cannot run the full multi-container `nself start` compose stack — verified on run 28823997500: steps 1-4 pass (install, init, build), a single postgres container starts fine, but `docker compose up` for the remaining services dies after ~50s with a generic `exit status 1` (nested DinD networking/storage-driver limitation).
- The self-hosted runner (nself-sentry box) has working host docker, so the compose stack runs the same way it would on a real dev machine.

## Change
- `runs-on: ubuntu-latest` (+ the `docker:24-dind` service block) → `runs-on: [self-hosted, Linux, X64]` for the `golden-path` job only — the only job in this workflow file.
- `cli` is a **public** repo, so every *other* workflow keeps free GitHub-hosted Actions; this move is scoped to the one job that needs real docker.
- "Install Homebrew" step now skips reinstall if already present (idempotent for repeated runs on the same shared runner).
- "Wait for Docker daemon" renamed to "Verify Docker daemon" (no dind service to wait on anymore, just confirming host docker answers).
- Added a cleanup step: `nself stop --force`, `nself admin stop`, `docker compose down -v --remove-orphans` for any leftover golden-path test project dirs, plus `docker container/volume/network prune -f` and tmp-file removal — since this runner is shared across CI jobs.

## Test plan
- [x] Confirmed host docker works on the self-hosted box as the `actions-runner` user
- [ ] `gh workflow run e2e-golden-path.yml --repo nself-org/cli` post-merge, watch to green