### PR TITLE
fix(ssl): install issued certs where nginx actually reads them

### DIFF
--- a/cmd/commands/ssl_setup.go
+++ b/cmd/commands/ssl_setup.go
@@ -147,12 +147,11 @@ func runSSLSetup(cmd *cobra.Command, args []string) error {
 		certArgs = append(certArgs, "--staging")
 	}
 
-	// Certificate path.
-	certArgs = append(certArgs,
-		"--cert-path", fmt.Sprintf("/etc/nginx/ssl/%s/fullchain.pem", domain),
-		"--key-path", fmt.Sprintf("/etc/nginx/ssl/%s/privkey.pem", domain),
-	)
-
+	// No --cert-path/--key-path: certbot ignores them for `certonly` and always
+	// writes to /etc/letsencrypt/live/<domain>/. They previously pointed at
+	// /etc/nginx/ssl/<dotted-domain>/, which is a CONTAINER path being handed to
+	// a certbot process running on the HOST, so it neither placed nor found
+	// anything. The certificate is installed explicitly below instead.
 	ui.Info(fmt.Sprintf("Running: certbot %s", strings.Join(certArgs, " ")))
 
 	certCmd := exec.Command("certbot", certArgs...)
@@ -162,12 +161,15 @@ func runSSLSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("certbot failed: %w", err)
 	}
 
-	// Set cert file permissions.
-	for _, f := range []string{"fullchain.pem", "privkey.pem"} {
-		path := fmt.Sprintf("/etc/nginx/ssl/%s/%s", domain, f)
-		if chErr := os.Chmod(path, 0600); chErr != nil {
-			ui.Warn(fmt.Sprintf("Could not set permissions on %s: %v", path, chErr))
-		}
+	// Install into the tree compose mounts at /etc/nginx/ssl, using the same
+	// certificates/<domain-safe> layout internal/ssl and `ssl add` use.
+	// For a wildcard request the lineage is still named after the bare domain.
+	certDir := filepath.Join(workdir, "ssl", "certificates", domainToFilesafe(domain))
+	if err := os.MkdirAll(certDir, 0750); err != nil {
+		return fmt.Errorf("creating cert directory: %w", err)
+	}
+	if err := installIssuedCert(domain, certDir); err != nil {
+		return fmt.Errorf("installing certificate for %s: %w", domain, err)
 	}
 
 	// Reload nginx.
@@ -225,12 +227,26 @@ func runSSLAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the cert output directory so certbot can write into it.
-	certDir := filepath.Join(workdir, "ssl", domain)
+	//
+	// This must match the layout the nginx container actually sees. Compose
+	// mounts "./ssl:/etc/nginx/ssl:ro" and internal/ssl writes certificates to
+	// ssl/certificates/<dir>, where <dir> is the domain with dots replaced by
+	// dashes. Writing to ssl/<dotted-domain> instead produced a cert on disk
+	// that the generated server block could never reference, so `ssl add`
+	// reported success while nginx kept serving the self-signed wildcard.
+	domainSafe := domainToFilesafe(domain)
+	certDir := filepath.Join(workdir, "ssl", "certificates", domainSafe)
 	if err := os.MkdirAll(certDir, 0750); err != nil {
 		return fmt.Errorf("creating cert directory: %w", err)
 	}
 
 	// Use HTTP-01 challenge for single domain adds (simpler, no DNS provider needed).
+	//
+	// --cert-path/--key-path are deliberately NOT passed: certbot ignores them
+	// for `certonly` (they apply to `install`), which is why earlier versions
+	// appeared to place the certificate where nginx expected it while certbot
+	// actually wrote to /etc/letsencrypt/live/<domain>/ and nothing ever bridged
+	// the two. We copy explicitly below instead.
 	certArgs := []string{
 		"certonly",
 		"--non-interactive",
@@ -239,8 +255,6 @@ func runSSLAdd(cmd *cobra.Command, args []string) error {
 		"--webroot",
 		"--webroot-path", "/var/www/certbot",
 		"-d", domain,
-		"--cert-path", filepath.Join(certDir, "fullchain.pem"),
-		"--key-path", filepath.Join(certDir, "privkey.pem"),
 	}
 
 	ui.Info(fmt.Sprintf("Provisioning certificate for %s...", domain))
@@ -249,6 +263,14 @@ func runSSLAdd(cmd *cobra.Command, args []string) error {
 	certCmd.Stderr = os.Stderr
 	if err := certCmd.Run(); err != nil {
 		return fmt.Errorf("certbot failed: %w", err)
+	}
+
+	// Install the issued certificate into the tree nginx actually reads.
+	// Without this the cert exists only under /etc/letsencrypt and nginx keeps
+	// serving the self-signed wildcard, which is a silent no-op from the
+	// operator's point of view.
+	if err := installIssuedCert(domain, certDir); err != nil {
+		return fmt.Errorf("installing certificate for %s: %w", domain, err)
 	}
 
 	// Write the nginx server block for this custom domain.
@@ -271,8 +293,8 @@ func runSSLAdd(cmd *cobra.Command, args []string) error {
 		ui.Warn(fmt.Sprintf("Nginx reload failed: %v", err))
 	}
 
-	domainSafe := domainToFilesafe(domain)
-	ui.Info(fmt.Sprintf("Custom domain conf written to nginx/conf.d/custom-%s.conf", domainSafe))
+	ui.Info(fmt.Sprintf("Custom domain conf written to %s",
+		filepath.Join(workdir, "nginx", "conf.d", fmt.Sprintf("custom-%s.conf", domainSafe))))
 	ui.Success(fmt.Sprintf("Certificate provisioned for %s.", domain))
 	return nil
 }
@@ -284,10 +306,47 @@ func domainToFilesafe(domain string) string {
 	return r.Replace(domain)
 }
 
+// letsEncryptLiveDir is where certbot stores issued certificates. Declared as a
+// variable so tests can point it at a temp dir.
+var letsEncryptLiveDir = "/etc/letsencrypt/live"
+
+// installIssuedCert copies the certificate certbot just issued for domain into
+// certDir, which is the directory the generated nginx server block references.
+//
+// certbot `certonly` always writes to /etc/letsencrypt/live/<domain>/ and
+// ignores --cert-path/--key-path, so without this step the certificate is
+// issued but invisible to nginx. Files are written 0600 because privkey.pem is
+// a private key; the containing directory is created by the caller.
+//
+// Copies rather than symlinks: /etc/letsencrypt/live entries are themselves
+// symlinks into ../archive, and a bind-mounted symlink chain does not resolve
+// inside the nginx container.
+func installIssuedCert(domain, certDir string) error {
+	liveDir := filepath.Join(letsEncryptLiveDir, domain)
+
+	for _, name := range []string{"fullchain.pem", "privkey.pem"} {
+		src := filepath.Join(liveDir, name)
+		data, err := os.ReadFile(src) //nolint:gosec // path derived from the validated domain
+		if err != nil {
+			return fmt.Errorf("reading %s (did certbot succeed?): %w", src, err)
+		}
+		dst := filepath.Join(certDir, name)
+		if err := os.WriteFile(dst, data, 0600); err != nil {
+			return fmt.Errorf("writing %s: %w", dst, err)
+		}
+	}
+	return nil
+}
+
 // writeCustomDomainConf generates an nginx server block for domain and writes
 // it to nginx/conf.d/custom-{domain-safe}.conf inside workdir.
 // When upstream is non-empty the server block proxy_passes to it; otherwise it
 // returns a 200 informational response until --upstream is configured.
+//
+// server_name keeps the real dotted domain, but ssl_certificate must point at
+// ssl/certificates/{domain-safe} — the layout internal/ssl writes and that
+// compose mounts at /etc/nginx/ssl. Using the dotted domain here produced a
+// path nginx could not resolve even once the conf was in place.
 func writeCustomDomainConf(workdir, domain, upstream string) error {
 	confDir := filepath.Join(workdir, "nginx", "conf.d")
 	if err := os.MkdirAll(confDir, 0750); err != nil {
@@ -328,8 +387,8 @@ server {
     http2 on;
     server_name %s;
 
-    ssl_certificate     /etc/nginx/ssl/%s/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/%s/privkey.pem;
+    ssl_certificate     /etc/nginx/ssl/certificates/%s/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/certificates/%s/privkey.pem;
 
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -338,7 +397,7 @@ server {
 
 %s
 }
-`, domain, domain, domain, domain, locationBlock)
+`, domain, domain, domainSafe, domainSafe, locationBlock)
 
 	if err := os.WriteFile(confPath, []byte(conf), 0644); err != nil {
 		return fmt.Errorf("writing %s: %w", confPath, err)
@@ -346,15 +405,39 @@ server {
 	return nil
 }
 
-// sslRenewalServiceContent is the systemd service unit for certbot renewal.
-const sslRenewalServiceContent = `[Unit]
+// sslRenewalServiceUnit builds the systemd service unit for certbot renewal,
+// rooted at workdir.
+//
+// Two things this has to get right, both of which were previously wrong:
+//
+//   - WorkingDirectory. The reload runs `docker compose exec`, which can only
+//     find the project's compose file from the project root. Without it the
+//     post-hook silently failed and nginx kept the old certificate loaded.
+//
+//   - deploy-hook. `certbot renew` refreshes /etc/letsencrypt/live/<domain>/
+//     but nothing copied the result into ssl/certificates/<domain-safe>/, so a
+//     renewed certificate never reached nginx and the served cert would simply
+//     expire ~90 days after issue. The hook mirrors installIssuedCert: it runs
+//     only for lineages that actually renewed, derives the same dash-safe
+//     directory name, and installs both files 0600.
+func sslRenewalServiceUnit(workdir string) string {
+	deployHook := fmt.Sprintf(
+		`safe=$(basename "$RENEWED_LINEAGE" | tr '.:' '--'); `+
+			`dest=%s/ssl/certificates/$safe; `+
+			`mkdir -p "$dest" && `+
+			`install -m 600 "$RENEWED_LINEAGE/fullchain.pem" "$RENEWED_LINEAGE/privkey.pem" "$dest/"`,
+		workdir)
+
+	return fmt.Sprintf(`[Unit]
 Description=nself SSL certificate renewal
 After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/certbot renew --quiet --post-hook "docker compose exec nginx nginx -s reload"
-`
+WorkingDirectory=%s
+ExecStart=/usr/bin/certbot renew --quiet --deploy-hook "%s" --post-hook "docker compose exec nginx nginx -s reload"
+`, workdir, deployHook)
+}
 
 // sslRenewalTimerContent is the systemd timer unit that triggers renewal twice daily.
 const sslRenewalTimerContent = `[Unit]
@@ -372,19 +455,19 @@ WantedBy=timers.target
 // installSSLRenewalCron installs automatic Let's Encrypt certificate renewal.
 // On Linux with systemd, creates and enables a systemd timer unit.
 // Returns an error with crontab fallback instructions if installation fails.
-func installSSLRenewalCron(_ string) error {
+func installSSLRenewalCron(workdir string) error {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return fmt.Errorf("systemd not available — add to crontab: 30 3 * * * certbot renew --quiet")
 	}
-	return installSSLRenewalSystemd()
+	return installSSLRenewalSystemd(workdir)
 }
 
 // installSSLRenewalSystemd writes and enables the nself-ssl-renew systemd timer.
-func installSSLRenewalSystemd() error {
+func installSSLRenewalSystemd(workdir string) error {
 	const unitDir = "/etc/systemd/system"
 
 	servicePath := filepath.Join(unitDir, "nself-ssl-renew.service")
-	if err := os.WriteFile(servicePath, []byte(sslRenewalServiceContent), 0644); err != nil {
+	if err := os.WriteFile(servicePath, []byte(sslRenewalServiceUnit(workdir)), 0644); err != nil {
 		return fmt.Errorf("writing service unit: %w", err)
 	}
 

--- a/cmd/commands/ssl_setup_paths_test.go
+++ b/cmd/commands/ssl_setup_paths_test.go
@@ -1,0 +1,245 @@
+package commands
+
+// ssl_setup_paths_test.go — Regression tests for `nself ssl add` path agreement.
+//
+// Purpose: Lock in that the host directory certbot writes into and the container
+//          path the generated nginx server block references describe the SAME
+//          certificate. They previously disagreed in two independent ways —
+//          the "certificates/" path segment was missing, and the directory was
+//          named with the dotted domain instead of the dash-safe form — so
+//          `ssl add` reported success while nginx kept serving the self-signed
+//          wildcard.
+// Inputs:  domain strings; a temp dir standing in for the project root.
+// Outputs: assertions on the written conf and the cert directory layout.
+// Constraints: No certbot, docker, or network. Pure filesystem + string checks.
+//
+// Compose mounts "./ssl:/etc/nginx/ssl:ro", so host <workdir>/ssl/X must be
+// visible to nginx as /etc/nginx/ssl/X. Any test here that fails means a cert
+// would be issued but unreadable by nginx.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDomainToFilesafe_MatchesInternalSSLConvention pins the naming used for
+// certificate directories. internal/ssl writes certificates to
+// certificates/<domain with dots replaced by dashes>; ssl add must agree.
+func TestDomainToFilesafe_MatchesInternalSSLConvention(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"staging.nself.org":     "staging-nself-org",
+		"nself.org":             "nself-org",
+		"api.task.nself.org":    "api-task-nself-org",
+		"localhost:8443":        "localhost-8443",
+		"a.b.c.d.example.co.uk": "a-b-c-d-example-co-uk",
+	}
+	for in, want := range cases {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			got := domainToFilesafe(in)
+			if got != want {
+				t.Errorf("domainToFilesafe(%q) = %q, want %q", in, got, want)
+			}
+			if strings.Contains(got, ".") {
+				t.Errorf("domainToFilesafe(%q) = %q still contains a dot", in, got)
+			}
+		})
+	}
+}
+
+// TestWriteCustomDomainConf_CertPathMatchesHostLayout is the core regression
+// test. It asserts the conf points at /etc/nginx/ssl/certificates/<safe>/,
+// which is exactly where the host directory <workdir>/ssl/certificates/<safe>/
+// surfaces inside the nginx container.
+func TestWriteCustomDomainConf_CertPathMatchesHostLayout(t *testing.T) {
+	t.Parallel()
+
+	const domain = "staging.nself.org"
+	safe := domainToFilesafe(domain)
+	workdir := t.TempDir()
+
+	if err := writeCustomDomainConf(workdir, domain, ""); err != nil {
+		t.Fatalf("writeCustomDomainConf: %v", err)
+	}
+
+	confPath := filepath.Join(workdir, "nginx", "conf.d", fmt.Sprintf("custom-%s.conf", safe))
+	raw, err := os.ReadFile(confPath) //nolint:gosec // path built from t.TempDir
+	if err != nil {
+		t.Fatalf("conf not written where ssl add reports it: %v", err)
+	}
+	conf := string(raw)
+
+	wantCert := fmt.Sprintf("/etc/nginx/ssl/certificates/%s/fullchain.pem", safe)
+	wantKey := fmt.Sprintf("/etc/nginx/ssl/certificates/%s/privkey.pem", safe)
+	for _, want := range []string{wantCert, wantKey} {
+		if !strings.Contains(conf, want) {
+			t.Errorf("conf missing %q\n--- conf ---\n%s", want, conf)
+		}
+	}
+
+	// The two historical bugs, asserted directly so a regression names itself.
+	if strings.Contains(conf, "/etc/nginx/ssl/"+domain+"/") {
+		t.Error("conf references the dotted domain directory; must use the dash-safe name")
+	}
+	if strings.Contains(conf, "ssl_certificate     /etc/nginx/ssl/"+safe) {
+		t.Error("conf omits the 'certificates/' path segment")
+	}
+}
+
+// TestWriteCustomDomainConf_ServerNameStaysDotted guards the other direction:
+// only the certificate PATH is dash-safe. server_name must remain the real
+// domain or nginx will never match the request.
+func TestWriteCustomDomainConf_ServerNameStaysDotted(t *testing.T) {
+	t.Parallel()
+
+	const domain = "staging.nself.org"
+	workdir := t.TempDir()
+
+	if err := writeCustomDomainConf(workdir, domain, ""); err != nil {
+		t.Fatalf("writeCustomDomainConf: %v", err)
+	}
+	confPath := filepath.Join(workdir, "nginx", "conf.d",
+		fmt.Sprintf("custom-%s.conf", domainToFilesafe(domain)))
+	raw, err := os.ReadFile(confPath) //nolint:gosec // path built from t.TempDir
+	if err != nil {
+		t.Fatalf("read conf: %v", err)
+	}
+	conf := string(raw)
+
+	if !strings.Contains(conf, "server_name "+domain+";") {
+		t.Errorf("server_name must be the dotted domain %q\n--- conf ---\n%s", domain, conf)
+	}
+	if strings.Contains(conf, "server_name "+domainToFilesafe(domain)+";") {
+		t.Error("server_name was written in dash-safe form; nginx would never match the host")
+	}
+}
+
+// TestWriteCustomDomainConf_UpstreamProxies verifies the --upstream branch still
+// produces a proxy_pass rather than the placeholder response.
+func TestWriteCustomDomainConf_UpstreamProxies(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	if err := writeCustomDomainConf(workdir, "app.example.com", "app:3000"); err != nil {
+		t.Fatalf("writeCustomDomainConf: %v", err)
+	}
+	confPath := filepath.Join(workdir, "nginx", "conf.d", "custom-app-example-com.conf")
+	raw, err := os.ReadFile(confPath) //nolint:gosec // path built from t.TempDir
+	if err != nil {
+		t.Fatalf("read conf: %v", err)
+	}
+	conf := string(raw)
+
+	if !strings.Contains(conf, "proxy_pass http://app:3000;") {
+		t.Errorf("expected proxy_pass to the upstream\n--- conf ---\n%s", conf)
+	}
+	if strings.Contains(conf, "configure --upstream") {
+		t.Error("placeholder response emitted even though an upstream was supplied")
+	}
+}
+
+// TestInstallIssuedCert_CopiesFromLetsEncryptLive covers the step that was
+// missing entirely: certbot `certonly` writes to /etc/letsencrypt/live/<domain>/
+// and ignores --cert-path, so the certificate has to be copied into the tree
+// nginx reads or `ssl add` is a silent no-op.
+func TestInstallIssuedCert_CopiesFromLetsEncryptLive(t *testing.T) {
+	const domain = "staging.nself.org"
+
+	root := t.TempDir()
+	live := filepath.Join(root, "live", domain)
+	if err := os.MkdirAll(live, 0o750); err != nil {
+		t.Fatalf("mkdir live: %v", err)
+	}
+	for name, body := range map[string]string{
+		"fullchain.pem": "FULLCHAIN-CONTENT",
+		"privkey.pem":   "PRIVKEY-CONTENT",
+	} {
+		if err := os.WriteFile(filepath.Join(live, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	orig := letsEncryptLiveDir
+	letsEncryptLiveDir = filepath.Join(root, "live")
+	t.Cleanup(func() { letsEncryptLiveDir = orig })
+
+	certDir := filepath.Join(root, "ssl", "certificates", domainToFilesafe(domain))
+	if err := os.MkdirAll(certDir, 0o750); err != nil {
+		t.Fatalf("mkdir certDir: %v", err)
+	}
+	if err := installIssuedCert(domain, certDir); err != nil {
+		t.Fatalf("installIssuedCert: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"fullchain.pem": "FULLCHAIN-CONTENT",
+		"privkey.pem":   "PRIVKEY-CONTENT",
+	} {
+		p := filepath.Join(certDir, name)
+		got, err := os.ReadFile(p) //nolint:gosec // temp dir
+		if err != nil {
+			t.Fatalf("%s not installed: %v", name, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+		fi, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		// privkey.pem is a private key; 0600 is required, not cosmetic.
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Errorf("%s mode = %o, want 600", name, perm)
+		}
+	}
+}
+
+// TestInstallIssuedCert_MissingLineageErrors ensures a failed/absent issuance is
+// reported instead of leaving nginx pointed at a cert that never arrived.
+func TestInstallIssuedCert_MissingLineageErrors(t *testing.T) {
+	root := t.TempDir()
+	orig := letsEncryptLiveDir
+	letsEncryptLiveDir = filepath.Join(root, "live")
+	t.Cleanup(func() { letsEncryptLiveDir = orig })
+
+	certDir := filepath.Join(root, "dest")
+	if err := os.MkdirAll(certDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := installIssuedCert("absent.example.com", certDir); err == nil {
+		t.Fatal("expected an error when the lineage directory does not exist")
+	}
+}
+
+// TestSSLRenewalServiceUnit_RenewsIntoNginxTree guards the renewal path: without
+// a deploy-hook the served certificate silently expires ~90 days after issue,
+// and without WorkingDirectory the compose reload cannot find the project.
+func TestSSLRenewalServiceUnit_RenewsIntoNginxTree(t *testing.T) {
+	t.Parallel()
+
+	const workdir = "/opt/nself-web/backend"
+	unit := sslRenewalServiceUnit(workdir)
+
+	for _, want := range []string{
+		"WorkingDirectory=" + workdir,
+		"--deploy-hook",
+		workdir + "/ssl/certificates/$safe",
+		"install -m 600",
+		"--post-hook",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("renewal unit missing %q\n--- unit ---\n%s", want, unit)
+		}
+	}
+
+	// The hook must derive the same dash-safe name installIssuedCert uses.
+	if !strings.Contains(unit, `tr '.:' '--'`) {
+		t.Errorf("renewal unit does not dash-normalise the lineage name\n--- unit ---\n%s", unit)
+	}
+}

--- a/cmd/commands/ssl_setup_paths_test.go
+++ b/cmd/commands/ssl_setup_paths_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -194,8 +195,16 @@ func TestInstallIssuedCert_CopiesFromLetsEncryptLive(t *testing.T) {
 			t.Fatalf("stat %s: %v", name, err)
 		}
 		// privkey.pem is a private key; 0600 is required, not cosmetic.
-		if perm := fi.Mode().Perm(); perm != 0o600 {
-			t.Errorf("%s mode = %o, want 600", name, perm)
+		//
+		// Windows has no Unix permission bits: Go's os.WriteFile maps the mode
+		// onto a read-only flag only, so a file written 0600 stats back as 0666
+		// there. The production write in ssl_setup.go is correct and unchanged;
+		// only the assertion is unportable, so it stays strict everywhere the
+		// bits actually exist.
+		if runtime.GOOS != "windows" {
+			if perm := fi.Mode().Perm(); perm != 0o600 {
+				t.Errorf("%s mode = %o, want 600", name, perm)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes the `nself ssl add` report from the inbox (2026-08-17, staging.nself.org / CLI v1.2.5).

## Symptom

`ssl add` prints success, the Let's Encrypt certificate **is** genuinely issued, and the site still serves the self-signed `*.nself.org` wildcard. A silent no-op.

## Three independent defects on the certbot → nginx path

**1. The certificate was never installed.**
Both `ssl add` and `ssl setup` passed `--cert-path`/`--key-path` to `certbot certonly`. certbot **ignores** those for `certonly` (they apply to `install`) and always writes to `/etc/letsencrypt/live/<domain>/`. Nothing copied from there into the ssl tree. Added `installIssuedCert`, writing both files `0600`.

It copies rather than symlinks: `live/` entries are themselves symlinks into `../archive`, and that chain does not resolve inside the nginx container.

**2. The host and container paths disagreed — in two ways at once.**

| | Was | Now |
|---|---|---|
| Cert dir | `/etc/nginx/ssl/staging.nself.org/` | `/etc/nginx/ssl/certificates/staging-nself-org/` |

Compose mounts `./ssl:/etc/nginx/ssl:ro` and `internal/ssl` writes `certificates/<dash-name>`. The old path was missing the `certificates/` segment *and* used the dotted domain. `server_name` deliberately stays dotted — only the cert path is dash-safe.

**3. Renewal never reached nginx.**
The systemd unit had no `--deploy-hook`, so a renewed lineage stayed under `/etc/letsencrypt` and the served certificate would simply expire ~90 days after issue. It also ran `docker compose exec` with **no `WorkingDirectory`**, so the reload could not locate the project. Both fixed.

## On the original report

The report's first two root causes (`ADMIN_EMAIL` read from the process env; the custom conf never written) were **retracted by the reporter** and are not what this fixes — the conf *is* written, just into a directory whose cert path could never resolve. The symptoms were real; the diagnosis was not.

## Verification

7 new tests covering path agreement, the install step, `0600` on the private key, the missing-lineage error path, and the renewal unit. **Confirmed they fail against the old code** ("conf references the dotted domain directory") and pass against the new.

Full suite: **98 pass / 0 fail**.

## Not covered here

The report's third point — a bare host colliding with the generated `default_server` block — is a separate design question about updating the existing vhost rather than appending a competing `server` block. Not folded into this fix.