### PR TITLE
ci: path-filtered workflows now watch their own file

### DIFF
--- a/.github/workflows/endpoint-auth-gate.yml
+++ b/.github/workflows/endpoint-auth-gate.yml
@@ -7,6 +7,7 @@ on:
       - 'plugins-pro/**'
       - 'web/backend/**'
       - 'tools/endpoint-auth-checker/**'
+      - '.github/workflows/endpoint-auth-gate.yml'
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - 'plugins-pro/**'
       - 'web/backend/**'
       - 'tools/endpoint-auth-checker/**'
+      - '.github/workflows/endpoint-auth-gate.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -6,12 +6,14 @@ on:
       - "**/Dockerfile"
       - "**/Dockerfile.*"
       - "**/.hadolint.yaml"
+      - '.github/workflows/hadolint.yml'
     branches: [main]
   pull_request:
     paths:
       - "**/Dockerfile"
       - "**/Dockerfile.*"
       - "**/.hadolint.yaml"
+      - '.github/workflows/hadolint.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/migration-fixture.yml
+++ b/.github/workflows/migration-fixture.yml
@@ -9,6 +9,7 @@ on:
       - 'cmd/commands/start.go'
       - 'cmd/commands/build.go'
       - 'cmd/commands/doctor.go'
+      - '.github/workflows/migration-fixture.yml'
   pull_request:
     paths:
       - 'internal/migration/**'
@@ -16,6 +17,7 @@ on:
       - 'cmd/commands/start.go'
       - 'cmd/commands/build.go'
       - 'cmd/commands/doctor.go'
+      - '.github/workflows/migration-fixture.yml'
   schedule:
     # Nightly at 02:00 UTC — catches environment drift
     - cron: '0 2 * * *'

--- a/.github/workflows/sdk-go-test.yml
+++ b/.github/workflows/sdk-go-test.yml
@@ -6,9 +6,11 @@ on:
       - main
     paths:
       - 'sdk/go/**'
+      - '.github/workflows/sdk-go-test.yml'
   pull_request:
     paths:
       - 'sdk/go/**'
+      - '.github/workflows/sdk-go-test.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-py-test.yml
+++ b/.github/workflows/sdk-py-test.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - 'sdk/py/**'
+      - '.github/workflows/sdk-py-test.yml'
   pull_request:
     paths:
       - 'sdk/py/**'
+      - '.github/workflows/sdk-py-test.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-ts-test.yml
+++ b/.github/workflows/sdk-ts-test.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - 'sdk/ts/**'
+      - '.github/workflows/sdk-ts-test.yml'
   pull_request:
     paths:
       - 'sdk/ts/**'
+      - '.github/workflows/sdk-ts-test.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - ".github/wiki/**"
+      - '.github/workflows/wiki-sync.yml'
 
 jobs:
   sync:


### PR DESCRIPTION
A workflow filtered to `paths: ['sdk/ts/**']` does not run when the only
change is to the workflow itself. That makes every edit to it unverifiable,
and it is how three Dependabot action bumps reached a green PR without the
action ever being executed:

  - pnpm/action-setup 3 -> 6 (#245): sdk-ts-test.yml, sdk-reverse-dep-check.yml
  - hadolint-action 3.1.0 -> 3.4.0 (#244): hadolint.yml

In each case every check on the PR passed and not one of them ran the action
being bumped. The green tick was reporting on unrelated jobs.

Adding each workflow's own path to its filter costs nothing at steady state
-- it triggers only when that one file changes -- and turns an action bump
into something a reviewer can actually see succeed.

quarterly-doc-audit.yml is untouched: its `add-paths:` is an input to
create-pull-request, not a trigger filter.