### PR TITLE
ci(e2e): golden path can now exercise this ref, not only the last release

### DIFF
--- a/.github/workflows/e2e-golden-path.yml
+++ b/.github/workflows/e2e-golden-path.yml
@@ -11,6 +11,12 @@ on:
         required: false
         default: 'false'
         type: boolean
+      source:
+        description: 'Which nself to exercise: the published release, or a build of this ref'
+        required: false
+        default: 'release'
+        type: choice
+        options: [release, local]
 
 concurrency:
   group: e2e-golden-path
@@ -40,6 +46,13 @@ jobs:
       # must not pull multi-GB AI models in CI (that's what destabilized step 5).
       AI_AUTO_INSTALL: 'false'
       GOLDEN_PATH_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '0' }}
+      # Which binary step 1 installs. The scheduled run stays on 'release' on
+      # purpose: its job is to prove the PUBLISHED install path works, which is
+      # what users actually hit. But that also means a fix to `nself start`
+      # cannot be validated here until after it ships, which is backwards for a
+      # pre-release gate. Dispatching with source=local builds this ref instead,
+      # so a fix can be proven BEFORE it is released.
+      GOLDEN_PATH_SOURCE: ${{ github.event.inputs.source || 'release' }}
 
     steps:
       - name: Checkout

--- a/scripts/golden-path.sh
+++ b/scripts/golden-path.sh
@@ -289,10 +289,21 @@ if [ -z "${NSELF_PLUGIN_LICENSE_KEY_OWNER:-}" ]; then
 fi
 
 # ── Step 1: Install nSelf CLI ─────────────────────────────────────────────────
+# GOLDEN_PATH_SOURCE=local builds the CLI from the checked-out ref and installs
+# that, instead of fetching the last published release.
+#
+# The scheduled run leaves this at "release" deliberately: its job is to prove
+# the install path real users take still works. But that also means a fix to any
+# command exercised below cannot be validated here until AFTER the release that
+# contains it, which is backwards for a pre-release gate. Dispatching with
+# source=local proves a fix first.
+if [ "${GOLDEN_PATH_SOURCE:-release}" = "local" ]; then
+  run_step 1 "build this ref and install it" \
+    bash -c 'set -e; cd "${GITHUB_WORKSPACE:-$PWD}"; make build; sudo install -m 0755 ./nself /usr/local/bin/nself; nself --version'
 # On macOS, prefer Homebrew. On Linux, use the curl installer even if brew is
 # present — the Homebrew formula only ships macOS (darwin) binaries and will
 # error with "formula requires at least a URL" on Linux runners.
-if command -v brew >/dev/null 2>&1 && [ "$(uname)" = "Darwin" ]; then
+elif command -v brew >/dev/null 2>&1 && [ "$(uname)" = "Darwin" ]; then
   run_step 1 "brew install nself-org/nself/nself" \
     bash -c 'brew install nself-org/nself/nself 2>&1 || brew upgrade nself-org/nself/nself 2>&1'
 else


### PR DESCRIPTION
Step 1 runs `curl install.nself.org | bash`, so the smoke has always tested the
last PUBLISHED release. That is correct for its scheduled job, which exists to
prove the install path real users take still works, and it stays the default.

But it also means a fix to any command the smoke exercises cannot be validated
here until after the release containing it. That is backwards for a gate meant
to run before a release, and it bit immediately: the postgres temp-init-server
race fixed in #259 could not be proven, because dispatching the smoke on main
still installed v1.3.3 and reproduced the very bug main had just fixed.

Dispatching with source=local builds the checked-out ref and installs that
instead. The weekly cron is unchanged and still uses the published release.