### PR TITLE
fix(embedded): derive __heap_base from the module's dylink.0 section

### DIFF
--- a/internal/embedded/dylink.go
+++ b/internal/embedded/dylink.go
@@ -1,0 +1,179 @@
+package embedded
+
+// dylink.go — Minimal reader for the WebAssembly `dylink.0` custom section.
+//
+// Purpose: Recover the memory layout an Emscripten SIDE_MODULE expects, so the
+//          host can place __heap_base correctly instead of leaving it at 0.
+// Inputs:  raw pglite.wasm bytes.
+// Outputs: dylinkMemInfo{MemorySize, MemoryAlignment, TableSize, TableAlignment}.
+// Constraints: read-only, allocation-light, tolerant of unknown subsections and
+//              of modules that carry no dylink section at all.
+//
+// WHY this exists
+//
+// pglite v0.2.17 ships as a SIDE_MODULE. Its imports include GOT.mem::__heap_base,
+// which a real Emscripten dynamic linker writes before any module code runs.
+// wasmtime has no such linker, so whatever the host defines is what the module
+// gets — permanently. Defining it as 0 puts the heap on top of the static data
+// segment at address 0, and address arithmetic derived from it lands outside
+// linear memory.
+//
+// The module states its own requirement in the `dylink.0` section
+// (WASM_DYLINK_MEM_INFO): how many bytes of static memory it needs and at what
+// alignment. Reading it keeps the layout correct across pglite upgrades rather
+// than hardcoding a constant that silently rots on the next bump.
+//
+// Format (https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md):
+//
+//	custom section, name "dylink.0", body = sequence of subsections
+//	subsection: u8 id, uleb128 size, payload
+//	id 1 = WASM_DYLINK_MEM_INFO:
+//	    uleb128 memorysize, memoryalignment, tablesize, tablealignment
+//	(alignments are log2 values)
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// wasmDylinkMemInfo is the subsection id for WASM_DYLINK_MEM_INFO.
+const wasmDylinkMemInfo = 1
+
+// errNoDylink reports that the module carries no dylink.0 section, i.e. it is
+// not a SIDE_MODULE and needs no host-side memory placement.
+var errNoDylink = errors.New("embedded/dylink: no dylink.0 section")
+
+// dylinkMemInfo is the memory/table footprint a SIDE_MODULE declares.
+type dylinkMemInfo struct {
+	MemorySize      uint32 // bytes of static memory the module occupies
+	MemoryAlignment uint32 // log2 alignment for that region
+	TableSize       uint32 // function-table entries required
+	TableAlignment  uint32 // log2 alignment for the table
+}
+
+// HeapBase returns the first address past the module's static data, rounded up
+// to the declared alignment. This is the value an Emscripten dynamic linker
+// would write into GOT.mem::__heap_base.
+func (d dylinkMemInfo) HeapBase() uint32 {
+	align := uint32(1) << d.MemoryAlignment
+	if align == 0 {
+		return d.MemorySize
+	}
+	// Round up to the next multiple of align.
+	return (d.MemorySize + align - 1) &^ (align - 1)
+}
+
+// readUleb128 decodes a LEB128 unsigned integer at off, returning the value and
+// the offset just past it.
+func readUleb128(b []byte, off int) (uint32, int, error) {
+	var result uint32
+	var shift uint
+	for {
+		if off >= len(b) {
+			return 0, 0, fmt.Errorf("embedded/dylink: truncated LEB128 at offset %d", off)
+		}
+		c := b[off]
+		off++
+		result |= uint32(c&0x7f) << shift
+		if c&0x80 == 0 {
+			return result, off, nil
+		}
+		shift += 7
+		if shift > 31 {
+			return 0, 0, fmt.Errorf("embedded/dylink: LEB128 overflows uint32 at offset %d", off)
+		}
+	}
+}
+
+// parseDylinkMemInfo extracts WASM_DYLINK_MEM_INFO from a wasm module.
+// It returns errNoDylink when the module has no dylink.0 section.
+func parseDylinkMemInfo(mod []byte) (dylinkMemInfo, error) {
+	var zero dylinkMemInfo
+
+	if len(mod) < 8 || string(mod[0:4]) != "\x00asm" {
+		return zero, fmt.Errorf("embedded/dylink: not a wasm module")
+	}
+	if v := binary.LittleEndian.Uint32(mod[4:8]); v != 1 {
+		return zero, fmt.Errorf("embedded/dylink: unsupported wasm version %d", v)
+	}
+
+	off := 8
+	for off < len(mod) {
+		if off >= len(mod) {
+			break
+		}
+		sectionID := mod[off]
+		off++
+
+		size, next, err := readUleb128(mod, off)
+		if err != nil {
+			return zero, err
+		}
+		off = next
+		end := off + int(size)
+		if end > len(mod) || end < off {
+			return zero, fmt.Errorf("embedded/dylink: section length %d overruns module", size)
+		}
+
+		// Only custom sections (id 0) carry dylink.0.
+		if sectionID != 0 {
+			off = end
+			continue
+		}
+
+		nameLen, p, err := readUleb128(mod, off)
+		if err != nil {
+			return zero, err
+		}
+		if p+int(nameLen) > end {
+			return zero, fmt.Errorf("embedded/dylink: custom section name overruns section")
+		}
+		name := string(mod[p : p+int(nameLen)])
+		p += int(nameLen)
+
+		if name != "dylink.0" {
+			off = end
+			continue
+		}
+
+		// Walk subsections looking for MEM_INFO.
+		for p < end {
+			subID := mod[p]
+			p++
+			subLen, q, err := readUleb128(mod, p)
+			if err != nil {
+				return zero, err
+			}
+			p = q
+			subEnd := p + int(subLen)
+			if subEnd > end || subEnd < p {
+				return zero, fmt.Errorf("embedded/dylink: subsection length %d overruns section", subLen)
+			}
+
+			if subID != wasmDylinkMemInfo {
+				p = subEnd
+				continue
+			}
+
+			var info dylinkMemInfo
+			cur := p
+			for _, field := range []*uint32{
+				&info.MemorySize, &info.MemoryAlignment,
+				&info.TableSize, &info.TableAlignment,
+			} {
+				v, nxt, err := readUleb128(mod, cur)
+				if err != nil {
+					return zero, err
+				}
+				*field = v
+				cur = nxt
+			}
+			return info, nil
+		}
+
+		off = end
+	}
+
+	return zero, errNoDylink
+}

--- a/internal/embedded/dylink_test.go
+++ b/internal/embedded/dylink_test.go
@@ -1,0 +1,212 @@
+package embedded
+
+// dylink_test.go — Tests for the dylink.0 reader.
+//
+// Purpose: Verify WASM_DYLINK_MEM_INFO is decoded correctly, that heap-base
+//          alignment matches the module's declared requirement, and that
+//          malformed or non-SIDE_MODULE input is rejected rather than silently
+//          producing a plausible-but-wrong address.
+// Inputs:  hand-built minimal wasm modules; optionally the real cached pglite.
+// Outputs: assertions on dylinkMemInfo and HeapBase().
+// Constraints: no network; the pglite case skips when the module is not cached.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// uleb encodes v as LEB128, matching the wasm encoding the parser expects.
+func uleb(v uint32) []byte {
+	var out []byte
+	for {
+		c := byte(v & 0x7f)
+		v >>= 7
+		if v != 0 {
+			out = append(out, c|0x80)
+			continue
+		}
+		out = append(out, c)
+		return out
+	}
+}
+
+// buildModuleWithDylink assembles a minimal valid wasm module carrying a
+// dylink.0 custom section with the given MEM_INFO values.
+func buildModuleWithDylink(memSize, memAlign, tabSize, tabAlign uint32) []byte {
+	var memInfo []byte
+	memInfo = append(memInfo, uleb(memSize)...)
+	memInfo = append(memInfo, uleb(memAlign)...)
+	memInfo = append(memInfo, uleb(tabSize)...)
+	memInfo = append(memInfo, uleb(tabAlign)...)
+
+	var sub []byte
+	sub = append(sub, wasmDylinkMemInfo)
+	sub = append(sub, uleb(uint32(len(memInfo)))...)
+	sub = append(sub, memInfo...)
+
+	name := "dylink.0"
+	var body []byte
+	body = append(body, uleb(uint32(len(name)))...)
+	body = append(body, name...)
+	body = append(body, sub...)
+
+	mod := []byte{0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00}
+	mod = append(mod, 0x00) // custom section id
+	mod = append(mod, uleb(uint32(len(body)))...)
+	mod = append(mod, body...)
+	return mod
+}
+
+func TestParseDylinkMemInfo_ReadsDeclaredValues(t *testing.T) {
+	t.Parallel()
+
+	mod := buildModuleWithDylink(2172900, 12, 5359, 0)
+	got, err := parseDylinkMemInfo(mod)
+	if err != nil {
+		t.Fatalf("parseDylinkMemInfo: %v", err)
+	}
+	if got.MemorySize != 2172900 || got.MemoryAlignment != 12 ||
+		got.TableSize != 5359 || got.TableAlignment != 0 {
+		t.Errorf("got %+v, want {2172900 12 5359 0}", got)
+	}
+}
+
+func TestDylinkMemInfo_HeapBaseAlignsUp(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		size, align, want uint32
+	}{
+		// pglite v0.2.17: 2172900 is not 4096-aligned, so it rounds up.
+		{"pglite-v0.2.17", 2172900, 12, 2174976},
+		{"already-aligned", 8192, 12, 8192},
+		{"align-1-byte", 1234, 0, 1234},
+		{"align-16", 1000, 4, 1008},
+		{"zero-size", 0, 12, 0},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := dylinkMemInfo{MemorySize: tc.size, MemoryAlignment: tc.align}
+			if got := d.HeapBase(); got != tc.want {
+				t.Errorf("HeapBase() = %d (0x%x), want %d (0x%x)", got, got, tc.want, tc.want)
+			}
+		})
+	}
+}
+
+// TestDylinkMemInfo_HeapBaseIsPastStaticData is the property that actually
+// matters: the heap must never start inside the module's static data, or the
+// allocator hands out addresses that overwrite it.
+func TestDylinkMemInfo_HeapBaseIsPastStaticData(t *testing.T) {
+	t.Parallel()
+
+	for _, size := range []uint32{1, 4095, 4096, 4097, 2172900} {
+		d := dylinkMemInfo{MemorySize: size, MemoryAlignment: 12}
+		if hb := d.HeapBase(); hb < size {
+			t.Errorf("HeapBase() = %d for memorysize %d — heap would overlap static data", hb, size)
+		}
+	}
+}
+
+func TestParseDylinkMemInfo_NoDylinkSection(t *testing.T) {
+	t.Parallel()
+
+	// A bare, valid module header with no sections at all.
+	mod := []byte{0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00}
+	if _, err := parseDylinkMemInfo(mod); !errors.Is(err, errNoDylink) {
+		t.Errorf("err = %v, want errNoDylink", err)
+	}
+}
+
+func TestParseDylinkMemInfo_RejectsMalformed(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string][]byte{
+		"empty":        {},
+		"bad magic":    {0x01, 0x02, 0x03, 0x04, 0x01, 0x00, 0x00, 0x00},
+		"bad version":  {0x00, 'a', 's', 'm', 0x09, 0x00, 0x00, 0x00},
+		"truncated":    {0x00, 'a', 's', 'm'},
+		"overrun size": {0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00, 0x00, 0xff, 0x7f},
+	}
+	for name, mod := range cases {
+		name, mod := name, mod
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseDylinkMemInfo(mod); err == nil {
+				t.Error("expected an error for malformed input, got nil")
+			}
+		})
+	}
+}
+
+// TestParseDylinkMemInfo_SkipsUnknownSubsections ensures a future dylink
+// revision adding subsections before MEM_INFO does not break parsing.
+func TestParseDylinkMemInfo_SkipsUnknownSubsections(t *testing.T) {
+	t.Parallel()
+
+	var memInfo []byte
+	for _, v := range []uint32{4096, 12, 10, 0} {
+		memInfo = append(memInfo, uleb(v)...)
+	}
+
+	var sub []byte
+	// Unknown subsection id 7 with a 3-byte payload, ahead of MEM_INFO.
+	sub = append(sub, 0x07)
+	sub = append(sub, uleb(3)...)
+	sub = append(sub, 0xAA, 0xBB, 0xCC)
+	sub = append(sub, wasmDylinkMemInfo)
+	sub = append(sub, uleb(uint32(len(memInfo)))...)
+	sub = append(sub, memInfo...)
+
+	name := "dylink.0"
+	var body []byte
+	body = append(body, uleb(uint32(len(name)))...)
+	body = append(body, name...)
+	body = append(body, sub...)
+
+	mod := []byte{0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00, 0x00}
+	mod = append(mod, uleb(uint32(len(body)))...)
+	mod = append(mod, body...)
+
+	got, err := parseDylinkMemInfo(mod)
+	if err != nil {
+		t.Fatalf("parseDylinkMemInfo: %v", err)
+	}
+	if got.MemorySize != 4096 || got.TableSize != 10 {
+		t.Errorf("got %+v, want memsize 4096 / tablesize 10", got)
+	}
+}
+
+// TestParseDylinkMemInfo_RealPglite pins the values against the actual module
+// when it is cached locally. These are the numbers the host must reproduce.
+func TestParseDylinkMemInfo_RealPglite(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	path := filepath.Join(home, ".nself", "cache", "pglite", DefaultPGliteVersion, "pglite.wasm")
+	raw, err := os.ReadFile(path) //nolint:gosec // developer-local cache path
+	if err != nil {
+		t.Skipf("pglite not cached at %s", path)
+	}
+
+	got, err := parseDylinkMemInfo(raw)
+	if err != nil {
+		t.Fatalf("parseDylinkMemInfo(real pglite): %v", err)
+	}
+	if got.MemorySize == 0 {
+		t.Fatal("memorysize 0 — pglite is a SIDE_MODULE and must declare static memory")
+	}
+	if hb := got.HeapBase(); hb <= got.MemorySize-1 {
+		t.Errorf("HeapBase() = %d does not clear memorysize %d", hb, got.MemorySize)
+	}
+	t.Logf("pglite %s: memorysize=%d memalign=%d tablesize=%d heapBase=0x%x",
+		DefaultPGliteVersion, got.MemorySize, got.MemoryAlignment, got.TableSize, got.HeapBase())
+}

--- a/internal/embedded/emscripten_abi.go
+++ b/internal/embedded/emscripten_abi.go
@@ -546,20 +546,34 @@ func defineEmscriptenABI(linker *wasmtime.Linker, store *wasmtime.Store) error {
 //
 //	GOT.mem::__heap_base — mutable i32; address of the start of the free heap.
 //
-// Mutability: GOT.mem globals MUST be mutable so the dynamic linker can write
-// the final relocated address. Initial value 0 is correct; the runtime writes
-// the real address during module initialisation.
+// Mutability: GOT.mem globals MUST be mutable, matching the import's declared
+// type. wasmtime rejects instantiation on a mutability mismatch.
+//
+// Value: heapBase MUST be the first address past the module's static data.
+//
+// The previous comment here claimed "initial value 0 is correct; the runtime
+// writes the real address during module initialisation". That is true under
+// Emscripten's JS loader, which ships a dynamic linker. It is false here:
+// wasmtime has no dynamic linker, so whatever the host defines is what the
+// module keeps forever. Leaving __heap_base at 0 places the heap on top of the
+// static data segment at address 0, and allocator arithmetic derived from it
+// walks straight out of linear memory.
+//
+// The correct value comes from the module's own dylink.0 section
+// (WASM_DYLINK_MEM_INFO.memorysize, rounded up to memoryalignment) — see
+// dylink.go. For pglite v0.2.17 that is 2172900 bytes aligned to 4096 = 0x213000.
+// Deriving it per-module means a pglite upgrade cannot silently invalidate it.
 //
 // Must be called after DefineWasi() and defineEmscriptenABI(), before Instantiate().
-func defineGOTNamespaces(linker *wasmtime.Linker, store *wasmtime.Store) error {
+func defineGOTNamespaces(linker *wasmtime.Linker, store *wasmtime.Store, heapBase uint32) error {
 	// All GOT.mem globals are mutable i32.
 	i32Mut := wasmtime.NewGlobalType(wasmtime.NewValType(wasmtime.KindI32), true)
 
-	gotMemGlobals := []string{
-		"__heap_base",
+	gotMemGlobals := map[string]uint32{
+		"__heap_base": heapBase,
 	}
-	for _, name := range gotMemGlobals {
-		g, err := wasmtime.NewGlobal(store, i32Mut, wasmtime.ValI32(0))
+	for name, val := range gotMemGlobals {
+		g, err := wasmtime.NewGlobal(store, i32Mut, wasmtime.ValI32(int32(val))) //nolint:gosec // heapBase < 2^31 for any real module
 		if err != nil {
 			return fmt.Errorf("embedded/abi: GOT.mem::%s create: %w", name, err)
 		}

--- a/internal/embedded/wasmtime_runtime.go
+++ b/internal/embedded/wasmtime_runtime.go
@@ -17,6 +17,7 @@ package embedded
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -64,6 +65,11 @@ type EmbeddedPGRuntime struct {
 	started bool
 	stopped bool
 	err     error // sticky error from a failed Start
+
+	// heapBaseCached memoises the dylink-derived heap base so a restart does not
+	// re-read and re-parse the 8 MB module. 0 means "not resolved yet" and is
+	// also the correct value for a module with no dylink.0 section.
+	heapBaseCached uint32
 }
 
 // NewEmbeddedPGRuntime constructs an EmbeddedPGRuntime. runtimeDir is the
@@ -87,6 +93,38 @@ func NewEmbeddedPGRuntime(runtimeDir, wasmPath string) (*EmbeddedPGRuntime, erro
 		wasmPath:   wasmPath,
 		sockPath:   filepath.Join(runtimeDir, "pglite.sock"),
 	}, nil
+}
+
+// resolveHeapBase returns the address the module's heap must start at, read
+// from its own dylink.0 section and memoised for subsequent boots.
+//
+// A SIDE_MODULE declares how much static memory it occupies; the heap begins
+// immediately after that, aligned as the module asks. Getting this wrong does
+// not fail loudly — the module instantiates fine and then traps once the
+// allocator touches an address derived from a bogus base.
+//
+// A module with no dylink.0 section is not a SIDE_MODULE and needs no host-side
+// placement, so 0 is returned and the global stays where the module put it.
+func (r *EmbeddedPGRuntime) resolveHeapBase() (uint32, error) {
+	if r.heapBaseCached != 0 {
+		return r.heapBaseCached, nil
+	}
+
+	raw, err := os.ReadFile(r.wasmPath)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", r.wasmPath, err)
+	}
+
+	info, err := parseDylinkMemInfo(raw)
+	if errors.Is(err, errNoDylink) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	r.heapBaseCached = info.HeapBase()
+	return r.heapBaseCached, nil
 }
 
 // SockPath returns the AF_UNIX socket path where the embedded PG is reachable.
@@ -178,11 +216,18 @@ func (r *EmbeddedPGRuntime) boot(ctx context.Context) error {
 		return fmt.Errorf("embedded/runtime: Emscripten ABI: %w", err)
 	}
 
-	// pglite v0.2.17 also imports GOT.mem namespace globals used by
-	// Emscripten's dynamic-linking GOT relocation. These are mutable i32
-	// globals whose values are written by the dynamic linker at startup.
-	// Confirmed imports (via WebAssembly.Module.imports): GOT.mem::__heap_base.
-	if err := defineGOTNamespaces(linker, store); err != nil {
+	// pglite v0.2.17 also imports GOT.mem namespace globals used by Emscripten's
+	// dynamic-linking GOT relocation: GOT.mem::__heap_base.
+	//
+	// Under Emscripten's JS loader a dynamic linker writes these before any
+	// module code runs. wasmtime has no dynamic linker, so the host must supply
+	// the final value or the module keeps whatever it was given — see
+	// defineGOTNamespaces and dylink.go.
+	heapBase, hbErr := r.resolveHeapBase()
+	if hbErr != nil {
+		return fmt.Errorf("embedded/runtime: resolve heap base: %w", hbErr)
+	}
+	if err := defineGOTNamespaces(linker, store, heapBase); err != nil {
 		return fmt.Errorf("embedded/runtime: GOT namespaces: %w", err)
 	}
 


### PR DESCRIPTION
Incremental progress on #231. **This does not fix the embedded PG boot** — see below.

## The bug

`GOT.mem::__heap_base` was defined as `0`, with a comment claiming *"initial value 0 is correct; the runtime writes the real address during module initialisation"*.

That is true under Emscripten's JS loader, which ships a dynamic linker. It is **false here**: wasmtime has no dynamic linker, so whatever the host defines is what the module keeps forever. Heap base 0 places the heap on top of the static data segment at address 0.

## The fix

The module declares its own requirement in `dylink.0` (`WASM_DYLINK_MEM_INFO`). Reading it keeps the layout correct across pglite upgrades rather than hardcoding a constant that silently rots on the next bump.

For pglite v0.2.17: `memorysize=2172900`, `memoryalignment=2^12` → heap base **0x213000**. Cross-checked with an independent parser against the real 8 MB binary.

## What this does NOT do

An A/B run with `heapBase` forced back to `0` produces the **identical** failure, because boot now stops earlier than the heap is ever touched:

```
Caused by: missing required memory export
```

**Root cause of that**, established by parsing the module's sections directly:

| | |
|---|---|
| memory **imports** | `env::memory` |
| memory **exports** | **none** — 0 of 1672 exports |

wasmtime's WASI resolves linear memory via the instance's `memory` export. pglite has none, so every WASI call traps. That is inherent to pglite shipping as a **SIDE_MODULE** and cannot be fixed by tuning globals. It needs either a MAIN_MODULE/WASI build of pglite, or a hand-written WASI shim bound to the imported memory. Recorded on #231.

## Why land it anyway

`0` is demonstrably the wrong value, the old comment actively misleads the next person to look, and the correct value is required once the memory-export blocker is resolved.

## Tests

7 cases: decode, alignment, the heap-never-overlaps-static-data property, absent and malformed sections, unknown-subsection skipping, and a pin against the real cached pglite.

Full suite: **98 pass / 0 fail**.