### PR TITLE
fix(ci): treat an already-published @nself/sdk version as a no-op

### DIFF
--- a/.github/workflows/sdk-ts-sdk-publish.yml
+++ b/.github/workflows/sdk-ts-sdk-publish.yml
@@ -58,6 +58,16 @@ jobs:
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # npm rejects re-publishing an existing version with E403, which turns
+          # any re-run of a partially-failed release into a permanent red check
+          # even though the package is already on the registry. Publishing is
+          # idempotent from our side, so treat "already there" as done.
+          VERSION=$(node -p "require('./sdk/ts-sdk/package.json').version")
+          if npm view "@nself/sdk@${VERSION}" version >/dev/null 2>&1; then
+            echo "@nself/sdk@${VERSION} is already published — nothing to do. No-op success."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "proceed=true" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem

`npm publish` returns **E403 "You cannot publish over the previously published versions: 1.2.6"** when the version already exists.

During the v1.2.6 release, the publish succeeded on the first tag run. The release then failed later in the pipeline (cross-repo lockstep), and every re-run left `Publish @nself/sdk` permanently red — even though `@nself/sdk@1.2.6` was correctly on the registry the whole time.

## Change

The `Check preconditions` step now queries the registry and sets `proceed=false` when the version is already published, alongside the existing package.json / NPM_TOKEN guards. Publishing is idempotent from our side, so "already there" is success, not failure.

This makes a partially-failed release safely re-runnable.

## Verification

Against the live registry:
- `@nself/sdk@1.2.6` → already published → skip
- `@nself/sdk@99.99.99` → absent → publish