### PR TITLE
chore(gitignore): ignore compiled tools/ helpers at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@ nself-darwin-*
 nself-linux-*
 nself-windows-*
 
+# Compiled helpers from tools/ land at the repo root when built with a bare
+# `go build ./tools/<name>`. They are large (flagaudit is ~38 MB) and the root
+# allowlist in .github/workflows/clean-root.yml does not permit them, so an
+# accidental `git add .` would both fail CI and push a binary to a public repo.
+/flagaudit
+/flagaudit.exe
+
 # Go build
 *.test
 *.out


### PR DESCRIPTION
## Why

`flagaudit` was sitting untracked at the repo root as a **37.8 MB Mach-O binary**. It is not in `.gitignore` and not in the root entry allowlist in `.github/workflows/clean-root.yml`, so a single `git add .` would both fail the clean-root gate and push a large binary to a public repo.

The cause is ordinary: `go build ./tools/<name>` with no `-o` drops the binary at the repo root.

## What

Ignores `/flagaudit` and `/flagaudit.exe` specifically, rather than a broad pattern or an extensionless-file rule, so a genuinely new root entry still has to be considered on its merits instead of being silently swallowed.

## Verification

```
$ git check-ignore -v flagaudit
.gitignore:20:/flagaudit    flagaudit
```

## Note

`tools/flagaudit/` (the Go source) is deliberately **not** touched here. It is untracked and referenced from nothing tracked: not the Makefile, not any workflow, not any script. Whether it gets committed and wired up or deleted is a separate call, covered in the hand-off notes.