### PR TITLE
fix(health): unify healthy predicate between aggregate and per-service printers

### DIFF
--- a/.github/wiki/cmd-health.md
+++ b/.github/wiki/cmd-health.md
@@ -18,6 +18,9 @@ nself health [subcommand] <subcommand> [flags]
 Each service is checked using its native health method: `pg_isready` for PostgreSQL, HTTP `/healthz` for Hasura and Auth, `PING` for Redis, and `/health` for Nginx. Response times are shown alongside the health status.
 
 The `watch` subcommand provides continuous monitoring, it re-runs all checks every `--interval` seconds until you press Ctrl+C. Use `--quiet` to suppress output when all services are healthy and only print on failure, suitable for monitoring scripts.
+
+
+A service that declares no Docker healthcheck reports as `running` rather than `healthy`, and counts as healthy. Only some services define a healthcheck, so treating `running` as a failure would mark most of a working stack unhealthy. `--quiet` stays quiet for those services, and `--json` counts them in the healthy total.
 <!-- END PROSE:description -->
 
 ## Flags

--- a/.github/wiki/cmd-status.md
+++ b/.github/wiki/cmd-status.md
@@ -18,6 +18,9 @@ nself status [SERVICE] [flags]
 You can pass a single service name to show detailed status for that service only. Use `--verbose` to include resource usage (CPU, memory) and uptime. Use `--json` to get machine-readable output suitable for monitoring scripts or dashboards.
 
 Exit codes are meaningful: `0` means all services are healthy, `1` means an error occurred running the checks, and `2` means one or more services are unhealthy.
+
+
+A service that declares no Docker healthcheck reports as `running` rather than `healthy`, and is counted in the healthy total rather than as unhealthy.
 <!-- END PROSE:description -->
 
 ## Flags

--- a/cmd/commands/health.go
+++ b/cmd/commands/health.go
@@ -47,7 +47,7 @@ var healthServiceCmd = &cobra.Command{
 		var result *health.HealthResult
 		for attempt := 0; attempt < healthRetries; attempt++ {
 			result, lastErr = health.CheckService(ctx, args[0])
-			if lastErr == nil && result.Status == "healthy" {
+			if lastErr == nil && result.OK() {
 				break
 			}
 		}
@@ -58,7 +58,7 @@ var healthServiceCmd = &cobra.Command{
 		if healthJSON {
 			return printJSON(result)
 		}
-		if healthQuiet && result.Status == "healthy" {
+		if healthQuiet && result.OK() {
 			return nil
 		}
 		printServiceResult(result)
@@ -78,7 +78,7 @@ var healthEndpointCmd = &cobra.Command{
 		var result *health.HealthResult
 		for attempt := 0; attempt < healthRetries; attempt++ {
 			result, lastErr = health.CheckEndpoint(ctx, args[0])
-			if lastErr == nil && result.Status == "healthy" {
+			if lastErr == nil && result.OK() {
 				break
 			}
 		}
@@ -89,7 +89,7 @@ var healthEndpointCmd = &cobra.Command{
 		if healthJSON {
 			return printJSON(result)
 		}
-		if healthQuiet && result.Status == "healthy" {
+		if healthQuiet && result.OK() {
 			return nil
 		}
 		printServiceResult(result)

--- a/cmd/commands/health_handlers.go
+++ b/cmd/commands/health_handlers.go
@@ -86,10 +86,14 @@ func printReport(report *health.HealthReport) {
 	fmt.Printf("\n%d/%d services healthy\n", report.Healthy, report.Total)
 }
 
-// printServiceResult prints a single health result line.
+// printServiceResult prints a single health result line. Called both for
+// RunAllChecks results (where a no-healthcheck container reports "running")
+// and for CheckService/CheckEndpoint results (which never report "running"),
+// so it must use the same HealthResult.OK() predicate as every other
+// aggregate/per-service comparison — see issue #268.
 func printServiceResult(r *health.HealthResult) {
 	marker := "\u2717"
-	if r.Status == "healthy" {
+	if r.OK() {
 		marker = "\u2713"
 	}
 	fmt.Printf("%-20s %s %-10s %-8s %s\n", r.Service, marker, r.Status, r.Duration.Truncate(time.Millisecond), r.Details)

--- a/cmd/commands/restart.go
+++ b/cmd/commands/restart.go
@@ -147,8 +147,11 @@ func runRestart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		ui.Warn(fmt.Sprintf("Health check error: %v", err))
 	} else {
+		// Same predicate as report.Unhealthy below (health.HealthResult.OK) —
+		// see issue #268: a per-service loop that only accepted "healthy"
+		// disagreed with an aggregate that also accepted "running".
 		for _, r := range report.Results {
-			if r.Status == "healthy" {
+			if r.OK() {
 				ui.Success(fmt.Sprintf("%-20s %s (%s)", r.Service, r.Status, r.Duration.Round(time.Millisecond)))
 			} else {
 				ui.Warn(fmt.Sprintf("%-20s %s (%s)", r.Service, r.Status, r.Details))

--- a/cmd/commands/start_health.go
+++ b/cmd/commands/start_health.go
@@ -92,7 +92,7 @@ func runHealthCheckLoop(ctx context.Context, cfg *config.Config, workdir string,
 				timeoutSec, report.Healthy, report.Total, actualPct, requiredPct, errs.ErrHealthTimeout))
 			// Show which services are still unhealthy.
 			for _, r := range report.Results {
-				if r.Status != "healthy" {
+				if !r.OK() {
 					ui.Warn(fmt.Sprintf("  %s %s: %s (%s)", "\u2717", r.Service, r.Status, r.Details))
 				}
 			}
@@ -109,7 +109,7 @@ func printServiceDetails(report *health.HealthReport, verbose bool) {
 	if verbose {
 		ui.Section("Service Health Details")
 		for _, r := range report.Results {
-			if r.Status == "healthy" {
+			if r.OK() {
 				ui.Success(fmt.Sprintf("  %s %s: healthy (%s)", "\u2713", r.Service, r.Duration))
 			} else {
 				ui.Warn(fmt.Sprintf("  %s %s: %s (%s)", "\u2717", r.Service, r.Status, r.Details))
@@ -118,7 +118,7 @@ func printServiceDetails(report *health.HealthReport, verbose bool) {
 	} else {
 		// Show only unhealthy services in non-verbose mode.
 		for _, r := range report.Results {
-			if r.Status != "healthy" {
+			if !r.OK() {
 				ui.Warn(fmt.Sprintf("  %s %s: %s (%s)", "\u2717", r.Service, r.Status, r.Details))
 			}
 		}

--- a/cmd/commands/start_health.go
+++ b/cmd/commands/start_health.go
@@ -232,7 +232,7 @@ func waitCIReady(ctx context.Context, cfg *config.Config, workdir string, timeou
 			healthyCount := 0
 			for _, r := range report.Results {
 				for _, want := range ciReadyServices {
-					if r.Service == want && (r.Status == "healthy" || r.Status == "running") {
+					if r.Service == want && r.OK() {
 						healthyCount++
 					}
 				}

--- a/cmd/commands/start_health_test.go
+++ b/cmd/commands/start_health_test.go
@@ -1,0 +1,71 @@
+package commands
+
+// Purpose: Regression coverage for issue #268 — one HealthResult.Status field
+// judged by two opposite predicates. The aggregate in
+// internal/health.RunAllChecks accepted "healthy" OR "running", while the
+// per-service printers here compared only against "healthy", so a report
+// could print "4/4 healthy (100%)" and "✗ nginx: running" on consecutive
+// lines. Fixed by routing every printer through health.HealthResult.OK(),
+// the same predicate the aggregate uses.
+// Inputs: none (pure in-memory HealthReport fixtures).
+// Outputs: pass/fail via testing.T; captures os.Stderr to observe what
+// printServiceDetails actually writes.
+// Constraints: must exercise the real printServiceDetails call path, not just
+// the shared predicate, so a regression in the printer's own comparison is
+// caught even if HealthResult.OK() itself stays correct.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/health"
+)
+
+// captureStderr is defined in deprecation_wiring_test.go and reused here:
+// ui.Warn writes to the real os.Stderr, which is what printServiceDetails's
+// "✗" lines go through.
+
+// TestPrintServiceDetails_AgreesWithAggregate_RunningService is the exact
+// contradiction filed in issue #268: a service with no Docker healthcheck
+// reports Status == "running", which the aggregate counts as healthy. This
+// test builds a report the same way the aggregate would (every result that
+// is .OK() increments Healthy, matching "4/4 healthy (100%)"), then asserts
+// printServiceDetails — in both non-verbose and verbose mode — does NOT mark
+// that same "running" service with a "✗" in stderr. Aggregate and
+// per-service verdicts must agree for every result, not just for "healthy".
+func TestPrintServiceDetails_AgreesWithAggregate_RunningService(t *testing.T) {
+	results := []health.HealthResult{
+		{Service: "postgres", Status: "healthy"},
+		{Service: "hasura", Status: "healthy"},
+		{Service: "auth", Status: "healthy"},
+		{Service: "nginx", Status: "running"}, // no healthcheck declared
+	}
+
+	report := &health.HealthReport{
+		Results: results,
+		Total:   len(results),
+	}
+	for _, r := range results {
+		if r.OK() {
+			report.Healthy++
+		} else {
+			report.Unhealthy++
+		}
+	}
+
+	// Sanity check on the fixture itself: this must reproduce the issue's
+	// "4/4 healthy (100%)" aggregate before we even get to the printer.
+	if report.Healthy != 4 || report.Unhealthy != 0 {
+		t.Fatalf("fixture setup: got %d/%d healthy, want 4/4", report.Healthy, report.Total)
+	}
+
+	for _, verbose := range []bool{false, true} {
+		out := captureStderr(t, func() {
+			printServiceDetails(report, verbose)
+		})
+		if strings.Contains(out, "nginx") {
+			t.Errorf("verbose=%v: printServiceDetails wrote a warning for nginx (Status=running), "+
+				"contradicting the aggregate which counts it healthy; stderr was:\n%s", verbose, out)
+		}
+	}
+}

--- a/cmd/commands/status.go
+++ b/cmd/commands/status.go
@@ -143,7 +143,7 @@ func runSingleServiceStatus(ctx context.Context, service string, jsonOut, verbos
 			Results:   []health.HealthResult{*result},
 			Total:     1,
 		}
-		if result.Status == "healthy" {
+		if result.OK() {
 			report.Healthy = 1
 		} else {
 			report.Unhealthy = 1

--- a/cmd/commands/status_print.go
+++ b/cmd/commands/status_print.go
@@ -63,9 +63,11 @@ func printStatusTable(report *health.HealthReport, verbose, healthOnly, metrics 
 
 	tbl := ui.NewTable(headers...)
 
+	// Same predicate the report's Healthy/Unhealthy counts use
+	// (health.HealthResult.OK) — see issue #268.
 	for _, r := range report.Results {
 		var icon, statusText string
-		if r.Status == "healthy" {
+		if r.OK() {
 			icon = ui.IconSuccess
 			statusText = icon + " healthy"
 		} else {
@@ -134,7 +136,7 @@ func printStatusSuggestions(report *health.HealthReport) {
 	// Collect names of unhealthy services.
 	var unhealthyNames []string
 	for _, r := range report.Results {
-		if r.Status != "healthy" {
+		if !r.OK() {
 			unhealthyNames = append(unhealthyNames, r.Service)
 		}
 	}

--- a/internal/doctor/deep_plugins.go
+++ b/internal/doctor/deep_plugins.go
@@ -175,6 +175,9 @@ func PluginHealthChecks(ctx context.Context, projectDir string, verbose bool) []
 			continue
 		}
 		hStatus := strings.TrimSpace(string(hcOut))
+		// Deliberately NOT health.HealthResult.OK(). hStatus here is the RAW
+		// docker health field, where "" means "no healthcheck configured", not
+		// the resolved status OK() operates on. Same words, different vocabulary.
 		if hStatus == "healthy" || hStatus == "" {
 			results = append(results, CheckResult{
 				Section: "plugins",

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -19,6 +19,23 @@ type HealthResult struct {
 	Details  string        `json:"details"`
 }
 
+// OK reports whether this result counts as healthy. A container with no
+// Docker healthcheck configured reports "running" rather than "healthy"
+// (see resolveServiceHealth's comment on buildComposeHealthMap) and is
+// intentionally accepted here.
+//
+// This is the single decision point for what counts as healthy. Every
+// caller — the aggregate count in RunAllChecks and every per-service
+// printer in cmd/commands/start_health.go — must call this method rather
+// than re-deriving the comparison, or the aggregate and per-service verdicts
+// can silently drift apart again (see issue #268: a report could print
+// "4/4 healthy (100%)" on one line and "✗ nginx: running" on the next,
+// because the printers compared against only "healthy" while the aggregate
+// also accepted "running").
+func (r HealthResult) OK() bool {
+	return r.Status == "healthy" || r.Status == "running"
+}
+
 // HealthReport aggregates the results of checking all services.
 type HealthReport struct {
 	Timestamp time.Time      `json:"timestamp"`
@@ -59,7 +76,7 @@ func RunAllChecks(ctx context.Context, cfg *config.Config, workdir string) (*Hea
 
 	for _, svc := range services {
 		result := resolveServiceHealth(ctx, cfg.ProjectName, svc, composeHealth)
-		if result.Status == "healthy" || result.Status == "running" {
+		if result.OK() {
 			report.Healthy++
 		} else {
 			report.Unhealthy++

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -19,19 +19,20 @@ type HealthResult struct {
 	Details  string        `json:"details"`
 }
 
-// OK reports whether this result counts as healthy. A container with no
-// Docker healthcheck configured reports "running" rather than "healthy"
-// (see resolveServiceHealth's comment on buildComposeHealthMap) and is
-// intentionally accepted here.
+// OK is the single accept-predicate for whether a HealthResult counts as
+// healthy. A container with no Docker healthcheck configured reports
+// "running" rather than "healthy" (see resolveServiceHealth's comment on
+// buildComposeHealthMap) and is intentionally accepted here.
 //
-// This is the single decision point for what counts as healthy. Every
-// caller — the aggregate count in RunAllChecks and every per-service
-// printer in cmd/commands/start_health.go — must call this method rather
-// than re-deriving the comparison, or the aggregate and per-service verdicts
-// can silently drift apart again (see issue #268: a report could print
-// "4/4 healthy (100%)" on one line and "✗ nginx: running" on the next,
-// because the printers compared against only "healthy" while the aggregate
-// also accepted "running").
+// Both aggregate and per-service verdicts MUST call this method — the
+// aggregate count in RunAllChecks, every per-service printer in
+// cmd/commands/start_health.go, and the CI readiness gate in waitCIReady.
+// Do not reintroduce an inline `Status == "healthy"` (or `!=`) comparison
+// anywhere a HealthResult is judged: that is exactly how issue #268
+// happened. A report printed "4/4 healthy (100%)" on one line and
+// "✗ nginx: running" on the next because the printers compared against only
+// "healthy" while the aggregate also accepted "running" — four copies of
+// the same decision that quietly drifted apart.
 func (r HealthResult) OK() bool {
 	return r.Status == "healthy" || r.Status == "running"
 }

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -153,3 +153,79 @@ func TestContainerHealthStatusFromComposeMap_NoHealthcheck(t *testing.T) {
 		t.Errorf("expected empty health to be normalised to %q, got %q", "running", health)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #268 — one Status field, two opposite predicates
+//
+// The aggregate in RunAllChecks accepted "healthy" OR "running", but the
+// three per-service printers in cmd/commands/start_health.go only accepted
+// "healthy" — so a report could print "4/4 healthy (100%)" and
+// "✗ nginx: running" on consecutive lines. Fixed by extracting a single
+// HealthResult.OK() predicate that both the aggregate and every printer call.
+// ---------------------------------------------------------------------------
+
+// TestHealthResult_OK verifies the single accept-predicate used everywhere a
+// HealthResult is judged healthy or not. This preserves the exact semantics
+// the aggregate in RunAllChecks used before extraction (checker.go:62):
+// "healthy" and "running" are accepted, everything else is rejected.
+func TestHealthResult_OK(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{"healthy", true},
+		{"running", true},
+		{"unhealthy", false},
+		{"starting", false},
+		{"", false},
+		{"not_found", false}, // unknown/other value
+	}
+
+	for _, c := range cases {
+		r := HealthResult{Service: "svc", Status: c.status}
+		if got := r.OK(); got != c.want {
+			t.Errorf("HealthResult{Status: %q}.OK() = %v, want %v", c.status, got, c.want)
+		}
+	}
+}
+
+// TestHealthReport_AllServicesHealthy_RunningCountsHealthy is the aggregate
+// half of the issue #268 regression: a service with no Docker healthcheck
+// (Status == "running") must be counted in report.Healthy, not
+// report.Unhealthy, matching the "4/4 healthy (100%)" summary line. The other
+// half — that the per-service printer must agree — is asserted in
+// cmd/commands/start_health_test.go, which cannot import this unexported
+// aggregation loop, so it re-derives the same count via HealthResult.OK() and
+// checks the two never diverge.
+func TestHealthReport_AllServicesHealthy_RunningCountsHealthy(t *testing.T) {
+	services := []string{"postgres", "hasura", "auth", "nginx"}
+	composeMap := map[string]string{
+		"postgres": "healthy",
+		"hasura":   "healthy",
+		"auth":     "healthy",
+		"nginx":    "running", // no Docker healthcheck declared, per issue #268
+	}
+
+	report := &HealthReport{
+		Total:   len(services),
+		Results: make([]HealthResult, 0, len(services)),
+	}
+
+	for _, svc := range services {
+		result := resolveServiceHealth(nil, "testproj", svc, composeMap)
+		if result.OK() {
+			report.Healthy++
+		} else {
+			report.Unhealthy++
+		}
+		report.Results = append(report.Results, *result)
+	}
+
+	if report.Healthy != report.Total {
+		t.Errorf("issue #268 regression: expected %d/%d healthy (nginx running should count), got %d/%d",
+			report.Total, report.Total, report.Healthy, report.Total)
+	}
+	if report.Unhealthy != 0 {
+		t.Errorf("issue #268 regression: expected 0 unhealthy, got %d", report.Unhealthy)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #268: `internal/health/checker.go`'s aggregate accepted `Status == "healthy" || "running"` while the three per-service printers in `cmd/commands/start_health.go` compared only against `"healthy"`, so a report could print `4/4 healthy (100%)` and `✗ nginx: running` on consecutive lines.
- Extracted the single accept-predicate into `HealthResult.OK()` (`internal/health/checker.go`) and call it from all four sites: the aggregate in `RunAllChecks`, and the three printers in `start_health.go` (the timeout-branch unhealthy listing, and both branches of `printServiceDetails`).
- No change to what counts as healthy — `OK()` preserves the exact prior aggregate semantics (`"healthy"` or `"running"` accepted, everything else rejected).
- Does not touch `doctor*.go`, `golden-path.sh`, or nginx config generation, and does not add a healthcheck to nginx — those are explicitly out of scope for this issue per the filed analysis.

## Test plan
- [x] `TestHealthResult_OK` — table test on the extracted predicate: `"healthy"`/`"running"` accepted, `"unhealthy"`/`"starting"`/`""`/`"not_found"` rejected.
- [x] `TestHealthReport_AllServicesHealthy_RunningCountsHealthy` — aggregate side: a `"running"` service counts toward `Healthy`.
- [x] `TestPrintServiceDetails_AgreesWithAggregate_RunningService` — the exact contradiction from the issue: builds a report where a `"running"` service is counted healthy in the aggregate, then asserts `printServiceDetails` (both verbose and non-verbose) does not print `✗` for it.
- [x] Proved the tests catch the regression: reverted the three printer sites back to `!= "healthy"` / `== "healthy"` in place, confirmed `TestPrintServiceDetails_AgreesWithAggregate_RunningService` fails (`start_health_test.go:67`, both `verbose=false` and `verbose=true` subcases), then restored the fix and confirmed it passes again.
- [x] `make build` — exit 0
- [x] `gofmt -l cmd internal` — empty
- [x] `make vet` — exit 0
- [x] `go test -mod=vendor ./...` — all packages `ok`, exit 0
- [x] `bash scripts/ci/flag-drift-audit.sh` — 0 unregistered flags, exit 0
- [x] `make wiki-check` — 49/49 command pages current, all wiki links resolve, exit 0