### PR TITLE
fix(ci): drop permanently-unmatchable JSON-findings pathspec from add-paths

### DIFF
--- a/.github/workflows/quarterly-doc-audit.yml
+++ b/.github/workflows/quarterly-doc-audit.yml
@@ -113,7 +113,6 @@ jobs:
           delete-branch: true
           add-paths: |
             **/*.md
-            .claude/qa/findings/*.json
 
       - name: Upload JSON report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Follow-up to #214 — the real, complete root cause. The AI-tooling config directory this org keeps out of git is gitignored repo-wide; `git add`'s pathspec matching does not count gitignored files as a match, so the findings-JSON pattern in `add-paths` would abort the whole `git add` call the moment any real `.md` change needs staging. Confirmed live in plugins (run 31958209014, nself-org/plugins#33). No functional loss — the JSON is already preserved via `actions/upload-artifact` and fed into the PR body via `body-path`.