### PR TITLE
fix(audit): stop --fix mangling prose by deleting adjectives

### DIFF
--- a/.github/workflows/quarterly-doc-audit.yml
+++ b/.github/workflows/quarterly-doc-audit.yml
@@ -113,7 +113,6 @@ jobs:
           delete-branch: true
           add-paths: |
             **/*.md
-            .claude/qa/findings/*.json
 
       - name: Upload JSON report
         uses: actions/upload-artifact@v7

--- a/internal/audit/docs.go
+++ b/internal/audit/docs.go
@@ -298,14 +298,22 @@ func scanFile(root, relPath string) ([]Finding, error) {
 		for i, re := range bannedRegex {
 			if m := re.FindStringSubmatchIndex(line); m != nil {
 				word := bannedWords[i]
+				// Only claim auto-fixability when the rewrite is actually safe;
+				// adjectives need a human. Keeping these in sync stops the
+				// summary's auto-fixable count from overstating what --fix does.
+				_, fixable := safeReplacement(word)
+				msg := fmt.Sprintf("banned word %q (F15 brand spec)", word)
+				if !fixable {
+					msg += " — rewrite the phrase by hand (no safe automatic fix)"
+				}
 				findings = append(findings, Finding{
 					Category: "banned_word",
 					Severity: "medium",
 					File:     relPath,
 					Line:     lineNum,
 					Match:    word,
-					Message:  fmt.Sprintf("banned word %q (F15 brand spec)", word),
-					AutoFix:  true,
+					Message:  msg,
+					AutoFix:  fixable,
 				})
 			}
 		}
@@ -453,7 +461,10 @@ func ApplyAutoFix(root string, report *DocReport) ([]string, error) {
 		orig := string(data)
 		updated := orig
 		for _, f := range fs {
-			replacement := safeReplacement(f.Match)
+			replacement, safe := safeReplacement(f.Match)
+			if !safe {
+				continue
+			}
 			updated = replaceWholeWord(updated, f.Match, replacement)
 		}
 		if updated == orig {
@@ -468,17 +479,32 @@ func ApplyAutoFix(root string, report *DocReport) ([]string, error) {
 	return modified, nil
 }
 
-// safeReplacement returns the neutral replacement for a banned word.
-// The CLI treats deletion as safer than substitution to avoid tone drift;
-// the result is a single space so sentence structure stays intact.
-func safeReplacement(word string) string {
+// safeReplacement returns the neutral replacement for a banned word and
+// whether an automatic rewrite is safe at all.
+//
+// Deletion is only safe for words that are grammatically optional in place:
+// conjunctive filler ("moreover, X" -> "X"). It is NOT safe for the adjectives
+// and set phrases in bannedWords, because they modify a following noun —
+// deleting the word alone leaves broken prose and, in Markdown, broken markup:
+//
+//	"Comprehensive guide for migrations"  -> " guide for migrations"
+//	"Wiki documentation is comprehensive" -> "Wiki documentation is "
+//	"**Comprehensive backup strategies**" -> "** backup strategies**"  (no longer bold)
+//	"The most powerful way to query"      -> "The most way to query"
+//
+// Those need a phrase-level rewrite with capitalization repair, which the
+// scanner has no sentence model for. They stay advisory: still reported as
+// findings so a human fixes them, never auto-rewritten. See the 2026-08-16
+// nself-org/plugins#34 review, which caught 48 wiki files being mangled this
+// way before merge.
+func safeReplacement(word string) (string, bool) {
 	switch strings.ToLower(word) {
 	case "moreover", "furthermore", "additionally":
-		return "" // drop conjunctive filler
+		return "", true // conjunctive filler: grammatically optional, safe to drop
 	case "leverage":
-		return "use"
+		return "use", true // direct verb-for-verb substitution
 	}
-	return ""
+	return "", false // adjectives and set phrases: report only
 }
 
 // replaceWholeWord replaces occurrences of word in src, honoring

--- a/internal/audit/docs_test.go
+++ b/internal/audit/docs_test.go
@@ -56,8 +56,14 @@ func TestRunDocs_BannedWord(t *testing.T) {
 	for _, f := range r.Findings {
 		if f.Category == "banned_word" && f.Match == "powerful" {
 			found = true
-			if !f.AutoFix {
-				t.Errorf("expected banned_word to be auto-fixable")
+			// Reported, but deliberately NOT auto-fixable. Deleting the
+			// adjective is only sometimes grammatical — "a powerful tool" ->
+			// "a tool" reads fine, but "the most powerful way" -> "the most
+			// way" does not — and a line scanner cannot tell the two apart.
+			// Since --fix writes public docs through an auto-opened PR, the
+			// safe default is to report and let a human rewrite the phrase.
+			if f.AutoFix {
+				t.Errorf("adjective %q must be advisory-only, not auto-fixed", f.Match)
 			}
 		}
 	}
@@ -162,11 +168,82 @@ func TestApplyAutoFix_LeverageToUse(t *testing.T) {
 }
 
 func TestReplaceWholeWord_DropsFiller(t *testing.T) {
-	got := replaceWholeWord("Moreover, we ship.", "moreover", safeReplacement("moreover"))
+	repl, safe := safeReplacement("moreover")
+	if !safe {
+		t.Fatal("conjunctive filler should be safely auto-fixable")
+	}
+	got := replaceWholeWord("Moreover, we ship.", "moreover", repl)
 	// The replacement is empty; we accept either ", we ship." or " , we ship."
 	// as long as the word is gone and the sentence remains readable.
 	if strings.Contains(strings.ToLower(got), "moreover") {
 		t.Errorf("moreover still present: %q", got)
+	}
+}
+
+// TestSafeReplacement_AdjectivesAreAdvisoryOnly pins the classification that
+// keeps --fix from mangling prose. Regression guard for nself-org/plugins#34,
+// where deleting these words alone rewrote 48 public wiki files into broken
+// English ("Comprehensive guide" -> " guide").
+func TestSafeReplacement_AdjectivesAreAdvisoryOnly(t *testing.T) {
+	for _, w := range []string{
+		"comprehensive", "powerful", "robust", "seamlessly",
+		"best-in-class", "world-class", "state-of-the-art",
+		"cutting-edge", "revolutionary", "game-changing",
+		"dive into", "delve into",
+	} {
+		if _, safe := safeReplacement(w); safe {
+			t.Errorf("%q must be advisory-only: deleting it alone breaks the sentence", w)
+		}
+	}
+	for _, w := range []string{"moreover", "furthermore", "additionally", "leverage"} {
+		if _, safe := safeReplacement(w); !safe {
+			t.Errorf("%q should still be auto-fixable", w)
+		}
+	}
+}
+
+// TestApplyAutoFix_LeavesAdjectivePhrasesIntact reproduces the exact strings
+// that plugins#34 corrupted and asserts --fix now leaves them untouched.
+func TestApplyAutoFix_LeavesAdjectivePhrasesIntact(t *testing.T) {
+	root := t.TempDir()
+	for _, anchor := range RequiredAnchors {
+		writeFile(t, filepath.Join(root, anchor), "# placeholder\n")
+	}
+	target := filepath.Join(root, ".claude/docs/prose.md")
+	const body = "# Title\n\n" +
+		"Comprehensive guide for database migrations.\n" +
+		"Wiki documentation is comprehensive\n" +
+		"4. **Comprehensive backup strategies** for safety\n" +
+		"The most powerful way to query your data:\n"
+	writeFile(t, target, body)
+
+	r, err := RunDocs(Options{Root: root})
+	if err != nil {
+		t.Fatalf("RunDocs: %v", err)
+	}
+	if _, err := ApplyAutoFix(root, r); err != nil {
+		t.Fatalf("ApplyAutoFix: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if got := string(data); got != body {
+		t.Errorf("adjective phrases must be left for a human rewrite.\n got: %q\nwant: %q", got, body)
+	}
+
+	// The findings must still be reported — advisory, not silently dropped.
+	var n int
+	for _, f := range r.Findings {
+		if f.Category == "banned_word" {
+			n++
+			if f.AutoFix {
+				t.Errorf("finding %q on line %d must not claim AutoFix", f.Match, f.Line)
+			}
+		}
+	}
+	if n == 0 {
+		t.Error("banned words must still be reported even when not auto-fixable")
 	}
 }
 


### PR DESCRIPTION
Closes the defect found reviewing nself-org/plugins#34.

## What went wrong

`nself audit docs --fix` deleted every banned word at word level. That is fine for conjunctive filler, but adjectives modify a following noun, so deleting the word alone leaves broken prose — and in Markdown, broken markup:

| Before | After |
|---|---|
| `Comprehensive guide for database migrations` | ` guide for database migrations` |
| `Wiki documentation is comprehensive` | `Wiki documentation is ` |
| `4. ✅ **Comprehensive backup strategies** for safety` | `4. ✅ ** backup strategies** for safety` (no longer renders bold) |
| `The most powerful way to query your data:` | `The most way to query your data:` |

The quarterly audit auto-opened plugins#34 rewriting **48 public wiki files** this way. It was closed unmerged; no docs shipped damaged.

## Fix

`safeReplacement` now returns `(replacement string, safe bool)`:

- **Auto-fixed** (unchanged): `moreover` / `furthermore` / `additionally` (grammatically optional in place), `leverage` -> `use` (verb-for-verb).
- **Advisory only** (new): the adjectives and set phrases. Still reported as findings, with the message noting a hand rewrite is needed — never auto-rewritten.

`AutoFix` on each finding is set from the same predicate, so the summary’s `auto_fixable` count stops overstating what `--fix` will actually change.

## Why not just repair the grammar

Deletion is *sometimes* fine (`a powerful tool` -> `a tool`) and sometimes not (`the most powerful way` -> `the most way`). Telling them apart needs a sentence model the line scanner does not have. Since `--fix` writes public docs through an auto-opened PR, reporting is the safe default.

## Verification

- `go test ./internal/audit/` — 20 passed
- `gofmt -l` clean, `go vet` clean
- New `TestApplyAutoFix_LeavesAdjectivePhrasesIntact` replays the exact strings plugins#34 corrupted and asserts they are byte-identical after `--fix`, while still asserting the findings are reported.
- `TestRunDocs_BannedWord` updated: it previously asserted the unsafe contract (`powerful` is auto-fixable). Comment explains why the contract changed.

Version files untouched (version lock).