### PR TITLE
chore(cli): docs.nself.org -> nself.org/docs (docs moved to /docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://docs.nself.org
+    url: https://nself.org/docs
     about: Check the docs first
   - name: Discord
     url: https://discord.gg/nself

--- a/.github/docs/ci-hygiene-policy.md
+++ b/.github/docs/ci-hygiene-policy.md
@@ -91,7 +91,7 @@ A PR satisfies the doc-sync check if at least one of these files is also modifie
 
 - `.github/wiki/**` (public repos) or `.github/docs/**` (private repos)
 - `.claude/docs/sport/F0*.md` (SPORT master lists)
-- `web/docs/content/**` (docs.nself.org content)
+- `web/docs/content/**` (nself.org/docs content)
 - `README.md` (when the change directly affects the readme content)
 
 ---

--- a/.github/install.ps1
+++ b/.github/install.ps1
@@ -200,7 +200,7 @@ function Install-Nself {
     Write-Host "  cd my-project"
     Write-Host "  nself start"
     Write-Host ""
-    Write-Host "Documentation: https://docs.nself.org" -ForegroundColor DarkGray
+    Write-Host "Documentation: https://nself.org/docs" -ForegroundColor DarkGray
 }
 
 Install-Nself

--- a/.github/wiki/Home.md
+++ b/.github/wiki/Home.md
@@ -257,4 +257,4 @@ Step-by-step guides for common workflows.
 | [Report Issues](https://github.com/nself-org/cli/issues) | Bug reports and feature requests |
 | [Discussions](https://github.com/nself-org/cli/discussions) | Community conversations |
 | [nself.org](https://nself.org) | Official website |
-| [docs.nself.org](https://docs.nself.org) | Online documentation |
+| [nself.org/docs](https://nself.org/docs) | Online documentation |

--- a/.github/wiki/_Footer.md
+++ b/.github/wiki/_Footer.md
@@ -2,4 +2,4 @@
 
 ɳSelf CLI v1.0.9. MIT licensed. Docs CC BY 4.0.
 
-[GitHub](https://github.com/nself-org/cli) · [Issues](https://github.com/nself-org/cli/issues) · [Discussions](https://github.com/nself-org/cli/discussions) · [nself.org](https://nself.org) · [docs.nself.org](https://docs.nself.org)
+[GitHub](https://github.com/nself-org/cli) · [Issues](https://github.com/nself-org/cli/issues) · [Discussions](https://github.com/nself-org/cli/discussions) · [nself.org](https://nself.org) · [nself.org/docs](https://nself.org/docs)

--- a/.github/wiki/cmd-dlq.md
+++ b/.github/wiki/cmd-dlq.md
@@ -76,5 +76,5 @@ nself dlq replay mux --filter status=quarantined --max-rows 50
 
 ### See Also
 
-- [Observability](https://docs.nself.org/operations/observability), DLQ metrics (S41-T02)
-- [mux plugin](https://docs.nself.org/plugins/mux), mux DLQ schema
+- [Observability](https://nself.org/docs/operations/observability), DLQ metrics (S41-T02)
+- [mux plugin](https://nself.org/docs/plugins/mux), mux DLQ schema

--- a/.github/wiki/cmd-doctor.md
+++ b/.github/wiki/cmd-doctor.md
@@ -181,7 +181,7 @@ nself migrate apply --rls-force np_chat_messages
 nself doctor --deep --only security
 ```
 
-**See also:** [multi-tenant conventions](https://docs.nself.org/multi-tenancy/conventions) for the canonical wall doc on `source_account_id` vs `tenant_id`.
+**See also:** [multi-tenant conventions](https://nself.org/docs/multi-tenancy/conventions) for the canonical wall doc on `source_account_id` vs `tenant_id`.
 
 ---
 

--- a/.github/wiki/cmd-help-topics.md
+++ b/.github/wiki/cmd-help-topics.md
@@ -12,7 +12,7 @@ nself help-topics [topic]
 
 `nself help-topics` provides quick access to built-in guides covering common nSelf workflows. Running the command without a topic argument prints the full topic index. Pass a topic name to display the article for that topic.
 
-This command is a local reference that works without a network connection. For the full documentation site, visit [docs.nself.org](https://docs.nself.org).
+This command is a local reference that works without a network connection. For the full documentation site, visit [nself.org/docs](https://nself.org/docs).
 
 ## Available Topics
 

--- a/.github/wiki/cmd-mail.md
+++ b/.github/wiki/cmd-mail.md
@@ -207,5 +207,5 @@ Record:   v=DKIM1; k=rsa; p=...
 ## Related
 
 - [[cmd-license]] — Manage license keys for paid bundles
-- [docs.nself.org/mail](https://docs.nself.org/mail) — Full mail user guide
+- [nself.org/docs/mail](https://nself.org/docs/mail) — Full mail user guide
 - [[Home]]

--- a/.github/wiki/cmd-oauth.md
+++ b/.github/wiki/cmd-oauth.md
@@ -67,5 +67,5 @@ nself oauth refresh --all
 
 ### See Also
 
-- [Observability](https://docs.nself.org/operations/observability), oauth_token_refresh_total metric
-- [google plugin](https://docs.nself.org/plugins/google), Google OAuth configuration
+- [Observability](https://nself.org/docs/operations/observability), oauth_token_refresh_total metric
+- [google plugin](https://nself.org/docs/plugins/google), Google OAuth configuration

--- a/.github/wiki/cmd-soak.md
+++ b/.github/wiki/cmd-soak.md
@@ -75,4 +75,4 @@ nself soak abort --rollback v1.0.8 --env prod --prod-i-mean-it --yes
 ### See Also
 
 - [nself deploy rollback](cmd-deploy.md), underlying rollback mechanism
-- [Observability](https://docs.nself.org/operations/observability), post-rollback metrics
+- [Observability](https://nself.org/docs/operations/observability), post-rollback metrics

--- a/.github/wiki/cmd-start.md
+++ b/.github/wiki/cmd-start.md
@@ -50,7 +50,7 @@ Since v1.2.2, when the project uses a default local domain (unset, `localhost`, 
 
 ```
 error: v0.9 project detected. Found 3 legacy artifact(s): docker-compose.yml, .env, nginx/nginx.conf
-Run `nself migrate` first. See https://docs.nself.org/migrate/from-v0.9
+Run `nself migrate` first. See https://nself.org/docs/migrate/from-v0.9
 ```
 
 A single hit produces a non-blocking warning. Use `nself migrate detect` to see all detected artifacts before running the migration. See [[Upgrade-From-v0.9]] for the full migration guide.

--- a/.github/wiki/cmd-update.md
+++ b/.github/wiki/cmd-update.md
@@ -22,7 +22,7 @@ When running on a v0.9 CLI (any `0.x.y` binary), `nself update --check` queries 
 
 ```
 WARNING: You are running a legacy v0.9 CLI. Migration to v1.1.1 is required.
-Upgrade guide: https://docs.nself.org/migrate/from-v0.9
+Upgrade guide: https://nself.org/docs/migrate/from-v0.9
 ```
 
 The check is read-only and non-destructive. It does not install anything. See [[Upgrade-From-v0.9]] for the full migration guide.

--- a/.github/wiki/commands/cmd-api.md
+++ b/.github/wiki/commands/cmd-api.md
@@ -78,7 +78,7 @@ nself api deprecation-check [--json]
 ```
 
 Cross-references the central deprecation registry at `.claude/docs/api-deprecations.md`
-(mirrored publicly at `docs.nself.org/api/deprecations/`).
+(mirrored publicly at `nself.org/docs/api/deprecations/`).
 
 At v1.0.9 baseline, the registry is empty. This command exits 0 with "0 deprecations
 found" at baseline.
@@ -87,7 +87,7 @@ When future deprecations are added, this command will report:
 
 ```
 [ping_api] /license/old-endpoint (deprecated since v1.1.0, EOL 2028-06-01)
-  Migration: https://docs.nself.org/api/deprecations/ping-api-license-old-endpoint
+  Migration: https://nself.org/docs/api/deprecations/ping-api-license-old-endpoint
 ```
 
 ### Flags
@@ -126,7 +126,7 @@ backward-compatible through 2027-04-17. Breaking changes during this window requ
 2. A maintainer (not PR author) approval label
 3. An entry in the deprecation registry with at least 6 months notice
 
-See [API Deprecations](https://docs.nself.org/api/deprecations/) and
+See [API Deprecations](https://nself.org/docs/api/deprecations/) and
 `.claude/docs/operations/breaking-change-policy.md` for details.
 
 ---

--- a/.github/wiki/commands/cmd-generate.md
+++ b/.github/wiki/commands/cmd-generate.md
@@ -118,7 +118,7 @@ Use generated types with the ɳSelf SDK packages:
 | Kotlin | `io.nself:client` | `import io.nself.generated.*` |
 | Python | `nself-client` | `from generated.python.models import User` |
 
-See [SDK reference](https://docs.nself.org/sdks/) for full usage.
+See [SDK reference](https://nself.org/docs/sdks/) for full usage.
 
 ## Notes
 

--- a/.github/wiki/commands/cmd-pitr.md
+++ b/.github/wiki/commands/cmd-pitr.md
@@ -185,6 +185,6 @@ and full restore orchestration.
 
 - [[cmd-backup]], full and metadata backups
 - [[cmd-restore]], restore from a pg_dump backup
-- [Point-in-Time Recovery Guide](https://docs.nself.org/guides/point-in-time-recovery)
+- [Point-in-Time Recovery Guide](https://nself.org/docs/guides/point-in-time-recovery)
 
 [[Home]]

--- a/.github/wiki/commands/cmd-plugin-logs.md
+++ b/.github/wiki/commands/cmd-plugin-logs.md
@@ -68,7 +68,7 @@ bundle. Equivalent Loki query:
 {container=~"nself-plugin-myplugin"} |= "ERROR"
 ```
 
-See [Observability guide](https://docs.nself.org/observability) for the Grafana dashboard.
+See [Observability guide](https://nself.org/docs/observability) for the Grafana dashboard.
 
 ## See Also
 

--- a/.github/wiki/commands/template.md
+++ b/.github/wiki/commands/template.md
@@ -15,7 +15,7 @@ Templates are full-stack app packages that include a Postgres schema, Hasura met
 
 Use `nself template list` to browse from the CLI, `nself template info <slug>` to inspect a specific template, and `nself init --template <slug>` to install one into a new project directory.
 
-Authors publish via `nself template publish` and receive 80% revenue share on paid templates (requires a KYC-approved author account, see [B55 plugin-author-revenue-share](https://docs.nself.org/developers/revenue-share)).
+Authors publish via `nself template publish` and receive 80% revenue share on paid templates (requires a KYC-approved author account, see [B55 plugin-author-revenue-share](https://nself.org/docs/developers/revenue-share)).
 
 ## Subcommands
 
@@ -190,6 +190,6 @@ nself template update --force
 - [[nself init]], Project initialisation including built-in language scaffolds
 - [[nself plugin]], Plugin management
 - [Template Marketplace](https://nself.org/templates), Browse templates in the browser
-- [Publish a template](https://docs.nself.org/templates/publish-template), Author guide
+- [Publish a template](https://nself.org/docs/templates/publish-template), Author guide
 
 [[Home]]

--- a/.github/wiki/deprecation-registry.md
+++ b/.github/wiki/deprecation-registry.md
@@ -31,7 +31,7 @@ No CLI commands or flags are deprecated at v1.0.9.
 
 **Phase 1, Warning:** Item works. Every invocation prints:
 ```
-[DEPRECATED] 'nself old-cmd' (since v1.0.9) → use 'nself new-cmd'. Docs: https://docs.nself.org/...
+[DEPRECATED] 'nself old-cmd' (since v1.0.9) → use 'nself new-cmd'. Docs: https://nself.org/docs/...
 ```
 
 **Phase 2, Deprecated:** Item still works. Warning includes removal timeline.
@@ -39,7 +39,7 @@ No CLI commands or flags are deprecated at v1.0.9.
 **Phase 3, Removed:** Item gone. Clear error with migration guide link.
 
 Emergency removals (security CVEs only) skip phases. See the full doctrine at
-`docs.nself.org/deprecation-cycle`.
+`nself.org/docs/deprecation-cycle`.
 
 ## Adding a Deprecation
 
@@ -56,7 +56,7 @@ items:
     type: command
     since: "v1.1.0"
     replacement: "nself new-cmd"
-    docs_url: "https://docs.nself.org/migrate/v1-1-0"
+    docs_url: "https://nself.org/docs/migrate/v1-1-0"
     phase: 1
 ```
 

--- a/.github/wiki/error-codes.md
+++ b/.github/wiki/error-codes.md
@@ -12,7 +12,7 @@ When the CLI encounters a problem, it prints a structured message in this format
 [E001] Docker not installed
   Why: The docker binary was not found in PATH.
   Fix: Install Docker: https://docs.docker.com/get-docker/
-  Docs: https://docs.nself.org/reference/error-codes#e001
+  Docs: https://nself.org/docs/reference/error-codes#e001
 ```
 
 The code in brackets (e.g., `[E001]`) is stable across CLI versions. You can search this page by code to find the cause and fix.
@@ -136,10 +136,10 @@ The full structured format for a CLI error:
 [EXXXX] What happened (brief)
   Why: Root cause explanation.
   Fix: Steps to resolve the issue.
-  Docs: https://docs.nself.org/reference/error-codes#eXXXX
+  Docs: https://nself.org/docs/reference/error-codes#eXXXX
 ```
 
-The `Why` and `Fix` lines provide context to act on. The `Docs` line links directly to the anchor for that code on this page (via `docs.nself.org`, which mirrors this wiki).
+The `Why` and `Fix` lines provide context to act on. The `Docs` line links directly to the anchor for that code on this page (via `nself.org/docs`, which mirrors this wiki).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Complete, production-ready backend stack — PostgreSQL, GraphQL API, Authentica
 brew install nself-org/nself/nself
 ```
 
-[Quick Start](#quick-start) · [The Stack](#the-stack) · [Plugins](#plugins) · [Pricing](#pricing) · [Docs](https://docs.nself.org)
+[Quick Start](#quick-start) · [The Stack](#the-stack) · [Plugins](#plugins) · [Pricing](#pricing) · [Docs](https://nself.org/docs)
 
 </div>
 
@@ -250,7 +250,7 @@ nself build && nself restart
 
 ## CLI Command Reference
 
-ɳSelf provides **47 top-level commands** organized by domain. Full reference: [docs.nself.org/cli](https://docs.nself.org/cli).
+ɳSelf provides **47 top-level commands** organized by domain. Full reference: [nself.org/docs/cli](https://nself.org/docs/cli).
 
 ### Stack lifecycle
 
@@ -486,7 +486,7 @@ Security hardening runs automatically on every deploy. No license required.
 
 ## Docs and Community
 
-- [docs.nself.org](https://docs.nself.org) — complete documentation
+- [nself.org/docs](https://nself.org/docs) — complete documentation
 - [nself.org](https://nself.org) — project home, pricing, plugins catalog
 - [GitHub Discussions](https://github.com/nself-org/cli/discussions) — community Q&A
 - [GitHub Issues](https://github.com/nself-org/cli/issues) — bug reports
@@ -522,6 +522,6 @@ The 109 pro plugins are source-available under a separate commercial license. Co
 
 **ɳSelf CLI v1.1.2** · [nself.org](https://nself.org) · [GitHub](https://github.com/nself-org/cli)
 
-[Get Started](#quick-start) · [Documentation](https://docs.nself.org) · [Pricing](#pricing)
+[Get Started](#quick-start) · [Documentation](https://nself.org/docs) · [Pricing](#pricing)
 
 </div>

--- a/charts/nself/templates/NOTES.txt
+++ b/charts/nself/templates/NOTES.txt
@@ -17,4 +17,4 @@ Next steps:
 To install plugins:
   Set NSELF_PLUGIN_LICENSE_KEY and re-install with --plugins.
 
-Docs: https://docs.nself.org/guides/kubernetes
+Docs: https://nself.org/docs/guides/kubernetes

--- a/cmd/commands/build.go
+++ b/cmd/commands/build.go
@@ -126,7 +126,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 					workdir = cwd
 				} else {
 					ui.Error(fmt.Sprintf("v0.9 project detected. Found %d legacy artifact(s): %s", count, strings.Join(names, ", ")))
-					fmt.Fprintln(os.Stderr, "Run `nself migrate` first. See https://docs.nself.org/migrate/from-v0.9")
+					fmt.Fprintln(os.Stderr, "Run `nself migrate` first. See https://nself.org/docs/migrate/from-v0.9")
 					return fmt.Errorf("v0.9 project detected — run `nself migrate` first")
 				}
 			}
@@ -152,7 +152,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 				}
 			} else {
 				ui.Error(fmt.Sprintf("v0.9 project detected. Found %d legacy artifact(s): %s", count, strings.Join(names, ", ")))
-				fmt.Fprintln(os.Stderr, "Run `nself migrate` first. See https://docs.nself.org/migrate/from-v0.9")
+				fmt.Fprintln(os.Stderr, "Run `nself migrate` first. See https://nself.org/docs/migrate/from-v0.9")
 				return fmt.Errorf("v0.9 project detected — run `nself migrate` first")
 			}
 		} else if count == 1 && !quiet {

--- a/cmd/commands/help_topics.go
+++ b/cmd/commands/help_topics.go
@@ -30,7 +30,7 @@ var helpTopics = map[string]helpTopic{
     nself start --env staging
     nself start --env production
 
-  Full guide: https://docs.nself.org/getting-started`,
+  Full guide: https://nself.org/docs/getting-started`,
 	},
 	"plugins": {
 		Title:   "Plugin System",
@@ -47,7 +47,7 @@ var helpTopics = map[string]helpTopic{
   Info:   nself plugin info <name>
   Remove: nself plugin remove <name>
 
-  Docs: https://docs.nself.org/plugins`,
+  Docs: https://nself.org/docs/plugins`,
 	},
 	"license": {
 		Title:   "License & Bundles",
@@ -62,7 +62,7 @@ var helpTopics = map[string]helpTopic{
   Validate:     nself license validate
   Upgrade:      nself license upgrade
 
-  Docs: https://docs.nself.org/licensing`,
+  Docs: https://nself.org/docs/licensing`,
 	},
 	"envs": {
 		Title:   "Environments",
@@ -78,7 +78,7 @@ var helpTopics = map[string]helpTopic{
   Full-environment init:
     nself init --full    # generates .env.dev, .env.staging, .env.prod, .env.secrets
 
-  Docs: https://docs.nself.org/environments`,
+  Docs: https://nself.org/docs/environments`,
 	},
 	"doctor": {
 		Title:   "Diagnostics",
@@ -94,7 +94,7 @@ var helpTopics = map[string]helpTopic{
     1  Checks failed
     2  Warnings only
 
-  Docs: https://docs.nself.org/doctor`,
+  Docs: https://nself.org/docs/doctor`,
 	},
 	"errors": {
 		Title:   "Error Codes",
@@ -110,7 +110,7 @@ var helpTopics = map[string]helpTopic{
   E300-E349  Init / project issues
   E350-E399  Domain issues
 
-  Full reference: https://docs.nself.org/reference/error-codes`,
+  Full reference: https://nself.org/docs/reference/error-codes`,
 	},
 }
 

--- a/cmd/commands/plugin_logs.go
+++ b/cmd/commands/plugin_logs.go
@@ -162,4 +162,4 @@ func resolveViaCompose(pluginName string) (string, error) {
 // For production debugging, use Grafana/Loki with the nSelf monitoring stack.
 // Equivalent Loki query for plugin logs:
 //   {container=~"nself-plugin-<name>"} |= "ERROR"
-// See docs.nself.org/observability for the Grafana dashboard.
+// See nself.org/docs/observability for the Grafana dashboard.

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -268,7 +268,7 @@ func runStart(cmd *cobra.Command, _ []string) error {
 				projectDir = cwd
 			} else {
 				ui.Error(fmt.Sprintf("v0.9 project detected. Found %d legacy artifact(s): %s", count, strings.Join(names, ", ")))
-				fmt.Fprintln(os.Stderr, "Run `nself migrate` first. See https://docs.nself.org/migrate/from-v0.9")
+				fmt.Fprintln(os.Stderr, "Run `nself migrate` first. See https://nself.org/docs/migrate/from-v0.9")
 				startErr = fmt.Errorf("v0.9 project detected — run `nself migrate` first")
 				return startErr
 			}
@@ -285,7 +285,7 @@ func runStart(cmd *cobra.Command, _ []string) error {
 			ui.Warn(fmt.Sprintf("WARNING: v0.9 project detected (%d artifact(s): %s). Proceeding due to --allow-legacy (not recommended).", count, strings.Join(names, ", ")))
 		} else {
 			ui.Error(fmt.Sprintf("v0.9 project detected. Found %d legacy artifact(s): %s", count, strings.Join(names, ", ")))
-			fmt.Fprintln(os.Stderr, "Run `nself migrate` first. See https://docs.nself.org/migrate/from-v0.9")
+			fmt.Fprintln(os.Stderr, "Run `nself migrate` first. See https://nself.org/docs/migrate/from-v0.9")
 			startErr = fmt.Errorf("v0.9 project detected — run `nself migrate` first")
 			return startErr
 		}

--- a/internal/deprecation/checker.go
+++ b/internal/deprecation/checker.go
@@ -72,7 +72,7 @@ func CheckPluginCompat(installed []InstalledPlugin, reg *PluginRegistry) []Warni
 					DeprecatedIn:     cal.DeprecatedIn,
 					RemovedIn:        cal.RemovedIn,
 					Replacement:      cal.Replacement,
-					Docs: fmt.Sprintf("https://docs.nself.org/api/migration/%s-%s",
+					Docs: fmt.Sprintf("https://nself.org/docs/api/migration/%s-%s",
 						ip.Name, strings.ReplaceAll(strings.TrimPrefix(cal.Path, "/"), "/", "-")),
 				})
 			}

--- a/internal/deprecation/deprecation_test.go
+++ b/internal/deprecation/deprecation_test.go
@@ -52,7 +52,7 @@ func TestLoadRegistry_WithEntry(t *testing.T) {
     type: command
     since: "v1.0.9"
     replacement: "nself new-cmd"
-    docs_url: "https://docs.nself.org/migrate"
+    docs_url: "https://nself.org/docs/migrate"
     phase: 1
 `
 	path := writeRegistry(t, yaml)
@@ -74,7 +74,7 @@ func TestWarnFormat_Phase1(t *testing.T) {
     type: command
     since: "v1.0.9"
     replacement: "nself new-cmd"
-    docs_url: "https://docs.nself.org/migrate"
+    docs_url: "https://nself.org/docs/migrate"
     phase: 1
 `
 	path := writeRegistry(t, yaml)
@@ -97,7 +97,7 @@ func TestWarnFormat_Phase1(t *testing.T) {
 	if !strings.Contains(out, "nself new-cmd") {
 		t.Errorf("warning must contain replacement, got: %q", out)
 	}
-	if !strings.Contains(out, "https://docs.nself.org/migrate") {
+	if !strings.Contains(out, "https://nself.org/docs/migrate") {
 		t.Errorf("warning must contain docs URL, got: %q", out)
 	}
 	if strings.Contains(out, "Will be removed") {
@@ -111,7 +111,7 @@ func TestWarnFormat_Phase2(t *testing.T) {
     type: command
     since: "v1.0.9"
     replacement: "nself new-cmd"
-    docs_url: "https://docs.nself.org/migrate"
+    docs_url: "https://nself.org/docs/migrate"
     phase: 2
 `
 	path := writeRegistry(t, yaml)
@@ -130,7 +130,7 @@ func TestWarnFormat_Phase2(t *testing.T) {
 func TestWarnWritesToStderr(t *testing.T) {
 	// Verify Warn() accepts os.Stderr without panic — io.Writer interface test.
 	var buf bytes.Buffer
-	deprecation.Warn(&buf, "nself x", "v1.0.0", "nself y", "https://docs.nself.org")
+	deprecation.Warn(&buf, "nself x", "v1.0.0", "nself y", "https://nself.org/docs")
 	if buf.Len() == 0 {
 		t.Error("Warn() must write output to the provided writer")
 	}
@@ -147,7 +147,7 @@ func TestLookup_NotFound(t *testing.T) {
 
 func TestPackageLevelWarnFormat(t *testing.T) {
 	var buf bytes.Buffer
-	deprecation.Warn(&buf, "nself old", "v1.1.0", "nself new", "https://docs.nself.org/migrate")
+	deprecation.Warn(&buf, "nself old", "v1.1.0", "nself new", "https://nself.org/docs/migrate")
 	out := buf.String()
 	if !strings.Contains(out, "[DEPRECATED]") {
 		t.Errorf("package-level Warn must contain [DEPRECATED], got: %q", out)

--- a/internal/deprecation/registry.yaml
+++ b/internal/deprecation/registry.yaml
@@ -33,7 +33,7 @@ items:
     type: env
     since: "v1.0.9"
     replacement: "nTV bundle — run: nself plugin install nTV"
-    docs_url: "https://docs.nself.org/migrate/v1-0-8-to-v1-0-9"
+    docs_url: "https://nself.org/docs/migrate/v1-0-8-to-v1-0-9"
     phase: 1
 
 # =============================================================================

--- a/internal/doctor/dogfood_checks.go
+++ b/internal/doctor/dogfood_checks.go
@@ -67,7 +67,7 @@ var dogfoodSubapps = []string{
 // dogfoodSubappURLs maps subapps to their production URLs for header probing.
 var dogfoodSubappURLs = map[string]string{
 	"org":     "https://nself.org",
-	"docs":    "https://docs.nself.org",
+	"docs":    "https://nself.org/docs",
 	"nchat":   "https://chat.nself.org",
 	"nclaw":   "https://claw.nself.org",
 	"ntask":   "https://task.nself.org",

--- a/internal/doctor/hardening_check_auth_net.go
+++ b/internal/doctor/hardening_check_auth_net.go
@@ -305,7 +305,7 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 			Name:    checkID,
 			Status:  "fail",
 			Message: "SEC-HARDENING-06: nginx missing rate-limit zones for /auth/login and /api/ — add limit_req_zone directives",
-			FixCmd:  "See docs.nself.org/security/nginx-rate-limiting",
+			FixCmd:  "See nself.org/docs/security/nginx-rate-limiting",
 		}
 	default:
 		missing := "/api/"
@@ -317,7 +317,7 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 			Name:    checkID,
 			Status:  "warn",
 			Message: fmt.Sprintf("SEC-HARDENING-06: nginx rate-limit zone missing for %s — add limit_req_zone directive", missing),
-			FixCmd:  "See docs.nself.org/security/nginx-rate-limiting",
+			FixCmd:  "See nself.org/docs/security/nginx-rate-limiting",
 		}
 	}
 }

--- a/internal/dr/alert.go
+++ b/internal/dr/alert.go
@@ -15,7 +15,7 @@ const DrillAlertRuleYAML = `groups:
           service: dr
         annotations:
           summary: "DR drill {{ $labels.drill_id }} failed"
-          runbook: "https://docs.nself.org/ops/dr-drill-failure"
+          runbook: "https://nself.org/docs/ops/dr-drill-failure"
 `
 
 // DrillResultMetricName is the Prometheus metric name emitted by a drill run.

--- a/internal/errs/errs_structured_test.go
+++ b/internal/errs/errs_structured_test.go
@@ -34,7 +34,7 @@ func TestCLIError_Error_AllFields(t *testing.T) {
 	if !strings.Contains(got, "Fix: run nself install widget") {
 		t.Errorf("Error() = %q: missing Fix", got)
 	}
-	if !strings.Contains(got, "Docs: https://docs.nself.org/reference/error-codes#e001") {
+	if !strings.Contains(got, "Docs: https://nself.org/docs/reference/error-codes#e001") {
 		t.Errorf("Error() = %q: missing Docs", got)
 	}
 }

--- a/internal/errs/structured.go
+++ b/internal/errs/structured.go
@@ -39,7 +39,7 @@ func (e *CLIError) Error() string {
 		b.WriteString(fmt.Sprintf("\n  Fix: %s", e.Fix))
 	}
 	if e.DocsPath != "" {
-		b.WriteString(fmt.Sprintf("\n  Docs: https://docs.nself.org/%s", e.DocsPath))
+		b.WriteString(fmt.Sprintf("\n  Docs: https://nself.org/docs/%s", e.DocsPath))
 	}
 	return b.String()
 }

--- a/internal/migration/migrator.go
+++ b/internal/migration/migrator.go
@@ -432,7 +432,7 @@ func pluginWarning(projectDir, backupDir string) {
 	}
 
 	fmt.Fprintln(os.Stdout)
-	fmt.Fprintln(os.Stdout, "  See: https://docs.nself.org/migrate/from-v0.9#step-3-re-install-plugins")
+	fmt.Fprintln(os.Stdout, "  See: https://nself.org/docs/migrate/from-v0.9#step-3-re-install-plugins")
 	fmt.Fprintln(os.Stdout)
 }
 

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -56,7 +56,7 @@ func TestParseStatus_Deprecated(t *testing.T) {
 	m.Deprecation = &DeprecationBlock{
 		AnnouncedDate:  "2026-04-01",
 		EOLDate:        "2027-04-01",
-		MigrationGuide: "https://docs.nself.org/migrate/my-plugin",
+		MigrationGuide: "https://nself.org/docs/migrate/my-plugin",
 	}
 	if err := validateManifest(m); err != nil {
 		t.Errorf("expected deprecated with full block to be valid, got: %v", err)
@@ -127,7 +127,7 @@ func TestDeprecationBlock_ReplacedByPromptFires(t *testing.T) {
 	m.Deprecation = &DeprecationBlock{
 		AnnouncedDate:  "2026-04-01",
 		EOLDate:        "2027-04-01",
-		MigrationGuide: "https://docs.nself.org/migrate/my-plugin",
+		MigrationGuide: "https://nself.org/docs/migrate/my-plugin",
 		ReplacedBy:     "my-plugin-v2",
 	}
 	if err := validateManifest(m); err != nil {

--- a/internal/ux/error.go
+++ b/internal/ux/error.go
@@ -88,7 +88,7 @@ func FromCLIError(e *errs.CLIError) *UXError {
 		ux.Suggestions = []string{e.Fix}
 	}
 	if e.DocsPath != "" {
-		ux.DocsLink = "https://docs.nself.org/" + e.DocsPath
+		ux.DocsLink = "https://nself.org/docs/" + e.DocsPath
 	}
 	return ux
 }

--- a/packaging/chocolatey/nself.nuspec
+++ b/packaging/chocolatey/nself.nuspec
@@ -18,7 +18,7 @@
     <owners>nself-org</owners>
     <projectUrl>https://nself.org</projectUrl>
     <projectSourceUrl>https://github.com/nself-org/cli</projectSourceUrl>
-    <docsUrl>https://docs.nself.org</docsUrl>
+    <docsUrl>https://nself.org/docs</docsUrl>
     <bugTrackerUrl>https://github.com/nself-org/cli/issues</bugTrackerUrl>
     <licenseUrl>https://github.com/nself-org/cli/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/scripts/sport/generate-f21.sh
+++ b/scripts/sport/generate-f21.sh
@@ -27,7 +27,7 @@ if [ -f "$REGISTRY" ]; then
     /^    type:/  { type=substr($0, index($0,$2)); gsub(/^"|"$/, "", type) }
     /^    since:/ { since=substr($0, index($0,$2)); gsub(/^"|"$/, "", since) }
     /^    replacement:/ { repl=substr($0, index($0,$2)); gsub(/^"|"$/, "", repl) }
-    /^    phase:/ { phase=substr($0, index($0,$2)); print "| " name " | " type " | " since " | " repl " | " phase " | https://docs.nself.org/migrate |" }
+    /^    phase:/ { phase=substr($0, index($0,$2)); print "| " name " | " type " | " since " | " repl " | " phase " | https://nself.org/docs/migrate |" }
   ' "$REGISTRY")
 fi
 

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -86,7 +86,7 @@
 //
 // Source: https://github.com/nself-org/cli/tree/main/sdk/go
 // Issues: https://github.com/nself-org/cli/issues
-// Docs:   https://docs.nself.org/sdk/go
+// Docs:   https://nself.org/docs/sdk/go
 //
 // # License
 //

--- a/sdk/go/internal/deprecation/deprecated.go
+++ b/sdk/go/internal/deprecation/deprecated.go
@@ -3,7 +3,7 @@
 // Usage in a plugin handler:
 //
 //	func (p *MyPlugin) OldHandler(ctx context.Context, req Request) (Response, error) {
-//	    deprecation.Mark(ctx, "OldHandler", "NewHandler", "v1.0.9", "https://docs.nself.org/plugins/deprecation")
+//	    deprecation.Mark(ctx, "OldHandler", "NewHandler", "v1.0.9", "https://nself.org/docs/plugins/deprecation")
 //	    return p.NewHandler(ctx, req)
 //	}
 //

--- a/sdk/go/internal/deprecation/deprecated_test.go
+++ b/sdk/go/internal/deprecation/deprecated_test.go
@@ -15,7 +15,7 @@ func TestMark_EmitsWarn(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	ctx := deprecation.WithLogger(context.Background(), logger)
 
-	deprecation.Mark(ctx, "OldHandler", "NewHandler", "v1.0.9", "https://docs.nself.org/plugins/deprecation")
+	deprecation.Mark(ctx, "OldHandler", "NewHandler", "v1.0.9", "https://nself.org/docs/plugins/deprecation")
 
 	out := buf.String()
 	if !strings.Contains(out, "deprecated") {
@@ -34,7 +34,7 @@ func TestMark_HandlerStillExecutes(t *testing.T) {
 	executed := false
 	ctx := context.Background()
 
-	deprecation.Mark(ctx, "OldHandler", "NewHandler", "v1.0.9", "https://docs.nself.org")
+	deprecation.Mark(ctx, "OldHandler", "NewHandler", "v1.0.9", "https://nself.org/docs")
 	executed = true
 
 	if !executed {
@@ -47,7 +47,7 @@ func TestMark_LogFormat(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	ctx := deprecation.WithLogger(context.Background(), logger)
 
-	deprecation.Mark(ctx, "Legacy", "Modern", "v1.0.9", "https://docs.nself.org")
+	deprecation.Mark(ctx, "Legacy", "Modern", "v1.0.9", "https://nself.org/docs")
 
 	out := buf.String()
 	// JSON handler should emit structured fields


### PR DESCRIPTION
## Summary
- Docs moved from `docs.nself.org` to `nself.org/docs` (path-preserving redirect: `docs.nself.org/X` now 308-redirects to `nself.org/docs/X`).
- Updated 42 files to point directly at the canonical URL instead of relying on the redirect hop: Go source (help/error text, deprecation registry, tests), README, `.github/wiki/**`, package metadata (`nself.nuspec`), Helm chart notes, PowerShell installer, ISSUE_TEMPLATE config.
- The old `docs.nself.org` URLs still work via redirect, so this is purely an optimization + hygiene change, not a breaking one.

## Deliberately left unchanged
- `scripts/soak/01-deploy-verify.sh:13` — probes the `docs.nself.org` subdomain's own `/api/version` health endpoint as a live deploy-verification check, not a documentation link. Left as-is pending a decision on whether that subdomain still serves its own version endpoint post-move.

## Test plan
- [x] `go build ./...` passes
- [x] `gofmt -l` clean on all changed `.go` files
- [x] Manual grep confirms no remaining `docs.nself.org` refs except the intentional soak-script line