### PR TITLE
fix(plugin): outdated probed the registry before checking if anything was installed

### DIFF
--- a/.github/wiki/cmd-plugin.md
+++ b/.github/wiki/cmd-plugin.md
@@ -69,6 +69,8 @@ To opt out, set `NSELF_DISABLE_TELEMETRY=1` in your environment or `.env.local`.
 `nself plugin list --detailed` prints an `Updated` column per plugin, sourced from the registry entry's (or local `plugin.json`'s) `updated_at` field when present. As of the current plugins.nself.org registry, no plugin carries a per-plugin `updated_at` — only a registry-wide snapshot timestamp, which `--detailed` prints as a `Registry snapshot: <timestamp>` header line instead of a per-row value. The column is plumbing ready for the day the registry starts sending a per-plugin value; it never fabricates one.
 
 `nself plugin outdated` compares every installed plugin's version against the registry and lists the ones behind, with `--json` for scripting. It exits `0` when everything is current and `1` when at least one plugin is outdated, so it composes in CI.
+
+With no plugins installed it answers from local state and never contacts the registry, so it stays fast and works offline. The registry is only consulted once there is something to compare.
 ## Permissions
 
 `nself plugin info <name>` lists the permissions a plugin declares, and every

--- a/cmd/commands/plugin_outdated.go
+++ b/cmd/commands/plugin_outdated.go
@@ -50,11 +50,6 @@ type outdatedPluginRow struct {
 func runPluginOutdated(cmd *cobra.Command, args []string) error {
 	jsonOut, _ := cmd.Flags().GetBool("json")
 
-	registryURL := os.Getenv("NSELF_PLUGIN_REGISTRY")
-	if err := plugin.ValidateNetworkAccess(cmd.Context(), registryURL); err != nil {
-		return err
-	}
-
 	pluginDir := resolvePluginDir()
 
 	installed, err := plugin.List(pluginDir, true)
@@ -67,6 +62,21 @@ func runPluginOutdated(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Println("No plugins installed.")
 		return nil
+	}
+
+	// The registry reachability probe belongs AFTER the nothing-installed
+	// check, not before it. With no plugins installed there is nothing to
+	// compare against, so reaching for the network is work we then throw away
+	// -- and when plugins.nself.org is slow it turned a question answerable
+	// entirely from local state into a 5s timeout and a non-zero exit.
+	//
+	// It also made TestPluginOutdated_NoneInstalled contact the real registry:
+	// unlike its siblings it sets no NSELF_PLUGIN_REGISTRY, so it inherited a
+	// live network dependency and failed CI with "context deadline exceeded"
+	// whenever the host was unreachable.
+	registryURL := os.Getenv("NSELF_PLUGIN_REGISTRY")
+	if err := plugin.ValidateNetworkAccess(cmd.Context(), registryURL); err != nil {
+		return err
 	}
 
 	registry, err := plugin.List(pluginDir, false)

--- a/cmd/commands/plugin_outdated_test.go
+++ b/cmd/commands/plugin_outdated_test.go
@@ -95,6 +95,36 @@ func TestPluginOutdated_NoneInstalled(t *testing.T) {
 	}
 }
 
+// TestPluginOutdated_NoneInstalledNeedsNoNetwork pins the reason
+// TestPluginOutdated_NoneInstalled kept failing in CI.
+//
+// runPluginOutdated used to probe the registry for reachability BEFORE checking
+// whether anything was installed. With nothing installed there is nothing to
+// compare a registry against, so the probe was wasted work that could only ever
+// turn a locally-answerable question into a failure. In CI it did exactly that:
+//
+//	cannot reach plugin registry https://plugins.nself.org/registry.json:
+//	Head "...": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+//
+// This points the registry at an address that cannot answer, so if the probe
+// ever moves back above the short-circuit this test fails immediately instead
+// of intermittently, and on a developer's machine rather than in CI.
+func TestPluginOutdated_NoneInstalledNeedsNoNetwork(t *testing.T) {
+	t.Setenv("NSELF_PLUGIN_DIR", t.TempDir())
+	setPluginTestHome(t, t.TempDir())
+
+	// Reserved as invalid-for-any-use by RFC 6890; nothing can answer here.
+	t.Setenv("NSELF_PLUGIN_REGISTRY", "http://192.0.2.0:1/registry.json")
+
+	run, stdout := newOutdatedTestCmd(t, false)
+	if err := run(); err != nil {
+		t.Fatalf("nothing installed must be answerable without the network, got: %v", err)
+	}
+	if !strings.Contains(stdout(), "No plugins installed") {
+		t.Errorf("expected 'No plugins installed', got: %q", stdout())
+	}
+}
+
 // TestPluginOutdated_AllCurrent verifies exit 0 and "up to date" messaging
 // when every installed plugin matches the registry's version.
 func TestPluginOutdated_AllCurrent(t *testing.T) {


### PR DESCRIPTION
`nself plugin outdated` called plugin.ValidateNetworkAccess before listing
installed plugins. With nothing installed there is nothing to compare a
registry against, so the probe was work that could only be discarded -- and
when plugins.nself.org is slow it turned a question answerable entirely from
local state into a 5s timeout and a non-zero exit.

Moving the probe below the nothing-installed short-circuit fixes the command
offline and makes the test hermetic. It was failing CI on unrelated PRs:

  --- FAIL: TestPluginOutdated_NoneInstalled (5.00s)
      cannot reach plugin registry https://plugins.nself.org/registry.json:
      Head "...": context deadline exceeded

That test, unlike its siblings in the same file, sets no NSELF_PLUGIN_REGISTRY,
so it had inherited a live dependency on a production host. It passed whenever
the host happened to answer, which is why it read as flaky rather than wrong.

TestPluginOutdated_NoneInstalledNeedsNoNetwork pins the guarantee by pointing
the registry at 192.0.2.0:1 (RFC 6890, cannot answer). Verified by mutation:
with the probe moved back above the short-circuit the new test fails in exactly
5.00s with the CI error above; with the fix in place it passes in 0.6s.