### PR TITLE
fix(plugin): third-party install path had missed two fixes

### DIFF
--- a/internal/plugin/install_paths_parity_test.go
+++ b/internal/plugin/install_paths_parity_test.go
@@ -1,0 +1,84 @@
+package plugin
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestBothInstallPathsShareTheirSteps guards a class of bug rather than an
+// instance.
+//
+// There are two install paths — installLocked for registry plugins and
+// installFromURL for third-party ones — and they had drifted. Two fixes made to
+// the registry path were never made to the other:
+//
+//   - publishing the command binary, so a third-party CLI plugin installed
+//     cleanly and its command did not exist;
+//   - skipping schema creation for a plugin with no tables, so installing a
+//     command-line plugin needed Docker and a running Postgres.
+//
+// Both were found by installing a third-party plugin end to end, months after
+// the registry path was fixed. Nothing pointed at the second path.
+//
+// This asserts the steps that must exist in both. It is deliberately a
+// source-level check: the two functions do genuinely different things and
+// cannot be collapsed into one, so the only thing worth pinning is that neither
+// forgets a step the other performs.
+func TestBothInstallPathsShareTheirSteps(t *testing.T) {
+	required := []string{
+		"linkCLIBinary",    // publish the command, or the plugin installs dead
+		"pluginOwnsTables", // do not demand a database from a plugin with no tables
+	}
+
+	for _, tc := range []struct{ file, fn string }{
+		{"installer_locked.go", "installLocked"},
+		{"install_thirdparty.go", "InstallFromURL"},
+	} {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, tc.file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", tc.file, err)
+		}
+
+		var body string
+		ast.Inspect(f, func(n ast.Node) bool {
+			fd, ok := n.(*ast.FuncDecl)
+			if !ok || fd.Name.Name != tc.fn || fd.Body == nil {
+				return true
+			}
+			start := fset.Position(fd.Body.Pos()).Offset
+			end := fset.Position(fd.Body.End()).Offset
+			src := readFile(t, tc.file)
+			body = src[start:end]
+			return false
+		})
+
+		if body == "" {
+			t.Fatalf("%s: function %s not found — rename it here too", tc.file, tc.fn)
+		}
+		for _, want := range required {
+			if !contains(body, want) {
+				t.Errorf("%s does not call %s. Both install paths must perform this step; "+
+					"the last time one of them did not, plugins installed successfully and "+
+					"then did not work.", tc.fn, want)
+			}
+		}
+	}
+}
+
+func readFile(t *testing.T, p string) string {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	return string(b)
+}
+
+func contains(hay, needle string) bool {
+	return len(hay) >= len(needle) && strings.Contains(hay, needle)
+}

--- a/internal/plugin/install_thirdparty.go
+++ b/internal/plugin/install_thirdparty.go
@@ -175,9 +175,26 @@ func InstallFromURL(ctx context.Context, cfg *config.Config, sourceURL string, p
 		return fmt.Errorf("installing third-party plugin %q: %w", manifest.Name, err)
 	}
 
-	if err := createPluginSchema(ctx, cfg, manifest.Name); err != nil {
+	// Publish the command binary, same as the registry install path. Without
+	// this a third-party CLI plugin installs cleanly and its command does not
+	// exist — the exact failure the registry path was fixed for, sitting
+	// unfixed in the parallel path because nobody had installed a third-party
+	// plugin end to end.
+	if err := linkCLIBinary(destDir, manifest.Name, manifest); err != nil {
 		rollbackInstall(ctx, cfg, manifest.Name, destDir)
-		return fmt.Errorf("creating schema for third-party plugin %q: %w", manifest.Name, err)
+		return fmt.Errorf("publishing third-party plugin %q command: %w", manifest.Name, err)
+	}
+
+	// Skipped for a plugin that owns no tables, same as the registry install
+	// path. Creating an empty schema reaches for Postgres through Docker, so a
+	// command-line plugin could not be installed on a machine with no stack
+	// running. The registry path was fixed for this; this one was missed, and
+	// only turned up by installing a third-party plugin end to end.
+	if pluginOwnsTables(manifest) {
+		if err := createPluginSchema(ctx, cfg, manifest.Name); err != nil {
+			rollbackInstall(ctx, cfg, manifest.Name, destDir)
+			return fmt.Errorf("creating schema for third-party plugin %q: %w", manifest.Name, err)
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "Plugin %q (v%s) installed from third-party source %s.\n", manifest.Name, manifest.Version, u.Host)

--- a/internal/plugin/install_thirdparty_test.go
+++ b/internal/plugin/install_thirdparty_test.go
@@ -138,7 +138,7 @@ func TestInstallFromURL_CorrectChecksumPassesVerification(t *testing.T) {
 	cfg := &config.Config{}
 
 	err := InstallFromURL(context.Background(), cfg, srv.URL+"/plugin.tar.gz", pluginDir, correctChecksum)
-	assertFailsAtSchemaNotEarlier(t, err)
+	assertGotPastVerification(t, err)
 }
 
 // TestInstallFromURL_NoChecksumWarnsAndProceeds verifies that omitting
@@ -157,7 +157,7 @@ func TestInstallFromURL_NoChecksumWarnsAndProceeds(t *testing.T) {
 	cfg := &config.Config{}
 
 	err := InstallFromURL(context.Background(), cfg, srv.URL+"/plugin.tar.gz", pluginDir, "")
-	assertFailsAtSchemaNotEarlier(t, err)
+	assertGotPastVerification(t, err)
 }
 
 // TestInstallFromURL_InvalidManifest verifies a plugin.json missing required
@@ -192,21 +192,29 @@ func TestInstallFromURL_InvalidManifest(t *testing.T) {
 // success can't be observed here without Docker — but a failure at THAT
 // specific step proves checksum verification, extraction, and manifest
 // validation all passed.
-func assertFailsAtSchemaNotEarlier(t *testing.T, err error) {
+func assertGotPastVerification(t *testing.T, err error) {
 	t.Helper()
+
+	// This used to assert the install FAILED at schema creation, using "no
+	// Docker in the test environment" as the signal that everything before it
+	// had passed. That stopped being true when schema creation started being
+	// skipped for a plugin that owns no tables — which the fixture is — so the
+	// install now succeeds and the old assertion failed on its own proxy.
+	//
+	// What these tests actually care about is that verification passed and
+	// nothing earlier in the pipeline objected. Success means exactly that.
 	if err == nil {
-		t.Fatal("expected an error from the schema-creation step (no Docker in test env), got nil")
+		return
 	}
-	if strings.Contains(err.Error(), "checksum") {
-		t.Errorf("did not expect a checksum error, got: %v", err)
-	}
-	if strings.Contains(err.Error(), "missing required fields") {
-		t.Errorf("did not expect a manifest validation error, got: %v", err)
-	}
-	if strings.Contains(err.Error(), "extracting") {
-		t.Errorf("did not expect an extraction error, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "schema") {
-		t.Errorf("expected the failure to occur at schema creation, got: %v", err)
+
+	for _, stage := range []struct{ token, what string }{
+		{"checksum", "checksum verification"},
+		{"missing required fields", "manifest validation"},
+		{"extracting", "extraction"},
+		{"unknown permission", "permission validation"},
+	} {
+		if strings.Contains(err.Error(), stage.token) {
+			t.Errorf("install failed at %s, which should have passed: %v", stage.what, err)
+		}
 	}
 }


### PR DESCRIPTION
Two install paths exist — `installLocked` (registry) and `InstallFromURL` (third-party). Two fixes made to the first were never made to the second. Found by installing a third-party plugin end to end while checking something else.

- **A third-party CLI plugin installed and its command did not exist** — the path never called `linkCLIBinary`, so the binary was extracted and never published where the proxy looks.
- **Installing a third-party command-line plugin required Docker and Postgres** — schema creation ran unconditionally, so a plugin with no tables died on a missing `docker.sock`.

Both are the same failures the registry path was fixed for, sitting unfixed in the parallel path.

So the guard is a **parity test**, not two more one-off fixes: it reads both functions and asserts each performs the steps the other does. Source-level on purpose — the two do genuinely different things and cannot be collapsed. Verified it fails when a step is removed.

Two existing tests asserted the install *failed* at schema creation, using "no Docker in CI" as the signal that everything before had passed. Skipping schema for a table-less plugin makes the install succeed, so they failed on their own proxy. Rewritten to assert the real property.

Verified end to end: descriptive-permission plugin with no tables installs cleanly with no database; one declaring a command with no binary fails naming the cause; one with an unknown permission is still refused.