### PR TITLE
docs(wiki): correct the credential store path in login and logout

### DIFF
--- a/.github/wiki/cmd-login.md
+++ b/.github/wiki/cmd-login.md
@@ -13,7 +13,7 @@ nself login [flags]
 ## Description
 
 <!-- BEGIN PROSE:description -->
-`nself login` authenticates the CLI with your ɳSelf account (cloud.nself.org or a self-hosted ɳSelf Cloud instance). On success, a session token is stored in the local credential store (`~/.config/nself/credentials.json`) and used automatically by subsequent commands that require authentication.
+`nself login` authenticates the CLI with your ɳSelf account (cloud.nself.org or a self-hosted ɳSelf Cloud instance). On success, a session token is stored in the local credential store (`~/.nself/auth.json`, mode 0600) and used automatically by subsequent commands that require authentication.
 
 Self-hosted users with no cloud account can skip this step, the CLI operates without a cloud login for local stack management. `nself login` is required for:
 

--- a/.github/wiki/cmd-logout.md
+++ b/.github/wiki/cmd-logout.md
@@ -13,7 +13,7 @@ nself logout [flags]
 ## Description
 
 <!-- BEGIN PROSE:description -->
-`nself logout` clears the stored session token from the local credential store (`~/.config/nself/credentials.json`). After logging out, commands that require cloud authentication will prompt you to log in again.
+`nself logout` clears the stored session token from the local credential store (`~/.nself/auth.json`). After logging out, commands that require cloud authentication will prompt you to log in again.
 
 Plugin license keys are NOT removed by `nself logout`. To clear license keys, use `nself license clear`.
 <!-- END PROSE:description -->


### PR DESCRIPTION
Both pages said the session token lives at ~/.config/nself/credentials.json.
It does not, and never has. internal/auth/storage.go writes ~/.nself/auth.json
at 0600 (authFilePath, authFileName = "auth.json"), and login.go's own Long
help already says so, so the wiki was the only place carrying the wrong path.

Anyone following the docs to inspect or clear their credentials would have
looked at a file that does not exist and concluded they were not logged in.

cmd-logout.md repeated the same path for the file DeleteAuthFile removes, so
both are corrected together rather than leaving one half wrong.