### PR TITLE
fix(embedded): initialise __stack_pointer to the top of memory, not 0

### DIFF
--- a/internal/embedded/emscripten_abi.go
+++ b/internal/embedded/emscripten_abi.go
@@ -57,6 +57,12 @@ func defineEmscriptenABI(linker *wasmtime.Linker, store *wasmtime.Store) error {
 	// Emscripten SIDE_MODULE linking globals. Values are set to 0; pglite's
 	// dynamic linker sets them at runtime before any code runs.
 
+	// Declared by pglite v0.2.17's env::memory import; also sets the stack top.
+	const (
+		pageSize     = 65536
+		initialPages = 2048 // 128 MB (2048 x 65536 bytes) — declared minimum
+	)
+
 	i32Const := wasmtime.NewGlobalType(wasmtime.NewValType(wasmtime.KindI32), false)
 	i32Mut := wasmtime.NewGlobalType(wasmtime.NewValType(wasmtime.KindI32), true)
 
@@ -76,8 +82,26 @@ func defineEmscriptenABI(linker *wasmtime.Linker, store *wasmtime.Store) error {
 		return fmt.Errorf("embedded/abi: define __table_base: %w", err)
 	}
 
-	// __stack_pointer is mutable (pglite's stack allocator modifies it).
-	stackPtr, err := wasmtime.NewGlobal(store, i32Mut, wasmtime.ValI32(0))
+	// __stack_pointer is mutable (pglite's stack allocator modifies it) and MUST
+	// start at the top of a usable stack region, not at 0.
+	//
+	// The WASM stack grows DOWNWARD: every function prologue does
+	// `sp -= frame_size`. Starting it at 0 means the very first prologue
+	// underflows i32 and dereferences near the top of the 4 GB address space.
+	// That produced the trap that made every embedded PG integration test fail:
+	//
+	//   memory fault at wasm address 0xfffffef0 in linear memory of size 0x8000000
+	//   wasm trap: out of bounds memory access
+	//
+	// 0xfffffef0 is exactly 0 - 272, a 272-byte first frame subtracted from a zero
+	// stack pointer, not a genuine 4 GB access. With a valid stack top the same
+	// boot proceeds 8 frames deep instead of trapping in the first.
+	//
+	// The stack starts at the end of the declared initial memory and grows down
+	// toward the data/heap region, which starts at __memory_base (0). This is the
+	// standard Emscripten layout and keeps maximum separation between the two.
+	const stackTop = initialPages * pageSize // 128 MB, one past the last valid byte
+	stackPtr, err := wasmtime.NewGlobal(store, i32Mut, wasmtime.ValI32(stackTop))
 	if err != nil {
 		return fmt.Errorf("embedded/abi: __stack_pointer: %w", err)
 	}
@@ -93,8 +117,7 @@ func defineEmscriptenABI(linker *wasmtime.Linker, store *wasmtime.Store) error {
 	// Providing fewer initial pages or a larger maximum causes an
 	// "incompatible import type" trap at instantiation.
 	const (
-		initialPages = 2048  // 128 MB (2048 × 65536 bytes) — declared minimum
-		maxPages     = 32768 // 2 GB (32768 × 65536 bytes) — declared maximum
+		maxPages = 32768 // 2 GB (32768 × 65536 bytes) — declared maximum
 	)
 	mem, err := wasmtime.NewMemory(store, wasmtime.NewMemoryType(initialPages, true, maxPages))
 	if err != nil {


### PR DESCRIPTION
Root cause of the embedded PG integration failures, **reproduced and verified locally** against the real pglite 0.2.17 WASM.

## The trap was a stack underflow, not a 4 GB access

```
memory fault at wasm address 0xfffffef0 in linear memory of size 0x8000000
wasm trap: out of bounds memory access
```

`0xfffffef0` is **exactly `0 - 272`**. The WASM stack grows *downward*: every function prologue does `sp -= frame_size`. With `__stack_pointer` initialised to `0`, the very first prologue underflows i32 and lands near the top of the 4 GB space. It never got past frame 0.

## Verified locally

Downloaded the pinned WASM (sha256 `545a6e03…`, matches the workflow pin) and ran the real integration test:

| `__stack_pointer` | result |
|---|---|
| `0` | trap at `0xfffffef0`, **1** backtrace frame |
| `0x1000000` | boots **8** frames deep |
| `0x8000000` | boots **8** frames deep |

The fix sets the stack top to the end of declared initial memory (128 MB), growing down toward the data/heap region at `__memory_base` (0). Standard Emscripten layout.

## Next blocker, deliberately not addressed here

Boot now reaches a separate architectural gap: WASI host functions from `linker.DefineWasi()` resolve guest memory through the instance's **exported** `memory`, but pglite is an Emscripten SIDE_MODULE that *imports* `env::memory` and exports nothing. The first WASI call fails with `missing required memory export`. Fixing that means implementing the WASI subset pglite needs directly against the host-owned memory, which is its own piece of work.

So this PR moves the failure forward by 8 frames and removes a genuine bug; it does not turn the integration job green on its own.

## Note on my earlier PRs

The timeout work in #221 was real but secondary, and my first diagnosis on that PR (a null `argv` from `__main_argc_argv(0, 0)`) was **wrong**. The argv path is fine; the stack pointer was the fault. Corrected here.

Unit tests pass, `gofmt` and `go vet` clean.