### PR TITLE
security(ci): route every govulncheck call site through one allowlist gate

### DIFF
--- a/.github/scripts/govuln-gate.sh
+++ b/.github/scripts/govuln-gate.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# govuln-gate.sh — run govulncheck and fail only on advisories that are not
+# explicitly accepted in .github/govulncheck-allow.txt.
+#
+# Why this exists: govulncheck's own exit code is "found anything at all", which
+# cannot distinguish a newly published advisory (must break the build) from one
+# we have already reviewed and accepted because upstream ships no fix. A bare
+# `govulncheck ./...` therefore either blocks every build forever or gets
+# disabled wholesale. This narrows the gate instead of removing it.
+#
+# Single source of truth for every workflow that scans Go vulns:
+#   govuln.yml · security-scan.yml · deep-qa-block.yml · govulncheck-nightly.yml
+#
+# Usage:   bash .github/scripts/govuln-gate.sh [packages]      (default ./...)
+# Exit:    0 = only accepted advisories (or none)
+#          1 = at least one advisory not in the allowlist
+#
+# Constraints: bash 3.2 compatible (no mapfile/associative arrays); writes only
+# under ${RUNNER_TEMP:-/tmp} so it can never trip the clean-root gate.
+
+set -uo pipefail
+
+PKGS="${1:-./...}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ALLOW_FILE="${REPO_ROOT}/.github/govulncheck-allow.txt"
+TMPDIR_="${RUNNER_TEMP:-/tmp}"
+REPORT="${TMPDIR_}/govuln-report.txt"
+
+if [ ! -f "${ALLOW_FILE}" ]; then
+  printf '::error::missing allowlist: %s\n' "${ALLOW_FILE}"
+  exit 1
+fi
+
+# Non-zero just means "found something"; the allowlist decides pass/fail.
+GOFLAGS="${GOFLAGS:--mod=vendor}" govulncheck "${PKGS}" > "${REPORT}" 2>&1 || true
+cat "${REPORT}"
+
+# Strip trailing comments so an ID mentioned in prose cannot silently allow itself.
+sed 's/#.*//' "${ALLOW_FILE}" \
+  | grep -oE 'GO-[0-9]{4}-[0-9]+' | sort -u > "${TMPDIR_}/govuln-allow.ids"
+grep -oE 'GO-[0-9]{4}-[0-9]+' "${REPORT}" | sort -u > "${TMPDIR_}/govuln-found.ids"
+
+comm -23 "${TMPDIR_}/govuln-found.ids" "${TMPDIR_}/govuln-allow.ids" \
+  > "${TMPDIR_}/govuln-unexpected.ids"
+comm -13 "${TMPDIR_}/govuln-found.ids" "${TMPDIR_}/govuln-allow.ids" \
+  > "${TMPDIR_}/govuln-stale.ids"
+
+FOUND=$(grep -c . "${TMPDIR_}/govuln-found.ids" || true)
+UNEXPECTED=$(grep -c . "${TMPDIR_}/govuln-unexpected.ids" || true)
+STALE=$(grep -c . "${TMPDIR_}/govuln-stale.ids" || true)
+
+if [ "${STALE}" -gt 0 ]; then
+  # Keeps the allowlist from rotting into a blanket suppression.
+  printf '::warning::allowlist entries no longer reported, remove them: %s\n' \
+    "$(tr '\n' ' ' < "${TMPDIR_}/govuln-stale.ids")"
+fi
+
+if [ "${UNEXPECTED}" -gt 0 ]; then
+  printf '::error::govulncheck reported advisories not in .github/govulncheck-allow.txt:\n'
+  while IFS= read -r id; do
+    [ -n "${id}" ] && printf '::error::  %s (https://pkg.go.dev/vuln/%s)\n' "${id}" "${id}"
+  done < "${TMPDIR_}/govuln-unexpected.ids"
+  printf '::error::Fix the dependency, or add the ID with a reason and tracking issue.\n'
+  exit 1
+fi
+
+printf 'govuln gate passed: %s advisory/ies reported, all accepted, 0 unexpected\n' "${FOUND}"

--- a/.github/workflows/deep-qa-block.yml
+++ b/.github/workflows/deep-qa-block.yml
@@ -44,7 +44,7 @@ jobs:
       - name: govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
-          GOFLAGS=-mod=vendor govulncheck ./...
+          bash .github/scripts/govuln-gate.sh
 
       - name: Generate report stub
         run: |

--- a/.github/workflows/govuln.yml
+++ b/.github/workflows/govuln.yml
@@ -28,34 +28,7 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
-      - name: Run govulncheck
+      - name: Run govulncheck (allowlist gate)
         env:
           GOFLAGS: -mod=vendor
-        run: |
-          set -uo pipefail
-          # Capture the report; a non-zero exit just means "found something",
-          # which the allowlist below decides about.
-          govulncheck ./... > "${RUNNER_TEMP}/govuln-report.txt" 2>&1 || true
-          cat "${RUNNER_TEMP}/govuln-report.txt"
-
-          found=$(grep -oE 'GO-[0-9]{4}-[0-9]+' "${RUNNER_TEMP}/govuln-report.txt" | sort -u)
-          allow=$(sed 's/#.*//' .github/govulncheck-allow.txt \
-                  | grep -oE 'GO-[0-9]{4}-[0-9]+' | sort -u)
-
-          # Anything reported that is not explicitly accepted fails the gate.
-          unexpected=$(comm -23 <(printf '%s\n' "$found") <(printf '%s\n' "$allow"))
-          if [ -n "${unexpected}" ]; then
-            printf '::error::govulncheck found advisories not in .github/govulncheck-allow.txt:\n'
-            printf '::error::%s\n' ${unexpected}
-            exit 1
-          fi
-
-          # Accepted entries that no longer fire should be pruned so the
-          # allowlist cannot rot into a blanket suppression.
-          stale=$(comm -13 <(printf '%s\n' "$found") <(printf '%s\n' "$allow"))
-          if [ -n "${stale}" ]; then
-            printf '::warning::allowlist entries no longer reported (remove them): %s\n' ${stale}
-          fi
-
-          printf 'govulncheck gate passed: %s accepted advisory/ies, 0 unexpected\n' \
-            "$(printf '%s\n' "$found" | grep -c . || true)"
+        run: bash .github/scripts/govuln-gate.sh

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run govulncheck
         env:
           GOFLAGS: -mod=vendor
-        run: govulncheck ./...
+        run: bash .github/scripts/govuln-gate.sh
       - name: Install Gitleaks
         run: |
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \


### PR DESCRIPTION
## Problem

The v1.2.6 allowlist landed in `govuln.yml` + the nightly, but two other workflows still ran a bare `govulncheck ./...`:

- `security-scan.yml` (job `security`) — **this is what is currently red on main**
- `deep-qa-block.yml`

Both fail on the same 7 unfixed `lib/pq` advisories tracked in #232.

## Change

Extracts the gate to `.github/scripts/govuln-gate.sh` and points all three symbol-mode call sites at it, so the accept list has exactly one home. The nightly keeps its call-graph/trace mode but reads the same allowlist file.

The gate fails on any advisory **not** in `.github/govulncheck-allow.txt`, and warns when an accepted entry stops firing so the list cannot rot into blanket suppression.

## Verification

- `shellcheck` clean
- real run: exit 0, "7 advisory/ies reported, all accepted, 0 unexpected"
- negative test: removing `GO-2026-6173` from the allowlist → exit 1, naming that ID
- all four workflow YAMLs parse