### PR TITLE
fix(ci): move cli off self-hosted runners onto GitHub-hosted

### DIFF
--- a/.github/workflows/e2e-golden-path.yml
+++ b/.github/workflows/e2e-golden-path.yml
@@ -19,16 +19,17 @@ concurrency:
 jobs:
   golden-path:
     name: 13-step golden path smoke
-    # Self-hosted (nself-sentry box): ubuntu-latest's docker-24-dind service
-    # cannot run the real multi-container `nself start` compose stack — a
-    # single container (postgres) comes up fine, but `docker compose up` for
-    # the full stack fails after ~50s with a generic "exit status 1" (nested
-    # DinD networking/storage-driver limitation, not an nself bug — verified
-    # 2026-07-07 on run 28823997500: steps 1-4 pass, step 5 dies specifically
-    # at "Starting remaining services"). The self-hosted runner has real host
-    # docker (verified working as the actions-runner user), so the compose
-    # stack runs the same way it would on a real dev machine.
-    runs-on: [self-hosted, Linux, X64]
+    # Moved back to GitHub-hosted ubuntu-latest 2026-08-14: cli is a PUBLIC
+    # repo, so hosted runners are free/unlimited and this job must not depend
+    # on a single self-hosted box. The 2026-07-07 failure recorded against the
+    # self-hosted runner (run 28823997500) predates this change; ubuntu-latest
+    # ships a real host Docker daemon (not a docker:dind service container),
+    # so the multi-container `nself start` compose stack is expected to work
+    # the same way it does on a real dev machine. Watch this job after the
+    # cutover — if it still fails at "Starting remaining services", that is a
+    # genuine ubuntu-latest Docker limitation to investigate, not the old
+    # self-hosted-specific issue.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write
@@ -72,7 +73,7 @@ jobs:
           NSELF_PLUGIN_LICENSE_KEY_OWNER: ${{ secrets.NSELF_PLUGIN_LICENSE_KEY_OWNER }}
         run: bash scripts/golden-path.sh
 
-      - name: Clean up docker state (self-hosted runner is shared)
+      - name: Clean up docker state
         if: always()
         run: |
           nself stop --force 2>/dev/null || true
@@ -80,8 +81,9 @@ jobs:
           # Belt-and-suspenders: golden-path.sh's own trap already does this,
           # but a hard failure inside the script (e.g. bash -e abort) could
           # skip its cleanup trap. Prune anything left behind by this run's
-          # test projects so state never leaks into the next job on this
-          # shared self-hosted runner.
+          # test projects within the job. GitHub-hosted ubuntu-latest VMs are
+          # single-use and torn down after the job, but this keeps the step
+          # correct if the workflow is ever pointed at a reused runner again.
           for d in /tmp/nself-golden-path-*; do
             [ -d "$d" ] || continue
             (cd "$d"/testproject 2>/dev/null && docker compose down -v --remove-orphans 2>/dev/null) || true

--- a/.github/workflows/pre-release-gate.yml
+++ b/.github/workflows/pre-release-gate.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   denylist-gate:
     name: Evaluate release denylist
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -28,7 +28,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   extract-version:
     name: Extract release version
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ver.outputs.version }}
       tag: ${{ steps.ver.outputs.tag }}
@@ -49,7 +49,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   build-dryrun:
     name: Build dry-run (all platforms)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: extract-version
     env:
       CGO_ENABLED: 0
@@ -98,7 +98,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   version-lockstep:
     name: Version lockstep check (CLI ↔ Admin)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: extract-version
     steps:
       - name: Checkout CLI repo
@@ -126,7 +126,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   homebrew-lockstep-dryrun:
     name: Homebrew formula lockstep (dry-run)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: extract-version
     steps:
       - name: Check formula version
@@ -168,7 +168,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   sbom-dryrun:
     name: SBOM generation dry-run
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: extract-version
     steps:
       - name: Checkout
@@ -195,7 +195,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   dryrun-gate:
     name: Dry-run gate (all checks passed)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: [build-dryrun, version-lockstep, homebrew-lockstep-dryrun, sbom-dryrun]
     steps:
       - name: Gate passed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   build:
     name: Build release artifacts
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hashes.outputs.hashes }}
       source_sha256: ${{ steps.source_sha256.outputs.sha256 }}
@@ -157,7 +157,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   sbom:
     name: Generate SBOM
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Download binaries
@@ -233,7 +233,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   verify-homebrew-lockstep:
     name: Verify Homebrew formula lockstep
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: build
 
     steps:
@@ -290,7 +290,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   sign-and-publish:
     name: Sign and publish release
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: [build, sbom, provenance, verify-homebrew-lockstep]
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- `cli` is a PUBLIC repo, so GitHub-hosted Actions runners are free and unlimited for it. Four workflows (12 `runs-on` occurrences) were pinned to `[self-hosted, Linux, X64]`, coupling the public flagship repo's CI to a single Hetzner box.
- That box's runner registrations were auto-deleted by GitHub after ~5 weeks idle, taking CI down org-wide for this repo (every `ci.yml` run since 2026-07-07 shows `conclusion=cancelled`; a stuck-`macos-13`-runner issue hit while landing #207 is a related-but-separate symptom of the same "don't depend on one box" problem, already fixed there).
- Changed `runs-on: [self-hosted, Linux, X64]` -> `runs-on: ubuntu-latest`:
  - `.github/workflows/e2e-golden-path.yml` (1)
  - `.github/workflows/pre-release-gate.yml` (1)
  - `.github/workflows/release-dryrun.yml` (6)
  - `.github/workflows/release.yml` (4)
- **release.yml / release-dryrun.yml**: only `runs-on` lines changed. No release logic, version handling, tags, signing, or the homebrew-lockstep gate were touched. The "Ensure build tools present (make, zip)" self-heal shim in release.yml was left as-is — it's a harmless no-op on ubuntu-latest (build-essential + zip ship preinstalled), and touching release.yml beyond `runs-on` adds risk for no benefit.
- **e2e-golden-path.yml**: updated the stale self-hosted-specific comments. The prior DinD-limitation note doesn't apply here — ubuntu-latest ships a real host Docker daemon, not a `docker:dind` service container, so `nself start`'s compose stack is expected to work. Watching this job post-merge to confirm.
- **pre-release-gate.yml**'s "Install gh CLI helpers" step only verifies `gh`/`jq` presence (no install) — no change needed, both ship preinstalled on ubuntu-latest.
- Grepped `.github/workflows/*.yml` and the whole repo for `self-hosted` / `nself-sentry-runner` — no other CI reference found. Remaining hits are unrelated product-doc mentions of nSelf being a self-hosted backend product.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` on all 4 edited workflow files — valid YAML
- [ ] CI checks on this PR green (ubuntu-latest jobs, no self-hosted dependency)
- [ ] After merge: trigger `release-dryrun` on a scratch `release/v*`-style ref or via re-run to confirm it runs on GitHub-hosted and is green
- [ ] After merge: observe/trigger `e2e-golden-path` (workflow_dispatch) — report whether it now passes on ubuntu-latest's native Docker or still fails (and why)