### PR TITLE
ci(e2e): surface golden-path diagnostics instead of discarding them

### DIFF
--- a/.github/workflows/e2e-golden-path.yml
+++ b/.github/workflows/e2e-golden-path.yml
@@ -117,6 +117,18 @@ jobs:
           path: /tmp/golden-path-report.json
           retention-days: 90
 
+      # The per-step diagnostics (nself version, docker ps, doctor --quick) are
+      # the only record of WHY a step failed, and the runner is discarded when
+      # the job ends. Without this they were written and thrown away.
+      - name: Upload golden-path diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: golden-path-diagnostics-${{ github.run_id }}
+          path: /tmp/golden-path-diag-step*.txt
+          if-no-files-found: ignore
+          retention-days: 90
+
       - name: Archive result to .github/golden-path-results/
         if: always()
         run: |

--- a/scripts/golden-path.sh
+++ b/scripts/golden-path.sh
@@ -112,6 +112,15 @@ capture_diagnostics() {
     ls -la "${WORK_DIR:-/tmp}" 2>&1 || true
   } > "${diag_file}" 2>&1
   warn "Diagnostics captured at ${diag_file}"
+
+  # Print them too. The file alone is useless in CI: the runner is torn down
+  # after the job, so unless the diagnostics reach the job log or an artifact,
+  # a failure here says only "not healthy" and nothing about WHY. The health
+  # wait polls `nself doctor --quick >/dev/null 2>&1`, discarding exactly the
+  # output that would identify the failing check.
+  echo "--- begin diagnostics (step ${step}) ---"
+  cat "${diag_file}" 2>/dev/null || true
+  echo "--- end diagnostics (step ${step}) ---"
 }
 
 run_step() {


### PR DESCRIPTION
The health wait polls `nself doctor --quick >/dev/null 2>&1`, so when it gives
up after 240s the log says "Services not healthy" and nothing else. The script
already captured diagnostics (nself version, docker ps, doctor --quick output)
to /tmp/golden-path-diag-step<N>.txt, but nothing read that file: the runner is
torn down with the job, and only the report JSON was uploaded.

So a failing run recorded precisely the information needed to diagnose it and
then deleted it. This prints the diagnostics into the job log and uploads them
as an artifact.

Found while chasing the step-6 health-wait failure that remains after the
postgres init race fix in #259, which cannot be diagnosed from the current log.