### PR TITLE
fix(plugin): registry cache dropped 21 fields, including the signature

### DIFF
--- a/.github/wiki/cmd-sentry-server.md
+++ b/.github/wiki/cmd-sentry-server.md
@@ -8,7 +8,7 @@ surface, not part of the self-hosted backend lifecycle the core covers.
 ## Install
 
 ```bash
-nself install sentry
+nself install sentry-cli
 ```
 
 One plugin provides both `nself sentry` and `nself sentry-server`. Once

--- a/.github/wiki/cmd-sentry.md
+++ b/.github/wiki/cmd-sentry.md
@@ -8,7 +8,7 @@ surface, not part of the self-hosted backend lifecycle the core covers.
 ## Install
 
 ```bash
-nself install sentry
+nself install sentry-cli
 ```
 
 One plugin provides both `nself sentry` and `nself sentry-server`. Once

--- a/internal/deprecation/registry.yaml
+++ b/internal/deprecation/registry.yaml
@@ -446,14 +446,14 @@ items:
   - name: "nself sentry"
     type: command
     since: "v1.3.0"
-    replacement: "nself install sentry"
-    docs_url: "https://nself.org/docs/plugins/sentry"
+    replacement: "nself install sentry-cli"
+    docs_url: "https://nself.org/docs/plugins/sentry-cli"
     phase: 1
   - name: "nself sentry-server"
     type: command
     since: "v1.3.0"
-    replacement: "nself install sentry"
-    docs_url: "https://nself.org/docs/plugins/sentry"
+    replacement: "nself install sentry-cli"
+    docs_url: "https://nself.org/docs/plugins/sentry-cli"
     phase: 1
   - name: "nself ai"
     type: command

--- a/internal/plugin/registry_cache.go
+++ b/internal/plugin/registry_cache.go
@@ -127,10 +127,38 @@ func (r Registry) MarshalJSON() ([]byte, error) {
 			// both empty — so linkCLIBinary saw a plugin that declared no
 			// command and did nothing. Language and Runtime were being lost
 			// the same way, which is the tell I should have followed sooner.
-			Language:   p.Language,
-			Runtime:    p.Runtime,
-			PluginType: p.PluginType,
-			BinaryName: p.BinaryName,
+			Language:    p.Language,
+			Runtime:     p.Runtime,
+			PluginType:  p.PluginType,
+			BinaryName:  p.BinaryName,
+			CLICommands: p.CLICommands,
+
+			// Signature material. Its absence here meant a warm cache handed
+			// verifyPluginSignature three empty strings, which takes the
+			// "unsigned" branch — and because publishStatus was empty too, that
+			// branch returns nil instead of refusing a stable plugin. Signature
+			// verification was being skipped on every cache-warm install.
+			PublishStatus:   p.PublishStatus,
+			AuthorPublicKey: p.AuthorPublicKey,
+			Signature:       p.Signature,
+
+			Author:               p.Author,
+			Homepage:             p.Homepage,
+			IsCommercial:         p.IsCommercial,
+			RequiredEntitlements: p.RequiredEntitlements,
+			MinNselfVersion:      p.MinNselfVersion,
+			MaxNselfVersion:      p.MaxNselfVersion,
+			MinNodeVersion:       p.MinNodeVersion,
+			ArchSupport:          p.ArchSupport,
+			EntryPoint:           p.EntryPoint,
+			CLI:                  p.CLI,
+			HealthEndpoint:       p.HealthEndpoint,
+			PackageManager:       p.PackageManager,
+			Framework:            p.Framework,
+			Views:                p.Views,
+			MultiApp:             p.MultiApp,
+			Deprecation:          p.Deprecation,
+			GraphQL:              p.GraphQL,
 		})
 	}
 	return json.Marshal(envelope{

--- a/internal/plugin/registry_cache_roundtrip_test.go
+++ b/internal/plugin/registry_cache_roundtrip_test.go
@@ -131,3 +131,54 @@ func TestRegistryCacheRoundTripIsDrivenByTheManifest(t *testing.T) {
 		t.Errorf("Tables not preserved: %v", got.Tables)
 	}
 }
+
+// TestCacheKeepsSignatureMaterial pins the most consequential instance of the
+// dropped-field bug.
+//
+// Registry.MarshalJSON did not copy AuthorPublicKey, Signature or
+// PublishStatus. The registry cache is read on every run after the first, so
+// from the second install onward verifyPluginSignature received three empty
+// strings. That takes the "no signature supplied" branch, which refuses only
+// when publishStatus is "stable" — and publishStatus was empty too, so it
+// returned nil.
+//
+// The result: a signed, stable plugin installed without its signature being
+// checked, on every cache-warm run, with nothing printed.
+func TestCacheKeepsSignatureMaterial(t *testing.T) {
+	original := &Registry{Plugins: []PluginManifest{{
+		Name:            "signed-plugin",
+		Version:         "1.0.0",
+		PublishStatus:   "stable",
+		AuthorPublicKey: "aa" + "bb" + "cc",
+		Signature:       "dd" + "ee" + "ff",
+	}}}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	reloaded, err := parseRegistryJSON(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, ok := findPlugin(reloaded, "signed-plugin")
+	if !ok {
+		t.Fatal("plugin vanished from the cache round-trip")
+	}
+
+	if got.AuthorPublicKey == "" || got.Signature == "" {
+		t.Errorf("signature material lost: key=%q sig=%q — verification would be skipped",
+			got.AuthorPublicKey, got.Signature)
+	}
+	if got.PublishStatus != "stable" {
+		t.Errorf("publishStatus = %q, want \"stable\" — an empty value turns a "+
+			"refused unsigned install into an allowed one", got.PublishStatus)
+	}
+
+	// The behaviour that matters, asserted directly: a stable plugin arriving
+	// with no signature must be refused, and this is the path the cache used to
+	// send every stable plugin down.
+	if err := verifyPluginSignature("/nonexistent", "", "", got.PublishStatus); err == nil {
+		t.Error("a stable plugin with no signature was accepted")
+	}
+}

--- a/internal/plugin/registry_field_coverage_test.go
+++ b/internal/plugin/registry_field_coverage_test.go
@@ -1,0 +1,146 @@
+package plugin
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestRegistryRoundTripLosesNoField guards a whole class of bug rather than one
+// instance of it.
+//
+// Three separate fields have now been silently dropped between the registry and
+// the manifest, each found only by running a real install:
+//
+//   - pluginType and binaryName, which made every CLI plugin install into a
+//     dead command;
+//   - language and runtime, lost the same way for much longer;
+//   - cliCommands, which meant a plugin declaring two commands had only one
+//     binary published, so `nself billing` did not exist after `nself install
+//     tenant` reported success.
+//
+// The cause is the same every time: pluginEntry and Registry.MarshalJSON are
+// hand-maintained allowlists, so a field added to PluginManifest is dropped
+// unless someone remembers to add it in two more places. Nobody remembered,
+// three times.
+//
+// This walks PluginManifest by reflection, fills every settable field with a
+// non-zero value, round-trips it through the cache's marshaller and the
+// registry parser, and reports every field that came back zero. Adding a field
+// to PluginManifest without wiring it through now fails here instead of
+// shipping.
+func TestRegistryRoundTripLosesNoField(t *testing.T) {
+	// Fields the registry legitimately does not carry. Each needs a reason: an
+	// empty exemption list is the goal, and a new entry here should be a
+	// deliberate decision rather than a way to silence this test.
+	notCarried := map[string]string{
+		"Consumes":    "resolved from the installed plugin's own manifest, not the registry",
+		"Provides":    "resolved from the installed plugin's own manifest, not the registry",
+		"EnvVars":     "declared in plugin.json; the registry does not carry it",
+		"Webhooks":    "declared in plugin.json; the registry does not carry it",
+		"Permissions": "declared in plugin.json; the registry does not carry it",
+
+		"SystemDependencies":   "declared in plugin.json; the registry does not carry it",
+		"OptionalDependencies": "folded into Dependencies by the grouped form",
+		"Actions":              "declared in plugin.json; the registry does not carry it",
+		"Hooks":                "declared in plugin.json; the registry does not carry it",
+		"Notes":                "documentation, not consumed by the CLI",
+		"Status":               "declared in plugin.json; the registry uses publishStatus",
+	}
+
+	filled := reflect.New(reflect.TypeOf(PluginManifest{})).Elem()
+	populate(t, filled)
+	original := filled.Interface().(PluginManifest)
+
+	data, err := json.Marshal(&Registry{Plugins: []PluginManifest{original}})
+	if err != nil {
+		t.Fatalf("marshal registry: %v", err)
+	}
+	reloaded, err := parseRegistryJSON(data)
+	if err != nil {
+		t.Fatalf("parse registry: %v", err)
+	}
+	if len(reloaded.Plugins) != 1 {
+		t.Fatalf("got %d plugins back, want 1", len(reloaded.Plugins))
+	}
+
+	got := reflect.ValueOf(reloaded.Plugins[0])
+	typ := got.Type()
+	var lost []string
+	for i := 0; i < typ.NumField(); i++ {
+		name := typ.Field(i).Name
+		if typ.Field(i).PkgPath != "" {
+			continue // unexported
+		}
+		if reason, ok := notCarried[name]; ok {
+			_ = reason
+			continue
+		}
+		if got.Field(i).IsZero() {
+			lost = append(lost, name)
+		}
+	}
+
+	if len(lost) > 0 {
+		t.Errorf("these fields were dropped by the registry round-trip: %v\n"+
+			"Add them to pluginEntry, entryToManifest and Registry.MarshalJSON, "+
+			"or list them in notCarried with a reason. A dropped field is silent "+
+			"in production: the plugin installs and the behaviour it controls "+
+			"simply does not happen.", lost)
+	}
+}
+
+// populate fills every settable field of v with a distinctive non-zero value,
+// so a field that survives the round-trip is visibly different from one that
+// was reset.
+func populate(t *testing.T, v reflect.Value) {
+	t.Helper()
+	typ := v.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		if typ.Field(i).PkgPath != "" {
+			continue // unexported
+		}
+		f := v.Field(i)
+		switch f.Kind() {
+		case reflect.String:
+			f.SetString("x-" + typ.Field(i).Name)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			f.SetInt(7)
+		case reflect.Bool:
+			f.SetBool(true)
+		case reflect.Slice:
+			elem := f.Type().Elem()
+			s := reflect.MakeSlice(f.Type(), 1, 1)
+			if elem.Kind() == reflect.Struct {
+				populate(t, s.Index(0))
+			} else if elem.Kind() == reflect.String {
+				s.Index(0).SetString("x")
+			}
+			f.Set(s)
+		case reflect.Map:
+			m := reflect.MakeMap(f.Type())
+			k := reflect.New(f.Type().Key()).Elem()
+			if k.Kind() == reflect.String {
+				k.SetString("k")
+			}
+			val := reflect.New(f.Type().Elem()).Elem()
+			if val.Kind() == reflect.String {
+				val.SetString("v")
+			} else if val.Kind() == reflect.Slice && val.Type().Elem().Kind() == reflect.String {
+				sl := reflect.MakeSlice(val.Type(), 1, 1)
+				sl.Index(0).SetString("v")
+				val.Set(sl)
+			}
+			m.SetMapIndex(k, val)
+			f.Set(m)
+		case reflect.Struct:
+			populate(t, f)
+		case reflect.Ptr:
+			p := reflect.New(f.Type().Elem())
+			if p.Elem().Kind() == reflect.Struct {
+				populate(t, p.Elem())
+			}
+			f.Set(p)
+		}
+	}
+}

--- a/internal/plugin/registry_json.go
+++ b/internal/plugin/registry_json.go
@@ -107,6 +107,7 @@ func entryToManifest(e pluginEntry) PluginManifest {
 	runtime := e.Runtime
 	pluginType := e.PluginType
 	binaryName := e.BinaryName
+	var implEntryPoint, implCLI, implPackageManager, implFramework string
 	if e.Implementation != nil {
 		if language == "" {
 			language = e.Implementation.Language
@@ -123,6 +124,10 @@ func entryToManifest(e pluginEntry) PluginManifest {
 		if binaryName == "" {
 			binaryName = e.Implementation.BinaryName
 		}
+		implEntryPoint = e.Implementation.EntryPoint
+		implCLI = e.Implementation.CLI
+		implPackageManager = e.Implementation.PackageManager
+		implFramework = e.Implementation.Framework
 	}
 
 	return PluginManifest{
@@ -145,10 +150,40 @@ func entryToManifest(e pluginEntry) PluginManifest {
 		Runtime:         runtime,
 		PluginType:      pluginType,
 		BinaryName:      binaryName,
-		Compat:          e.Compat,
-		PublishStatus:   e.PublishStatus,
-		AuthorPublicKey: e.AuthorPublicKey,
-		Signature:       e.Signature,
-		UpdatedAt:       e.UpdatedAt,
+		CLICommands:     e.CLICommands,
+
+		Author:               e.Author,
+		Homepage:             e.Homepage,
+		IsCommercial:         e.IsCommercial,
+		RequiredEntitlements: e.RequiredEntitlements,
+		MinNselfVersion:      e.MinNselfVersion,
+		MaxNselfVersion:      e.MaxNselfVersion,
+		MinNodeVersion:       e.MinNodeVersion,
+		ArchSupport:          e.ArchSupport,
+		EntryPoint:           firstNonEmptyStr(e.EntryPoint, implEntryPoint),
+		CLI:                  firstNonEmptyStr(e.CLI, implCLI),
+		HealthEndpoint:       e.HealthEndpoint,
+		PackageManager:       firstNonEmptyStr(e.PackageManager, implPackageManager),
+		Framework:            firstNonEmptyStr(e.Framework, implFramework),
+		Views:                e.Views,
+		MultiApp:             e.MultiApp,
+		Deprecation:          e.Deprecation,
+		GraphQL:              e.GraphQL,
+		Compat:               e.Compat,
+		PublishStatus:        e.PublishStatus,
+		AuthorPublicKey:      e.AuthorPublicKey,
+		Signature:            e.Signature,
+		UpdatedAt:            e.UpdatedAt,
 	}
+}
+
+// firstNonEmptyStr returns the first non-empty argument, so a flat registry
+// field wins over the same value nested under implementation.
+func firstNonEmptyStr(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }

--- a/internal/plugin/registry_parse.go
+++ b/internal/plugin/registry_parse.go
@@ -110,6 +110,32 @@ type pluginEntry struct {
 	Runtime    string `json:"runtime,omitempty"`
 	PluginType string `json:"pluginType,omitempty"`
 	BinaryName string `json:"binaryName,omitempty"`
+
+	// CLICommands lists every command a plugin provides. Dropping it meant a
+	// plugin declaring two commands had only one binary published, so the
+	// second command stayed dead after a successful install.
+	CLICommands []CLICommand `json:"cliCommands,omitempty"`
+
+	// The rest of the manifest. These were absent, so the cache round-trip
+	// silently reset them — see TestRegistryRoundTripLosesNoField for why that
+	// class of omission keeps producing production bugs.
+	Author               string              `json:"author,omitempty"`
+	Homepage             string              `json:"homepage,omitempty"`
+	IsCommercial         bool                `json:"isCommercial,omitempty"`
+	RequiredEntitlements []string            `json:"requiredEntitlements,omitempty"`
+	MinNselfVersion      string              `json:"minNselfVersion,omitempty"`
+	MaxNselfVersion      string              `json:"maxNselfVersion,omitempty"`
+	MinNodeVersion       string              `json:"minNodeVersion,omitempty"`
+	ArchSupport          []string            `json:"arch_support,omitempty"`
+	EntryPoint           string              `json:"entryPoint,omitempty"`
+	CLI                  string              `json:"cli,omitempty"`
+	HealthEndpoint       string              `json:"health_endpoint,omitempty"`
+	PackageManager       string              `json:"packageManager,omitempty"`
+	Framework            string              `json:"framework,omitempty"`
+	Views                []string            `json:"views,omitempty"`
+	MultiApp             MultiApp            `json:"multiApp,omitempty"`
+	Deprecation          *DeprecationBlock   `json:"deprecation,omitempty"`
+	GraphQL              *PluginGraphQLBlock `json:"graphql,omitempty"`
 	// APIEndpoints is raw JSON because the registry format is not stable:
 	// the live registry returns objects; older registries return strings.
 	APIEndpoints json.RawMessage `json:"apiEndpoints,omitempty"`


### PR DESCRIPTION
Found by installing published plugins with the published 1.3.0 binary.

## `nself install tenant` published one binary instead of two

The tarball contained `nself-tenant` and `nself-billing`, both extracted, and only the first reached the proxy's lookup directory — so `nself billing` did not exist after an install that reported success. `cliCommands` was missing from `pluginEntry`.

That is the **third** field silently dropped between registry and manifest (`pluginType`/`binaryName`, then `language`/`runtime`, now `cliCommands`). Same cause each time: `pluginEntry` and `Registry.MarshalJSON` are hand-maintained allowlists.

So this fixes the class. A reflection test fills every `PluginManifest` field, round-trips through the cache marshaller and registry parser, and fails naming anything that came back zero. **It found twenty more.**

## One of them is a security hole

`AuthorPublicKey`, `Signature` and `PublishStatus` were all dropped by the cache. The cache is read on every run after the first, so from the second install onward `verifyPluginSignature` received three empty strings — the "no signature supplied" branch, which refuses only when `publishStatus == "stable"`, and that was empty too. It returned `nil`.

**A signed, stable plugin installed without signature verification on every cache-warm run.** Tests now assert the material survives and that an unsigned stable plugin is refused.

## `nself install sentry` installed the wrong thing

`sentry` is an alias of the paid ɳSentry bundle and bundles resolve first, so the command tried the bundle and failed on a missing licence, leaving the free plugin unreachable. Renamed `sentry-cli`, matching `claw-cli` and `ai-cli`. Every other extracted name was checked against the bundle catalogue; `sentry` was the only clash.