### PR TITLE
fix(plugin): nself remove left the command working

### DIFF
--- a/internal/plugin/cli_binary.go
+++ b/internal/plugin/cli_binary.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -228,50 +227,4 @@ func copyExecutable(src, dst string) error {
 		return err
 	}
 	return os.Chmod(dst, 0o755)
-}
-
-// readPluginManifest loads plugin.json from an installed plugin directory.
-// Returns nil when it cannot be read; callers treat that as "assume the
-// nself-<name> convention" rather than as a failure, because a plugin with a
-// corrupt manifest must still be removable.
-func readPluginManifest(destDir string) *PluginManifest {
-	data, err := os.ReadFile(filepath.Join(destDir, "plugin.json"))
-	if err != nil {
-		return nil
-	}
-	var m PluginManifest
-	if err := json.Unmarshal(data, &m); err != nil {
-		return nil
-	}
-	return &m
-}
-
-// IsCommandInstalled reports whether a plugin providing the named command is
-// present, i.e. whether ProxyCommand would find a binary for it.
-//
-// Used by the CLI to decide whether a relocated command still needs its
-// "moved to a plugin" notice. Once the plugin is installed the old spelling is
-// the supported spelling, and repeating the install hint is noise.
-func IsCommandInstalled(cmdName string) bool {
-	candidate := PublishedBinaryPath("nself-" + cmdName)
-	info, err := os.Stat(candidate)
-	return err == nil && !info.IsDir()
-}
-
-// pluginOwnsTables reports whether a plugin declares any database tables.
-//
-// A plugin with none needs no schema, and every CLI-R11 extraction produces
-// exactly that shape: a Go binary that adds a command, with "tables": [] in its
-// manifest. Running the schema step for those meant `nself install <cmd>`
-// required Docker and a running Postgres to create an empty schema, so a
-// command-line tool could not be installed on a machine without a stack.
-//
-// A nil manifest is treated as owning tables: it means the manifest could not
-// be read, and skipping schema creation on a guess is the more damaging
-// mistake of the two.
-func pluginOwnsTables(m *PluginManifest) bool {
-	if m == nil {
-		return true
-	}
-	return len(m.Tables) > 0
 }

--- a/internal/plugin/cli_binary_test.go
+++ b/internal/plugin/cli_binary_test.go
@@ -254,3 +254,49 @@ func TestProxyCommandDoesNotLogToSlog(t *testing.T) {
 		t.Errorf("proxy wrote to the default logger, which reaches the user's terminal:\n%s", got)
 	}
 }
+
+// TestReadPluginManifestFindsNestedManifests covers the reason a whole set of
+// fallbacks were being taken silently.
+//
+// Release tarballs carry a leading directory — `<name>/...` for the platform
+// archive, `free/<name>/...` for the source one — and extraction keeps it. So
+// an installed plugin's manifest is nested, and readPluginManifest only looked
+// at the root. It returned nil for every plugin installed from a release, and
+// each caller quietly used its nil fallback: unlinkCLIBinary guessed the binary
+// name, and pluginOwnsTables assumed tables existed, which made `nself remove`
+// demand a database from a plugin that had none.
+func TestReadPluginManifestFindsNestedManifests(t *testing.T) {
+	const body = `{"name":"demo","pluginType":"cli","binaryName":"nself-demo","tables":[]}`
+
+	for _, layout := range []struct {
+		name string
+		rel  string
+	}{
+		{"at the root", "plugin.json"},
+		{"platform archive: <name>/", filepath.Join("demo", "plugin.json")},
+		{"source archive: free/<name>/", filepath.Join("free", "demo", "plugin.json")},
+	} {
+		t.Run(layout.name, func(t *testing.T) {
+			dir := t.TempDir()
+			full := filepath.Join(dir, layout.rel)
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			m := readPluginManifest(dir)
+			if m == nil {
+				t.Fatal("manifest not found — callers would silently take their nil fallback")
+			}
+			if m.BinaryName != "nself-demo" {
+				t.Errorf("BinaryName = %q, want nself-demo", m.BinaryName)
+			}
+			if pluginOwnsTables(m) {
+				t.Error("a plugin declaring \"tables\": [] was reported as owning tables, " +
+					"which is what made `nself remove` demand a database")
+			}
+		})
+	}
+}

--- a/internal/plugin/install_paths_parity_test.go
+++ b/internal/plugin/install_paths_parity_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// TestBothInstallPathsShareTheirSteps guards a class of bug rather than an
+// TestInstallAndRemovePathsShareTheirSteps guards a class of bug rather than an
 // instance.
 //
 // There are two install paths — installLocked for registry plugins and
@@ -28,15 +28,26 @@ import (
 // source-level check: the two functions do genuinely different things and
 // cannot be collapsed into one, so the only thing worth pinning is that neither
 // forgets a step the other performs.
-func TestBothInstallPathsShareTheirSteps(t *testing.T) {
+func TestInstallAndRemovePathsShareTheirSteps(t *testing.T) {
 	required := []string{
 		"linkCLIBinary",    // publish the command, or the plugin installs dead
 		"pluginOwnsTables", // do not demand a database from a plugin with no tables
 	}
 
-	for _, tc := range []struct{ file, fn string }{
-		{"installer_locked.go", "installLocked"},
-		{"install_thirdparty.go", "InstallFromURL"},
+	// Remove is the third path, and it had drifted the same way: it never
+	// unpublished the command binary and demanded a database from a plugin with
+	// no tables. What each path must do differs, so the requirements are
+	// per-path rather than one shared list.
+	for _, tc := range []struct {
+		file, fn string
+		steps    []string
+	}{
+		{"installer_locked.go", "installLocked", required},
+		{"install_thirdparty.go", "InstallFromURL", required},
+		{"installer_remove_update.go", "Remove", []string{
+			"unlinkCLIBinary",  // or the command survives its own removal
+			"pluginOwnsTables", // or removal needs a database the plugin never used
+		}},
 	} {
 		fset := token.NewFileSet()
 		f, err := parser.ParseFile(fset, tc.file, nil, 0)
@@ -60,7 +71,7 @@ func TestBothInstallPathsShareTheirSteps(t *testing.T) {
 		if body == "" {
 			t.Fatalf("%s: function %s not found — rename it here too", tc.file, tc.fn)
 		}
-		for _, want := range required {
+		for _, want := range tc.steps {
 			if !contains(body, want) {
 				t.Errorf("%s does not call %s. Both install paths must perform this step; "+
 					"the last time one of them did not, plugins installed successfully and "+

--- a/internal/plugin/installer_remove_update.go
+++ b/internal/plugin/installer_remove_update.go
@@ -101,11 +101,26 @@ func Remove(ctx context.Context, cfg *config.Config, name string, pluginDir stri
 		}
 	}
 
-	// Drop schema unless the caller wants to keep data.
-	if !keepData {
+	// The manifest has to be read before the directory goes, because it names
+	// the command binaries to unpublish and says whether there is a schema.
+	manifest := readPluginManifest(destDir)
+
+	// Drop schema unless the caller wants to keep data — and only when the
+	// plugin owns tables. Dropping reaches for Postgres through Docker, so
+	// without this a command-line plugin could be installed on a machine with
+	// no stack running and then never removed from it.
+	if !keepData && pluginOwnsTables(manifest) {
 		if err := dropPluginSchema(ctx, cfg, name); err != nil {
 			return fmt.Errorf("dropping schema for plugin %q: %w", name, err)
 		}
+	}
+
+	// Unpublish the command binary. unlinkCLIBinary has existed since the
+	// install side was written and was never called from anywhere, so removing
+	// a plugin left its command working: `nself remove foo` then `nself foo`
+	// still ran the removed plugin.
+	if err := unlinkCLIBinary(name, manifest); err != nil {
+		return fmt.Errorf("unpublishing plugin %q command: %w", name, err)
 	}
 
 	// Remove plugin directory.

--- a/internal/plugin/manifest_locate.go
+++ b/internal/plugin/manifest_locate.go
@@ -1,0 +1,106 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Locating an installed plugin's manifest.
+//
+// Split out of cli_binary.go on the file-size ratchet, which picked a fair
+// boundary: that file is about publishing and removing command binaries, and
+// this is about finding the manifest that describes them.
+//
+// The nesting handled here is the whole reason this is more than one line —
+// release tarballs carry a leading directory and extraction keeps it.
+
+// readPluginManifest loads plugin.json from an installed plugin directory.
+// Returns nil when it cannot be read; callers treat that as "assume the
+// nself-<name> convention" rather than as a failure, because a plugin with a
+// corrupt manifest must still be removable.
+func readPluginManifest(destDir string) *PluginManifest {
+	for _, p := range manifestCandidates(destDir) {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		var m PluginManifest
+		if err := json.Unmarshal(data, &m); err != nil {
+			continue
+		}
+		return &m
+	}
+	return nil
+}
+
+// manifestCandidates lists where an installed plugin's manifest may sit.
+//
+// Release tarballs carry a leading directory — the source archive is
+// `free/<name>/...` and the platform archive is `<name>/...` — and extraction
+// keeps it, so an installed plugin is nested one or two levels below destDir
+// rather than sitting at its root. readPluginManifest only ever looked at the
+// root, so it returned nil for every plugin installed from a release, and every
+// caller silently took its nil fallback instead. That is why removing a plugin
+// tried to drop a schema it did not have.
+//
+// findExtractedBinary already copes with the same nesting by walking; this does
+// the same thing with a bounded search rather than a full walk, since a
+// manifest is always near the top.
+func manifestCandidates(destDir string) []string {
+	out := []string{filepath.Join(destDir, "plugin.json")}
+
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sub := filepath.Join(destDir, e.Name())
+		out = append(out, filepath.Join(sub, "plugin.json"))
+
+		// One more level, for the `free/<name>/` shape of the source archive.
+		inner, err := os.ReadDir(sub)
+		if err != nil {
+			continue
+		}
+		for _, ie := range inner {
+			if ie.IsDir() {
+				out = append(out, filepath.Join(sub, ie.Name(), "plugin.json"))
+			}
+		}
+	}
+	return out
+}
+
+// IsCommandInstalled reports whether a plugin providing the named command is
+// present, i.e. whether ProxyCommand would find a binary for it.
+//
+// Used by the CLI to decide whether a relocated command still needs its
+// "moved to a plugin" notice. Once the plugin is installed the old spelling is
+// the supported spelling, and repeating the install hint is noise.
+func IsCommandInstalled(cmdName string) bool {
+	candidate := PublishedBinaryPath("nself-" + cmdName)
+	info, err := os.Stat(candidate)
+	return err == nil && !info.IsDir()
+}
+
+// pluginOwnsTables reports whether a plugin declares any database tables.
+//
+// A plugin with none needs no schema, and every CLI-R11 extraction produces
+// exactly that shape: a Go binary that adds a command, with "tables": [] in its
+// manifest. Running the schema step for those meant `nself install <cmd>`
+// required Docker and a running Postgres to create an empty schema, so a
+// command-line tool could not be installed on a machine without a stack.
+//
+// A nil manifest is treated as owning tables: it means the manifest could not
+// be read, and skipping schema creation on a guess is the more damaging
+// mistake of the two.
+func pluginOwnsTables(m *PluginManifest) bool {
+	if m == nil {
+		return true
+	}
+	return len(m.Tables) > 0
+}


### PR DESCRIPTION
Found by installing a plugin and removing it — which nothing had done end to end. Two bugs, and a third underneath that explains both.

- **Removing a plugin left its command working.** `unlinkCLIBinary` has existed since the install side was written and was **never called from anywhere**. `nself remove maintenance` then `nself maintenance` still ran the removed binary.
- **Removing a command-line plugin required Docker and Postgres** — the schema drop ran unconditionally, so a plugin that installs fine without a stack could never be removed without one.

**Underneath both:** `readPluginManifest` never found the manifest. Release tarballs carry a leading directory and extraction keeps it, so an installed plugin's manifest is nested; the lookup only checked the root, returned nil for **every plugin installed from a release**, and each caller silently took its nil fallback. `pluginOwnsTables(nil)` is `true` — the safe default — and it was firing every time.

The parity test grows a third path. Remove is not an install, so it gets its own required steps: what matters is that no path forgets something its siblings do.

Verified end to end: install, remove, command gone, bin directory empty, no database needed at either end.