### PR TITLE
fix: second TypeScript SDK was not in version lockstep

### DIFF
--- a/.github/workflows/version-lockstep.yml
+++ b/.github/workflows/version-lockstep.yml
@@ -31,6 +31,7 @@ on:
       - 'internal/version/version.go'
       - 'sdk/go/doc.go'
       - 'sdk/ts/package.json'
+      - 'sdk/ts-sdk/package.json'
       - 'sdk/py/pyproject.toml'
       - '.github/workflows/version-lockstep.yml'
       - 'scripts/check-version-lockstep.sh'
@@ -40,7 +41,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   lockstep:
-    name: Verify all 11 version files are in lockstep
+    name: Verify all 12 version files are in lockstep
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -136,9 +137,20 @@ jobs:
                 | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' | head -1)
           check "cli/sdk/go/doc.go" "${V}" 1
 
-          # 4. cli/sdk/ts/package.json
+          # 4. cli/sdk/ts/package.json  (@nself/plugin-sdk)
           V=$(node -p "require('${NSELF_REPO_ROOT}/sdk/ts/package.json').version")
           check "cli/sdk/ts/package.json" "${V}" 1
+
+          # 4b. cli/sdk/ts-sdk/package.json  (@nself/sdk)
+          #
+          # There are TWO TypeScript packages and only the first was listed
+          # here, so a release bumped one and left the other behind. Its publish
+          # workflow then saw its version already on npm, no-opped as
+          # "already published", and reported success — and the SDK Version
+          # Coherence check caught the drift a day later on its schedule,
+          # after the release had shipped.
+          V=$(node -p "require('${NSELF_REPO_ROOT}/sdk/ts-sdk/package.json').version")
+          check "cli/sdk/ts-sdk/package.json" "${V}" 1
 
           # 5. cli/sdk/py/pyproject.toml
           V=$(grep -E '^version\s*=' "${NSELF_REPO_ROOT}/sdk/py/pyproject.toml" \

--- a/sdk/ts-sdk/package.json
+++ b/sdk/ts-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nself/sdk",
-  "version": "1.2.7",
-  "description": "TypeScript consumer SDK for nSelf — query GraphQL, manage plugins, auth, and admin from any TS/JS app.",
+  "version": "1.3.3",
+  "description": "TypeScript consumer SDK for nSelf \u2014 query GraphQL, manage plugins, auth, and admin from any TS/JS app.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
The scheduled **SDK Version Coherence** check went red on main after 1.3.3: `@nself/sdk` on npm was still 1.2.7 while the CLI was 1.3.3.

There are two TypeScript packages and lockstep listed only one:

| path | package | state |
|---|---|---|
| `sdk/ts` | `@nself/plugin-sdk` | in lockstep, bumped, published |
| `sdk/ts-sdk` | `@nself/sdk` | **not listed**, left at 1.2.7 |

So every release since 1.3.0 bumped one and left the other. The publish workflow then read its own `package.json`, saw that version already on npm, no-opped as "already published" — correct by its own logic — and reported success. The drift surfaced a day later on a scheduled check, after four releases had shipped.

`sdk/ts-sdk` is bumped and added to the list, now 12 files rather than 11.

Also: milestones for v1.3.0–v1.3.3 were missing. Every prior release back to v1.2.0 has a closed one and `DENY-005` requires it, so the Pre-Release Gate failed on all four tags. Created and closed, each describing what that release contained.