### PR TITLE
fix(ci): correct nself release tarball extraction in quarterly-doc-audit

### DIFF
--- a/.github/workflows/quarterly-doc-audit.yml
+++ b/.github/workflows/quarterly-doc-audit.yml
@@ -52,9 +52,13 @@ jobs:
               | grep tag_name | head -1 | cut -d'"' -f4 | sed 's/^v//')
             OS=$(uname -s | tr '[:upper:]' '[:lower:]')
             ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-            curl -fsSL "https://github.com/nself-org/cli/releases/download/v${LATEST}/nself-${LATEST}-${OS}-${ARCH}.tar.gz" \
-              | tar -xz -C /tmp
-            sudo mv /tmp/nself /usr/local/bin/nself
+            if curl -fsSL "https://github.com/nself-org/cli/releases/download/v${LATEST}/nself-${LATEST}-${OS}-${ARCH}.tar.gz" \
+              | tar -xz -C /tmp --strip-components=1; then
+              # release tarballs nest a nself-<ver>-<os>-<arch>/ dir — strip it
+              sudo mv /tmp/nself /usr/local/bin/nself
+            else
+              echo "::warning::nself release download/extract failed — audit tool unavailable, skipping"
+            fi
           fi
           nself --version || true
 


### PR DESCRIPTION
The nself CLI release tarballs nest the binary inside a `nself-${VERSION}-${OS}-${ARCH}/` directory. The quarterly-doc-audit install step assumed a flat extraction and did `mv /tmp/nself ...`, which fails since the release packaging added the wrapping dir. Adds `--strip-components=1` (matching the already-working fix in nchat/nclaw/nfamily/clawde/homebrew-nself) and fails soft instead of hard-erroring the whole audit.

Verified locally: downloaded the current v1.2.5 linux-amd64 release tarball and confirmed `--strip-components=1` extracts `/tmp/nself` correctly. Confirmed this repo's quarterly-doc-audit workflow_dispatch runs were failing with `mv: cannot stat '/tmp/nself': No such file or directory` before this fix.