### PR TITLE
fix(doctor,ci): missing --quick flag; surface E2E golden-path failures

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -824,6 +824,7 @@
       "--install-check",
       "--json",
       "--only",
+      "--quick",
       "--section",
       "--skip",
       "--skip-ollama",

--- a/.github/wiki/cmd-doctor.md
+++ b/.github/wiki/cmd-doctor.md
@@ -301,6 +301,7 @@ Status values: `pass`, `warn`, `fail`, `critical`.
 | `--install-check` | `false` | Run 6-stage onboarding funnel check (used by Homebrew post-install hook) |
 | `--json` | `false` | JSON output |
 | `--only` | `""` | Run only a specific subsystem check (host, docker, postgres, hasura, nginx, ssl, ping, plugins, license, monitoring, backups, security) |
+| `--quick` | `false` | Fast check: infrastructure, disk, ports, config, plugins, license, container health only (the default check set; explicit opt-in overrides --full/--deep) |
 | `--section` | `""` | Run only a specific section (system, core, backups, license, plugins, monitoring, security) |
 | `--skip-ollama` | `false` | Skip local Ollama installation step |
 | `--skip-pool` | `false` | Skip Gemini pool setup step |

--- a/.github/wiki/llms.txt
+++ b/.github/wiki/llms.txt
@@ -311,6 +311,7 @@ Flags:
 - `--install-check` (default false) — Run 6-stage onboarding funnel check (used by Homebrew post-install hook)
 - `--json` (default false) — JSON output
 - `--only` (default "") — Run only a specific subsystem check (host, docker, postgres, hasura, nginx, ssl, ping, plugins, license, monitoring, backups, security)
+- `--quick` (default false) — Fast check: infrastructure, disk, ports, config, plugins, license, container health only (the default check set; explicit opt-in overrides --full/--deep)
 - `--section` (default "") — Run only a specific section (system, core, backups, license, plugins, monitoring, security)
 - `--skip` (default []) — Skip specific check sections
 - `--skip-ollama` (default false) — Skip local Ollama installation step

--- a/.github/workflows/e2e-golden-path.yml
+++ b/.github/workflows/e2e-golden-path.yml
@@ -144,18 +144,56 @@ jobs:
           retention-days: 90
 
       - name: Summarise result
+        # CLI-R05 follow-up: this step wrote its header to GITHUB_STEP_SUMMARY
+        # but piped the actual pass/fail table to the python3 subshell's own
+        # stdout (the job log) instead of the summary file, so the step
+        # summary was effectively just a lone "### Golden Path Result" line —
+        # a scheduled run could fail for five weeks and the one place meant to
+        # surface it stayed blank. STEP_LABELS below mirrors the 13-step names
+        # from scripts/golden-path.sh's STEP_BASELINE comments so a failure is
+        # named, not just numbered.
         if: always()
         run: |
-          if [ -f /tmp/golden-path-report.json ]; then
-            echo "### Golden Path Result" >> "${GITHUB_STEP_SUMMARY}"
-            python3 - <<PYEOF
+          {
+            echo "### Golden Path Result"
+            if [ -f /tmp/golden-path-report.json ]; then
+              python3 - <<'PYEOF'
           import json
+
+          STEP_LABELS = {
+              "1": "brew/curl install", "2": "create test project dir",
+              "3": "nself init", "4": "nself build", "5": "nself start",
+              "6": "wait healthy", "7": "doctor --quick",
+              "8": "plugin install ai", "9": "plugin install claw",
+              "10": "license set", "11": "admin start", "12": "curl health",
+              "13": "claw readiness",
+          }
+
           with open("/tmp/golden-path-report.json") as f:
               r = json.load(f)
-          icon = "✅" if r.get("overall") == "pass" else "❌"
-          print(f"| Overall | {icon} {r.get('overall','?').upper()} |")
-          print(f"| Pass    | {r.get('pass',0)} |")
-          print(f"| Fail    | {r.get('fail',0)} |")
-          print(f"| Warn    | {r.get('warn',0)} |")
+          overall = r.get("overall", "?")
+          icon = "✅" if overall == "pass" else "❌"
+          print(f"| Overall | {icon} {overall.upper()} |")
+          print(f"| Pass    | {r.get('pass', 0)} |")
+          print(f"| Fail    | {r.get('fail', 0)} |")
+          print(f"| Warn    | {r.get('warn', 0)} |")
+
+          failing = {
+              idx: s for idx, s in r.get("steps", {}).items()
+              if s.get("status") == "fail"
+          }
+          if failing:
+              print()
+              print("**Failing step(s):**")
+              for idx, s in sorted(failing.items(), key=lambda kv: int(kv[0])):
+                  label = STEP_LABELS.get(idx, "unknown step")
+                  note = s.get("note", "")
+                  print(f"- Step {idx} ({label}): {note}" if note else f"- Step {idx} ({label})")
+          elif overall != "pass":
+              print()
+              print("_Overall failed but no individual step reported fail — check the job log._")
           PYEOF
-          fi
+            else
+              echo "❌ FAIL — no /tmp/golden-path-report.json was produced (the smoke script exited before writing a report; see the \"Run golden-path smoke\" step log)"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/cmd/commands/doctor.go
+++ b/cmd/commands/doctor.go
@@ -75,6 +75,19 @@ Exit codes:
 		if deep {
 			full = true
 		}
+		// --quick was documented (help_topics.go: "Fast 10-second check") and
+		// relied on by scripts/golden-path.sh's health-wait loop, but the flag
+		// was never registered on this command — every invocation failed at
+		// cobra's flag parser with "unknown flag: --quick" before RunE ever
+		// ran, so the E2E golden-path smoke could never pass regardless of
+		// actual service health. The base check set below (no --full/--deep)
+		// already matches the documented "quick" behavior; --quick just makes
+		// that intent explicit and wins over an accidental --full/--deep.
+		quick, _ := cmd.Flags().GetBool("quick")
+		if quick {
+			full = false
+			deep = false
+		}
 		fix, _ := cmd.Flags().GetBool("fix")
 		jsonOut, _ := cmd.Flags().GetBool("json")
 		formatFlag, _ := cmd.Flags().GetString("format")

--- a/cmd/commands/doctor_install_check.go
+++ b/cmd/commands/doctor_install_check.go
@@ -21,6 +21,7 @@ func init() {
 	doctorCmd.Flags().Bool("verbose", false, "Detailed diagnostics")
 	doctorCmd.Flags().Bool("full", false, "Run all checks including network and memory (slower)")
 	doctorCmd.Flags().Bool("deep", false, "Alias for --full (run all checks)")
+	doctorCmd.Flags().Bool("quick", false, "Fast check: infrastructure, disk, ports, config, plugins, license, container health only (the default check set; explicit opt-in overrides --full/--deep)")
 	doctorCmd.Flags().Bool("fix", false, "Auto-fix safe issues")
 	doctorCmd.Flags().Bool("json", false, "JSON output")
 	doctorCmd.Flags().String("section", "", "Run only a specific section (system, core, backups, license, plugins, monitoring, security)")

--- a/cmd/commands/doctor_test.go
+++ b/cmd/commands/doctor_test.go
@@ -94,6 +94,30 @@ func TestDoctorCmd_FlagOnly(t *testing.T) {
 	}
 }
 
+// TestDoctorCmd_QuickFlagRegistered is a regression guard: `nself doctor
+// --quick` was documented as a "Fast 10-second check" (help_topics.go) and
+// relied on by scripts/golden-path.sh's health-wait loop (E2E golden-path
+// smoke, steps 6-7), but --quick was never registered as a flag on the real
+// doctorCmd — only the disconnected stub above (newDoctorCmd, which hand-lists
+// its own flags rather than reading the real registration) accepted it.
+// Every real invocation failed at cobra's flag parser with "unknown flag:
+// --quick" before RunE ever ran, so the smoke's wait loop could never
+// succeed regardless of actual service health — it was failing on flag
+// parsing, not container state. This checks the actual flag set doctorCmd
+// registers (not a copy), so a future removal of --quick fails a fast unit
+// test instead of a weekly scheduled CI run.
+func TestDoctorCmd_QuickFlagRegistered(t *testing.T) {
+	f := doctorCmd.Flags().Lookup("quick")
+	if f == nil {
+		t.Fatal("doctor command has no --quick flag: `nself doctor --quick` " +
+			"(documented in help_topics.go, used by scripts/golden-path.sh) " +
+			"would fail with \"unknown flag: --quick\"")
+	}
+	if f.Value.Type() != "bool" {
+		t.Fatalf("--quick should be a bool flag, got %q", f.Value.Type())
+	}
+}
+
 // TestDoctorCmd_UnknownFlagRejected verifies unknown flags fail fast.
 func TestDoctorCmd_UnknownFlagRejected(t *testing.T) {
 	root := newDoctorCmd()


### PR DESCRIPTION
## Summary

The weekly "E2E Golden Path" workflow (`.github/workflows/e2e-golden-path.yml`) has not passed since at least 2026-07-27 (failures/cancellations on 08-24, 08-17, 08-10, 08-03, 07-27). It runs on a schedule with no notification path, so this went unnoticed for five weeks.

### Fixed (with evidence)

**Root cause of the smoke failure itself**, found by reading the code, not guessed: `nself doctor --quick` is documented in `cmd/commands/help_topics.go` ("Fast 10-second check") and is exactly what `scripts/golden-path.sh` calls in its `wait_healthy()` loop and step 7 — but `--quick` was **never registered as a flag** on `doctorCmd` (`cmd/commands/doctor.go` / `doctor_install_check.go`). Every invocation failed at cobra's flag parser with `Error: unknown flag: --quick` (exit 1) *before any check ran*. That means `wait_healthy()` could never succeed regardless of actual container/nginx health — it looped to timeout on a flag-parsing error every single run.

Evidence: built the binary and ran it in a temp dir outside the repo:
```
$ /tmp/nself-test-build doctor --quick
Error: unknown flag: --quick
EXIT=1
```
Confirmed by history: `--quick` has never existed in `doctor.go` at any commit (`git log --all -S'"quick"'` shows no hit in the doctor command's history).

Fix: registered `--quick` as an explicit bool flag that maps to the existing default (non-`--full`, non-`--deep`) check set — which already matches the documented "fast" behavior — and wins over an accidentally-combined `--full`/`--deep`. Re-ran the built binary after the fix: `--quick` is now accepted and returns real check results (exit code reflects actual pass/fail, not a parse error). Added `TestDoctorCmd_QuickFlagRegistered` in `doctor_test.go`, asserting against the **real** `doctorCmd`'s flag set — the pre-existing doctor flag tests all ran against a disconnected hand-maintained stub (`newDoctorCmd()`) that silently drifted from the real command, which is exactly why this was never caught.

**The step-B "commit to main" defect described in the task brief no longer exists in current `main`** — it was already fixed by commit `cff23f6b` (PR #242, ticket CLI-R05, merged 2026-08-25, one day *after* the 08-24 failing run this task was scoped against). The workflow now uploads the archived result as a build artifact instead of `git push`ing to protected `main`. No action needed there; verified by reading the current workflow file and its git history.

**Silent-failure visibility**: the "Summarise result" step wrote its `### Golden Path Result` header to `GITHUB_STEP_SUMMARY` but piped the actual pass/fail table to the `python3` subshell's own stdout (the job log) instead — so the step summary was, in practice, just a lone heading with no data. This is independently part of why nobody noticed. Fixed by redirecting the whole block into `GITHUB_STEP_SUMMARY`, naming the failing step(s) by label (e.g. "Step 6 (wait healthy): timeout=240s"), and adding a branch for the case where the smoke script crashes before writing a report at all. Verified by extracting and running the exact bash+python logic locally against sample report JSON (pass case, fail case, and missing-report case) — all three produce correct summary output.

### Diagnosed only (not fixed)

The task brief's log excerpt shows a second, separate anomaly: `nself start`'s own health-check printer (`cmd/commands/start_health.go`, `printServiceDetails` and the `runHealthCheckLoop` "still unhealthy" branch) treats any `Status != "healthy"` as unhealthy for *display*, while `internal/health/checker.go`'s `RunAllChecks` already correctly counts a no-healthcheck service's `"running"` status as healthy for the *percentage gate*. This is a real display inconsistency (a running nginx with no configured healthcheck gets a `✗` next to it even though it isn't blocking `nself start`), but it is cosmetic relative to the actual gating failure — the `--quick` flag bug alone is sufficient to explain why `wait_healthy()` in `golden-path.sh` never succeeded, independent of nginx's real state. I did not "fix" this display inconsistency in this PR to keep the change scoped to the reproduced, code-verified defect; flagging it here rather than guessing at a fix. Docker was not used/needed to reach this conclusion.

### Evidence commands run
```
make build                          # exit 0
gofmt -l cmd internal               # empty output
make vet                            # exit 0
go test -mod=vendor ./...           # exit 0, no FAIL
make cmd-inventory                  # regenerated .github/command-inventory.json (new --quick flag)
```

## What remains unresolved

- Whether the smoke test *actually passes end-to-end* in CI is unverified — no scheduled run has occurred since this fix (next scheduled run is the following Monday 00:00 UTC per the cron). This PR removes the flag-parsing defect that guaranteed failure, but does not itself constitute proof of a green run.
- The `start_health.go` "running" vs "healthy" display inconsistency described above is real but not fixed here (out of scope: display-only, doesn't gate anything).

## Test plan
- [x] `make build`, `gofmt -l cmd internal`, `make vet`, `go test -mod=vendor ./...` all green (see Evidence above)
- [x] Manually reproduced the original defect and confirmed the fix resolves it by running the built binary in a temp dir outside the source tree
- [x] Extracted and ran the new workflow summary logic locally against sample JSON for pass/fail/missing-report cases
- [ ] A real scheduled (or `workflow_dispatch`) run of `E2E Golden Path` on this branch, to confirm the smoke itself now completes — not run as part of this change; do not merge without watching that once it runs