### PR TITLE
fix(wiki): correct mcp-serve.md drift left open by #262

### DIFF
--- a/.github/wiki/commands/mcp-serve.md
+++ b/.github/wiki/commands/mcp-serve.md
@@ -27,13 +27,7 @@ Run `nself mcp` from inside an nSelf project directory — it fails fast if one 
 
 | Variable | Default | Description |
 |---|---|---|
-| `NSELF_MCP_PORT` | `3825` | HTTP/SSE port |
-| `NSELF_MCP_HOST` | `127.0.0.1` | HTTP/SSE bind host |
-| `NSELF_MCP_AUTH_TOKEN` | (empty) | Optional bearer token for SSE requests |
-| `NSELF_MCP_MDNS_ENABLED` | `true` | Broadcast via mDNS |
-| `NSELF_MCP_ALLOW_MUTATIONS` | `false` | Enable `nself_migration_apply` tool |
-| `NSELF_MCP_ALLOW_SECRETS` | `false` | Allow `nself_env_get` to return secret keys |
-| `NSELF_FEATURE_MCP` | `false` | Feature flag , set to `true` to enable auto-start with `nself start` |
+| `NSELF_MCP_TOKEN` | (empty) | Optional bearer token required on `sse`/`http` requests. Unset means no auth check; stdio mode is unaffected. |
 
 ## Claude Code integration
 
@@ -44,55 +38,29 @@ Add to `.claude/settings.json` in your project root:
   "mcpServers": {
     "nself": {
       "command": "nself",
-      "args": ["mcp", "serve"]
+      "args": ["mcp"]
     }
   }
 }
 ```
 
-Claude Code will start the server automatically and expose all 9 tools in its tool context. You can then ask Claude Code questions like:
+Claude Code will start the server automatically and expose its full tool, resource, and prompt set in its tool context (see [[cmd-mcp]] for the generated list). You can then ask Claude Code questions like:
 
 - "What tables does this ɳSelf project have?"
-- "Show me the schema for np_ai_usage"
+- "What's the health status of this project?"
 - "Which plugins are installed?"
 - "Tail the hasura logs"
 - "What permissions does the 'user' role have?"
 
 ## Available MCP tools
 
-| Tool | Description |
-|---|---|
-| `nself_schema_list` | List all PostgreSQL tables in the project |
-| `nself_schema_describe` | Describe columns, types, and constraints for a table |
-| `nself_migration_list` | List migration history from `nself_migrations` |
-| `nself_migration_apply` | Apply a SQL migration (requires `NSELF_MCP_ALLOW_MUTATIONS=true`) |
-| `nself_permission_list` | List Hasura permissions for a Hasura role |
-| `nself_log_tail` | Tail recent logs from a Docker service container |
-| `nself_plugin_list` | List installed ɳSelf plugins |
-| `nself_plugin_describe` | Full details for a specific plugin |
-| `nself_env_get` | Read an env var (secret keys redacted unless `NSELF_MCP_ALLOW_SECRETS=true`) |
+The tool, resource, and prompt list is generated from source (`make mcp-docs`) rather than hand-maintained here, so it can't drift the way an earlier hand-listed table did. See [[cmd-mcp]] for the current, authoritative list.
 
 ## Security
 
 - HTTP/SSE transport binds to `127.0.0.1` by default. Never expose to `0.0.0.0` in production.
-- Secret env vars (`*SECRET*`, `*KEY*`, `*TOKEN*`, `*PASSWORD*`) are redacted by default.
-- `nself_migration_apply` requires explicit opt-in. Treat it as a privileged operation.
-- mDNS operates on the local network segment only.
-
-## Status check
-
-```bash
-nself mcp status
-```
-
-Reports the configured port, whether it is in use (server likely running), mDNS status, and mutation/secret flags.
-
-## Doctor integration
-
-`nself doctor` reports MCP server status:
-
-- `MCP-01`, MCP server process running (info)
-- `MCP-02`, Port 3825 not in conflict (warning)
+- Config values whose key contains `SECRET`, `PASSWORD`, `KEY`, or `TOKEN` are always redacted in tool output; there is no opt-out.
+- The migration-apply tool requires an explicit `confirm: true` argument on every call, and a DDL allowlist blocks destructive statements even then. Treat it as a privileged operation.
 
 ## Examples
 
@@ -110,6 +78,8 @@ None — `nself mcp` is a core CLI command, no plugin or license required.
 
 ## See also
 
-- [Plugin documentation](https://nself.org/plugins/mcp)
+- [[cmd-mcp]]: generated tool/resource/prompt reference for this command
 - [MCP specification](https://modelcontextprotocol.io/specification/2025-03-26)
-- [nself doctor](./cmd-doctor.md)
+- [[cmd-doctor]]
+
+Note: `nself.org/plugins/mcp` documents an unrelated paid plugin (`plugins-pro/paid/mcp`, ɳClaw/ClawDE bundles, its own port and tool set), not this core `nself mcp` command.


### PR DESCRIPTION
## Summary

Finishes the audit #262 flagged as a follow-up ("`.github/wiki/commands/mcp-serve.md` has more drift than the flags fixed here ... worth a dedicated doc pass"). Resolves the four unverified claims:

| Claim | Verdict | Evidence |
|---|---|---|
| Env vars: `NSELF_MCP_PORT/HOST/AUTH_TOKEN/MDNS_ENABLED/ALLOW_MUTATIONS/ALLOW_SECRETS`, `NSELF_FEATURE_MCP` | Not real for this command | `grep` across `cmd/`, `internal/`, `tools/` — zero hits for all seven. Only real var is `NSELF_MCP_TOKEN` (`cmd/commands/mcp_auth.go:26`) |
| mDNS broadcast (`_nself-mcp._tcp.local.`) | Removed feature, not present | `cmd/commands/mcp_test.go:36,45`: "the mDNS feature was removed (CLI-R15)"; no `mdns`/`zeroconf` symbol anywhere in `cmd/`/`internal/` |
| Doctor `MCP-01`/`MCP-02` checks | Does not exist | Zero hits for `MCP-01`/`MCP-02` anywhere in the repo; `internal/doctor/` has no MCP check at all |
| `curl /mcp/tools/list`, `/mcp/tools/call` | Already fixed by #262 | `git show 24ebedb1` confirms the curl examples were removed in that PR; the real SSE transport serves `/sse`+`/message` (JSON-RPC 2.0), the HTTP transport serves a single `/mcp` endpoint (`vendor/.../mcp-go/server/sse.go:410-411`, `streamable_http.go:340`) — no REST paths exist |

**Root cause found for items 1-3**: that content is real, but for a *different* product — `plugins-pro/paid/mcp` (`plugins-pro/paid/mcp/plugin.json`), a separate license-gated plugin on port 3828 with its own env vars, mDNS capability, and `doctor_checks` manifest entries (nclaw/clawde bundles). It got copied onto this page describing the free core `nself mcp` command (`cmd/commands/mcp.go`, CLI-R15, port 3825, no license required) and never removed.

## Changes

- Environment variables table: 7 fictional vars removed, kept only the real `NSELF_MCP_TOKEN`.
- Removed the "Status check" section (`nself mcp status` — no such subcommand, contradicts the page's own Synopsis) and "Doctor integration" section (checks don't exist; the plugin's own `doctor_checks` manifest field isn't even wired into `nself doctor` today).
- Fixed the MCP client config JSON: `args: ["mcp", "serve"]` -> `["mcp"]`.
- Replaced the stale 9-tool table (wrong tool names, doesn't match the ~26 tools actually registered in `cmd/commands/mcp.go`) with a pointer to `.github/wiki/cmd-mcp.md`, the generated, currently-accurate tool/resource/prompt inventory (`make mcp-docs`).
- Security section: removed the mDNS bullet, corrected the migration-tool description to match the real `confirm: true` + DDL-allowlist gate (no `NSELF_MCP_ALLOW_MUTATIONS` env var), reworded secret redaction as unconditional (matches `cmd/commands/config_helpers.go:isSecretKey`, no opt-out flag exists).
- "See also": swapped markdown links for the audited `[[wikilink]]` style, and added a note that `nself.org/plugins/mcp` is the separate paid plugin, not this command.

## Discoveries (not fixed here, out of this ticket's scope)

- `plugins-pro/paid/mcp`'s own wiki page (`.github/wiki/plugin-mcp.md`) disagrees with its own `plugin.json` manifest (different port: 3825 vs 3828 in the manifest; different env vars: `DATABASE_URL`/`NSELF_LICENSE_KEY`/`PORT`/`MCP_TRANSPORT` vs the manifest's `NSELF_MCP_*` vars; different tool list). Worth its own audit pass.
- `plugin.json`'s `doctor_checks` field (`MCP-01`/`MCP-02`) isn't consumed by any Go code — it's dead manifest data even for the plugin it actually belongs to.
- `.github/wiki/commands/mcp-serve.md` living in a `commands/` subdirectory is inconsistent with the locked `cmd-<name>.md` naming convention (T03 template) that `cmd-mcp.md` (the generated page for the same command) already follows.

## Test plan

- [x] `make wiki-check` — exit 0: "All 49 wiki command pages are current." / "Wiki link audit passed: 302 distinct targets, all resolve."
- [x] `bash scripts/ci/wiki-link-audit.sh` — exit 0, same result
- [x] `bash scripts/ci/flag-drift-audit.sh` — exit 0: "2467 invocation(s) checked across 421 file(s), 0 unregistered flags"