### PR TITLE
fix(install): stop SDK releases hijacking the installer's latest-version lookup

### DIFF
--- a/.github/install.sh
+++ b/.github/install.sh
@@ -56,11 +56,33 @@ get_latest_version() {
     return
   fi
 
+  # Take the newest release that actually ships a CLI tarball, not simply
+  # releases/latest.
+  #
+  # The @nself/sdk package publishes its own releases into this same repo, on
+  # the same tag. When one of those is newest it takes the "Latest" slot even
+  # though it carries no CLI binaries, and releases/latest then points at a tag
+  # whose nself-<ver>-<os>-<arch> assets do not exist — every install 404s.
+  # That broke installs on 2026-08-18 with v1.2.7. The SDK workflow now passes
+  # --latest=false, and this check means a future mistake degrades to picking
+  # the previous good release instead of failing outright.
   local latest
-  latest=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
-    | grep '"tag_name"' \
-    | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \
-    | sed 's/^v//')
+  latest=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20" 2>/dev/null \
+    | tr ',{' '\n\n' \
+    | grep -E '"(tag_name|name)": *"' \
+    | sed -E 's/.*: *"([^"]*)".*/\1/' \
+    | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+|nself-[0-9].*\.tar\.gz)$' \
+    | awk '/^nself-.*linux-amd64\.tar\.gz$/ {if (tag != "") {print tag; exit}} /^v?[0-9]+\.[0-9]+\.[0-9]+$/ {tag=$0}' \
+    | sed 's/^v//' | head -1)
+
+  # Fall back to releases/latest if the asset scan found nothing (e.g. the API
+  # shape changed); better to try than to hard-fail here.
+  if [ -z "$latest" ]; then
+    latest=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
+      | grep '"tag_name"' \
+      | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \
+      | sed 's/^v//')
+  fi
 
   if [ -z "$latest" ]; then
     error "Could not determine latest version. Set NSELF_VERSION=x.y.z or check https://github.com/${REPO}/releases"

--- a/.github/workflows/sdk-ts-sdk-publish.yml
+++ b/.github/workflows/sdk-ts-sdk-publish.yml
@@ -99,9 +99,16 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION=$(node -p "require('./sdk/ts-sdk/package.json').version")
+          # --latest=false is load-bearing. The SDK publishes into nself-org/cli,
+          # so without it GitHub hands the "Latest" slot to this release simply
+          # because it is newest. install.nself.org resolves releases/latest and
+          # would then download nself-<ver>-linux-amd64.tar.gz from an SDK
+          # release that ships no CLI binaries — a hard 404 for every new user.
+          # That is exactly what happened with v1.2.7 on 2026-08-18.
           gh release create "$TAG" \
             --title "@nself/sdk v${VERSION}" \
             --notes "Published @nself/sdk v${VERSION} to npm." \
             --draft=false \
             --prerelease=false \
+            --latest=false \
             || true


### PR DESCRIPTION
**`curl -fsSL https://install.nself.org | bash` was broken in production today.** Found while chasing an unrelated admin Docker 404.

## What happened

`@nself/sdk` publishes its own GitHub release **into `nself-org/cli`, on the same tag as the CLI**. `gh release create` claims the "Latest" slot by default, so when the SDK released `v1.2.7` at 21:51 it became Latest — with **zero assets**.

`install.sh` resolves `releases/latest`, then downloads `nself-<ver>-<os>-<arch>.tar.gz` from that tag. Result:

```
installer resolves -> v1.2.7
downloads          -> .../v1.2.7/nself-1.2.7-linux-amd64.tar.gz
                   -> HTTP 404
```

Every new install failed. `v1.2.5` carries the same `@nself/sdk` title, so this was set to recur on every SDK publish.

## Fixes

**1. The SDK release no longer claims Latest** (`--latest=false`). It ships no CLI binaries; it should never own that slot.

**2. `install.sh` no longer trusts `releases/latest` blindly.** It walks the release list and takes the newest release that actually carries a `nself-*-linux-amd64.tar.gz` asset, falling back to the old lookup if the scan finds nothing. A future mistake now degrades to the previous good release rather than a hard 404.

## Verified against the live API, in the broken state

With `v1.2.7` still the newest tag:

```
resolved: 1.2.6
download -> HTTP 200
```

It correctly skipped the newer, assetless tag.

## Already done outside this PR

`v1.2.6` was marked Latest immediately so installs work **now**, without waiting for this to merge. This PR is what stops it happening again.

## Related

The same missing-release problem broke admin's Docker builds (`ARG NSELF_VERSION=1.2.7` with no published tarball). Fixed separately in nself-org/admin.