### PR TITLE
fix(ci): quarterly-doc-audit hardening — lfs filter disable + drop unmatched mdx pathspec

### DIFF
--- a/.github/workflows/quarterly-doc-audit.yml
+++ b/.github/workflows/quarterly-doc-audit.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Disable git-lfs filters
+        # See admin/web workflow for the full rationale: any file under this repo's
+        # filter=lfs .gitattributes patterns that was committed as raw (non-pointer)
+        # content will otherwise show as spuriously "modified" to git, which can trip
+        # peter-evans/create-pull-request's internal git stash/checkout dance in the
+        # next Open-auto-fix-PR step. Harmless no-op if nothing is affected.
+        run: git lfs uninstall --local || true
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -101,7 +109,6 @@ jobs:
           delete-branch: true
           add-paths: |
             **/*.md
-            **/*.mdx
             .claude/qa/findings/*.json
 
       - name: Upload JSON report


### PR DESCRIPTION
## Summary
Part of a consistency fix across the 5 repos sharing this workflow (cli/admin/web/plugins/ntask), following the tarball-extraction fix (#213) and the plugins mdx-pathspec bug (nself-org/plugins#31):

- **Drop `**/*.mdx` from `add-paths`**: this repo has zero `.mdx` files. `git add`'s multi-pathspec matching is atomic — an unmatched pathspec element aborts the entire `git add`, which broke plugins' `Open auto-fix PR` step whenever the audit actually produced `.md` changes to stage. Currently latent here (cli's last audit run was clean), but the bug is real.
- **Disable git-lfs filters right after Checkout** (defensive): same shared-workflow hardening as admin (nself-org/admin#70) and web, where `.gitattributes`-declared `filter=lfs` binaries that were never actually migrated to real LFS pointers show as perpetually "modified" to git, breaking `peter-evans/create-pull-request`'s internal stash/checkout dance. cli has one candidate file (`vendor/.../chroma.jpg`) that doesn't presently trip this, but this keeps the workflow consistent across all 5 repos.

## Test plan
- [x] Confirmed via full-tree grep this repo has 0 `.mdx` files.
- [x] `git lfs uninstall --local` is a documented, safe no-op when nothing is affected.
- [ ] Watch `Quarterly doc audit` stays green on main HEAD after merge.