### PR TITLE
feat(clean): implement --all for host-wide docker system prune

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -442,7 +442,11 @@
     "path": "nself clean",
     "short": "Remove generated artifacts (docker-compose.yml, nginx configs, build cache)",
     "hidden": false,
-    "group_id": "core"
+    "group_id": "core",
+    "flags": [
+      "--all",
+      "--yes"
+    ]
   },
   {
     "name": "completion",

--- a/.github/wiki/cmd-clean.md
+++ b/.github/wiki/cmd-clean.md
@@ -13,11 +13,13 @@ nself clean [flags]
 ## Description
 
 <!-- BEGIN PROSE:description -->
-`nself clean` removes Docker resources (stopped containers, unused images, dangling volumes, orphaned networks) scoped to the current ɳSelf project. By default it uses Docker label filters to only remove resources belonging to the current project, other Docker projects on your machine are not affected.
+By default, `nself clean` removes generated artifacts scoped to the current ɳSelf project: `docker-compose.yml`, generated `nginx/sites/` config files, the `.nself/cache/` build cache, and Docker's build cache. Other Docker projects on your machine are not affected.
 
-`nself clean` does **not** delete your `.env` files, data directories, or any user data. It only removes generated Docker artifacts. To remove generated configuration files (nginx configs, `docker-compose.yml`), use `nself reset` instead.
+`nself clean` does **not** delete your `.env` files, data directories, or any user data. Docker volumes and container data are preserved. To also remove Docker volumes and other project state, use `nself reset` instead.
 
-`nself clean` takes no flags today, it always scopes to the current project. A system-wide `docker system prune` is not something this command runs, use the `docker` CLI directly for that.
+With `--all`, clean additionally runs a host-wide `docker system prune --all`, removing unused containers, unused networks, unused images, and build cache for every Docker project on the machine, not just this one. Named volumes are never touched by `--all`; there is no flag on `nself clean` that deletes volumes.
+
+Because `--all` affects Docker resources outside the current project, it prompts for confirmation before running: type `yes` to proceed, anything else (including piping in empty input) cancels. Pass `--yes` alongside `--all` to skip the prompt for scripted or CI use.
 <!-- END PROSE:description -->
 
 ## Flags
@@ -25,6 +27,8 @@ nself clean [flags]
 <!-- BEGIN GENERATED:flags -->
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--all` | `false` | Also run a host-wide 'docker system prune' affecting every Docker project on this machine (destructive; requires confirmation) |
+| `--yes` | `false` | Skip the --all confirmation prompt (for CI/CD) |
 | `--help`, `-h` | — | Show help |
 <!-- END GENERATED:flags -->
 
@@ -32,19 +36,31 @@ nself clean [flags]
 
 <!-- BEGIN PROSE:examples -->
 ```bash
-# Project-scoped cleanup (safe, recommended)
+# Project-scoped cleanup (default, recommended)
 nself clean
+
+# Also prune Docker resources across the whole machine (prompts for confirmation)
+nself clean --all
+
+# Same, skipping the confirmation prompt (CI/CD)
+nself clean --all --yes
 ```
 
 **What is preserved:**
 - `.env` and all `.env.*` variant files
 - `data/` and `volumes/` directories
-- Your application source code
+- Docker volumes and container data, on the default path and with `--all`
 
-**What is removed:**
-- Stopped ɳSelf project containers
-- Unused images tagged to this project
-- Dangling volumes belonging to this project
+**What is removed by default:**
+- `docker-compose.yml` and generated `nginx/sites/` config files
+- The `.nself/cache/` build cache
+- Docker build cache
+
+**What `--all` additionally removes, host-wide:**
+- Stopped containers from every Docker project on the machine
+- Unused networks
+- Unused images (not just images tagged to this project)
+- Build cache from every project
 <!-- END PROSE:examples -->
 
 ## See Also

--- a/.github/wiki/llms.txt
+++ b/.github/wiki/llms.txt
@@ -163,6 +163,11 @@ Remove generated artifacts (docker-compose.yml, nginx configs, build cache)
 nself clean [flags]
 ```
 
+Flags:
+
+- `--all` (default false) — Also run a host-wide 'docker system prune' affecting every Docker project on this machine (destructive; requires confirmation)
+- `--yes` (default false) — Skip the --all confirmation prompt (for CI/CD)
+
 Full page: [[cmd-clean]]
 
 ### nself completion

--- a/cmd/commands/clean.go
+++ b/cmd/commands/clean.go
@@ -1,13 +1,16 @@
 package commands
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/confirm"
 
 	"github.com/spf13/cobra"
 )
@@ -29,12 +32,34 @@ Preserved:
   - User-managed files
 
 No confirmation required — this operation is non-destructive (data is preserved).
-Run 'nself build' after clean to regenerate all artifacts.`,
+Run 'nself build' after clean to regenerate all artifacts.
+
+With --all, clean additionally runs a host-wide 'docker system prune',
+removing unused containers, networks, images, and build cache for EVERY
+Docker project on the machine, not just this one. Named volumes are never
+touched. --all requires typing "yes" at an interactive prompt; pass --yes
+to skip the prompt for scripted or CI use.`,
 	RunE: runClean,
 }
 
 func init() {
+	cleanCmd.Flags().Bool("all", false, "Also run a host-wide 'docker system prune' affecting every Docker project on this machine (destructive; requires confirmation)")
+	cleanCmd.Flags().Bool("yes", false, "Skip the --all confirmation prompt (for CI/CD)")
 	RootCmd.AddCommand(cleanCmd)
+}
+
+// dockerSystemPrune runs a host-wide `docker system prune`, removing unused
+// containers, networks, images, and build cache for every Docker project on
+// the machine. It deliberately never passes --volumes: named volumes hold
+// other projects' database and storage data, and deleting them requires its
+// own explicit opt-in and confirmation, which this command does not yet
+// offer. It is a package variable so tests can swap in a spy and assert
+// whether it was invoked without needing a Docker daemon.
+var dockerSystemPrune = func(ctx context.Context, out, errOut io.Writer) error {
+	pruneCmd := exec.CommandContext(ctx, "docker", "system", "prune", "--all", "--force")
+	pruneCmd.Stdout = out
+	pruneCmd.Stderr = errOut
+	return pruneCmd.Run()
 }
 
 func runClean(cmd *cobra.Command, args []string) error {
@@ -115,6 +140,27 @@ func runClean(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(out, "  - %s\n", r)
 		}
 		fmt.Fprintln(out, "\nRun 'nself build' to regenerate.")
+	}
+
+	// 5. --all: host-wide docker system prune, gated behind confirmation.
+	all, _ := cmd.Flags().GetBool("all")
+	if !all {
+		return nil
+	}
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		if confirmErr := confirm.ConfirmHostWidePrune(cmd.InOrStdin(), out); confirmErr != nil {
+			fmt.Fprintln(out, "\nHost-wide prune canceled.")
+			return nil
+		}
+	}
+
+	fmt.Fprintln(out, "\nPruning all unused Docker resources on this host...")
+	if pruneAllErr := dockerSystemPrune(cmd.Context(), out, cmd.ErrOrStderr()); pruneAllErr != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: docker system prune failed (Docker may not be running): %v\n", pruneAllErr)
+	} else {
+		fmt.Fprintln(out, "Host-wide prune complete.")
 	}
 
 	return nil

--- a/cmd/commands/clean_test.go
+++ b/cmd/commands/clean_test.go
@@ -1,0 +1,235 @@
+package commands
+
+// clean_test.go — Unit tests for the clean command's --all / --yes flags.
+//
+// Purpose: --all was documented as system-wide `docker system prune` but never
+// implemented (see PR #262, which correctly removed the claim rather than
+// invent behavior). This verifies the real flags exist on the real cleanCmd
+// (not a hand-listed stub — that exact mistake let doctor's --quick flag ship
+// unregistered for over a month, see doctor_test.go) and that --all refuses
+// to prune without confirmation.
+// Inputs:  cobra command execution against runClean, a spy in place of
+//          dockerSystemPrune.
+// Outputs: pass/fail per assertion below.
+// Constraints: no Docker daemon required — the docker system prune call is
+//              stubbed via the package-level dockerSystemPrune variable.
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestCleanCmd_AllFlagRegistered is a regression guard: checks the flag
+// directly on the real cleanCmd, not a hand-listed copy.
+func TestCleanCmd_AllFlagRegistered(t *testing.T) {
+	f := cleanCmd.Flags().Lookup("all")
+	if f == nil {
+		t.Fatal("clean command has no --all flag")
+	}
+	if f.Value.Type() != "bool" {
+		t.Fatalf("--all should be a bool flag, got %q", f.Value.Type())
+	}
+}
+
+// TestCleanCmd_YesFlagRegistered checks --yes directly on the real cleanCmd.
+func TestCleanCmd_YesFlagRegistered(t *testing.T) {
+	f := cleanCmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("clean command has no --yes flag")
+	}
+	if f.Value.Type() != "bool" {
+		t.Fatalf("--yes should be a bool flag, got %q", f.Value.Type())
+	}
+}
+
+// newCleanTestCmd builds a cobra.Command wired to the real runClean function
+// (not a reimplementation) with the same flags production registers, so
+// behavior tests exercise the actual code path without mutating the shared
+// global cleanCmd/RootCmd state.
+func newCleanTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "clean", RunE: runClean}
+	c.Flags().Bool("all", false, "")
+	c.Flags().Bool("yes", false, "")
+	c.SetContext(context.Background())
+	return c
+}
+
+// withTempCwd runs fn with the process working directory set to a fresh
+// temp dir, restoring the original afterward.
+func withTempCwd(t *testing.T, fn func()) {
+	t.Helper()
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("os.Chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Fatalf("restore os.Chdir: %v", err)
+		}
+	}()
+	fn()
+}
+
+// TestCleanCmd_AllWithoutConfirmation_DoesNotPrune verifies that --all
+// without --yes, and a non-affirmative response at the prompt, never invokes
+// the host-wide prune.
+func TestCleanCmd_AllWithoutConfirmation_DoesNotPrune(t *testing.T) {
+	origPrune := dockerSystemPrune
+	called := false
+	dockerSystemPrune = func(ctx context.Context, out, errOut io.Writer) error {
+		called = true
+		return nil
+	}
+	defer func() { dockerSystemPrune = origPrune }()
+
+	withTempCwd(t, func() {
+		cmd := newCleanTestCmd()
+		if err := cmd.Flags().Set("all", "true"); err != nil {
+			t.Fatalf("set --all: %v", err)
+		}
+		cmd.SetIn(strings.NewReader("no\n"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("runClean returned error: %v", err)
+		}
+
+		if called {
+			t.Fatal("expected dockerSystemPrune NOT to be called without confirmation")
+		}
+		if !strings.Contains(out.String(), "canceled") {
+			t.Fatalf("expected cancellation message in output, got: %q", out.String())
+		}
+	})
+}
+
+// TestCleanCmd_AllWithoutConfirmation_EOF verifies that an EOF on stdin
+// (e.g. a non-interactive pipe) is treated as a decline, not a hang or a
+// silent prune.
+func TestCleanCmd_AllWithoutConfirmation_EOF(t *testing.T) {
+	origPrune := dockerSystemPrune
+	called := false
+	dockerSystemPrune = func(ctx context.Context, out, errOut io.Writer) error {
+		called = true
+		return nil
+	}
+	defer func() { dockerSystemPrune = origPrune }()
+
+	withTempCwd(t, func() {
+		cmd := newCleanTestCmd()
+		if err := cmd.Flags().Set("all", "true"); err != nil {
+			t.Fatalf("set --all: %v", err)
+		}
+		cmd.SetIn(strings.NewReader(""))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("runClean returned error: %v", err)
+		}
+		if called {
+			t.Fatal("expected dockerSystemPrune NOT to be called on EOF")
+		}
+	})
+}
+
+// TestCleanCmd_AllWithYes_Prunes verifies that --yes skips the prompt and
+// invokes the host-wide prune.
+func TestCleanCmd_AllWithYes_Prunes(t *testing.T) {
+	origPrune := dockerSystemPrune
+	called := false
+	dockerSystemPrune = func(ctx context.Context, out, errOut io.Writer) error {
+		called = true
+		return nil
+	}
+	defer func() { dockerSystemPrune = origPrune }()
+
+	withTempCwd(t, func() {
+		cmd := newCleanTestCmd()
+		if err := cmd.Flags().Set("all", "true"); err != nil {
+			t.Fatalf("set --all: %v", err)
+		}
+		if err := cmd.Flags().Set("yes", "true"); err != nil {
+			t.Fatalf("set --yes: %v", err)
+		}
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("runClean returned error: %v", err)
+		}
+		if !called {
+			t.Fatal("expected dockerSystemPrune to be called with --yes")
+		}
+	})
+}
+
+// TestCleanCmd_AllWithConfirmation_Prunes verifies that typing "yes" at the
+// prompt invokes the host-wide prune.
+func TestCleanCmd_AllWithConfirmation_Prunes(t *testing.T) {
+	origPrune := dockerSystemPrune
+	called := false
+	dockerSystemPrune = func(ctx context.Context, out, errOut io.Writer) error {
+		called = true
+		return nil
+	}
+	defer func() { dockerSystemPrune = origPrune }()
+
+	withTempCwd(t, func() {
+		cmd := newCleanTestCmd()
+		if err := cmd.Flags().Set("all", "true"); err != nil {
+			t.Fatalf("set --all: %v", err)
+		}
+		cmd.SetIn(strings.NewReader("yes\n"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("runClean returned error: %v", err)
+		}
+		if !called {
+			t.Fatal("expected dockerSystemPrune to be called after typing yes")
+		}
+	})
+}
+
+// TestCleanCmd_WithoutAll_NeverPrunes verifies default (no --all) behavior
+// never touches the host-wide prune, regardless of stdin content.
+func TestCleanCmd_WithoutAll_NeverPrunes(t *testing.T) {
+	origPrune := dockerSystemPrune
+	called := false
+	dockerSystemPrune = func(ctx context.Context, out, errOut io.Writer) error {
+		called = true
+		return nil
+	}
+	defer func() { dockerSystemPrune = origPrune }()
+
+	withTempCwd(t, func() {
+		cmd := newCleanTestCmd()
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("runClean returned error: %v", err)
+		}
+		if called {
+			t.Fatal("expected dockerSystemPrune NOT to be called without --all")
+		}
+	})
+}

--- a/internal/confirm/confirm.go
+++ b/internal/confirm/confirm.go
@@ -33,3 +33,31 @@ func ConfirmDestruction(projectName string, r io.Reader, w io.Writer) error {
 
 	return nil
 }
+
+// ConfirmHostWidePrune prompts the user to type "yes" before a command runs a
+// host-wide `docker system prune`. Unlike ConfirmDestruction there is no
+// project name to type against: the operation is not scoped to a project at
+// all, it affects every Docker resource on the machine, so the prompt states
+// that plainly instead. Returns nil only when the typed response is exactly
+// "yes" (case-insensitive). Returns ErrDestructionCanceled on any other input,
+// including EOF.
+func ConfirmHostWidePrune(r io.Reader, w io.Writer) error {
+	fmt.Fprintln(w, "⚠  This will run a host-wide 'docker system prune'.")
+	fmt.Fprintln(w, "   It removes stopped containers, unused networks, unused images, and")
+	fmt.Fprintln(w, "   build cache for EVERY Docker project on this machine, not just the")
+	fmt.Fprintln(w, "   current one. Named volumes are not affected.")
+	fmt.Fprintf(w, "   Type \"yes\" to continue: ")
+
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		// EOF or read error — treat as canceled
+		return ErrDestructionCanceled
+	}
+
+	input := strings.ToLower(strings.TrimSpace(scanner.Text()))
+	if input != "yes" {
+		return ErrDestructionCanceled
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- `nself clean --all` was documented once and then removed (#262) because it was never implemented. This builds it.
- Default `nself clean` behavior is unchanged (project-scoped generated-artifact removal).
- `--all` additionally runs `docker system prune --all --force`, affecting every Docker project on the host, gated behind an interactive confirmation via a new `internal/confirm.ConfirmHostWidePrune` (typed "yes", following `reset.go`'s existing confirm-package pattern rather than a new prompt style).
- `--yes` skips that confirmation for scripted/CI use.

## --volumes decision

`--all` never passes `--volumes` to `docker system prune`, and no separate volume-pruning flag was added. Named Docker volumes hold other projects' database and storage data; deleting them host-wide on a single confirmation would be a silent way to destroy unrelated projects' data. If volume pruning is wanted later it should be its own explicit flag with its own separate confirmation, not folded into `--all`.

## Testing

Added `cmd/commands/clean_test.go`:
- `TestCleanCmd_AllFlagRegistered` / `TestCleanCmd_YesFlagRegistered` — assert against the real `cleanCmd`, not a hand-listed stub (a stub-vs-real mismatch is exactly how `doctor --quick` shipped broken).
- `TestCleanCmd_AllWithoutConfirmation_DoesNotPrune`, `TestCleanCmd_AllWithoutConfirmation_EOF`, `TestCleanCmd_WithoutAll_NeverPrunes` — confirm the prune never runs without affirmative confirmation.
- `TestCleanCmd_AllWithYes_Prunes`, `TestCleanCmd_AllWithConfirmation_Prunes` — confirm it does run when authorized.

The `docker system prune` call sits behind a package-level `dockerSystemPrune` variable so these tests need no Docker daemon.

Also regenerated `.github/command-inventory.json` and `.github/wiki/llms.txt` (`make cmd-inventory` / wikigen), and rewrote `.github/wiki/cmd-clean.md`'s PROSE:description and PROSE:examples to describe the real `--all`/`--yes` behavior.

## Test plan

- [x] `make build`
- [x] `gofmt -l cmd internal` (empty)
- [x] `make vet`
- [x] `go test -mod=vendor ./...` (4491 passed)
- [x] `make wiki-check`
- [x] `bash scripts/ci/flag-drift-audit.sh` (0 unregistered flags)