### PR TITLE
fix(ci): quarterly benchmarks fired ~10x per quarter, not once

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,8 +16,39 @@ permissions:
   pull-requests: write
 
 jobs:
+  # cron ORs day-of-month with day-of-week when both are restricted, so
+  # "0 7 1-7 3,6,9,12 1" matches the 1st-7th AND every Monday of those months,
+  # not the first Monday. That is roughly ten fires per quarter instead of one,
+  # each a 30-minute job holding contents:write and pull-requests:write.
+  # Same defect the DR drill reminder carried until #235.
+  #
+  # Gating as a separate job keeps the condition in one place rather than
+  # repeating `if:` on every step of the benchmark job.
+  gate:
+    name: First Monday check
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - id: check
+        run: |
+          DOM=$(date -u +%-d)
+          DOW=$(date -u +%u)   # 1 = Monday
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "manual dispatch — bypassing the first-Monday gate"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          elif [ "$DOW" -eq 1 ] && [ "$DOM" -le 7 ]; then
+            echo "first Monday (dom=${DOM}) — proceeding"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "not the first Monday (dom=${DOM} dow=${DOW}) — skipping benchmarks"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   benchmark:
     name: Run Benchmarks
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
Found by the gate sweep (issues #268, #270 are the other findings).

## The bug

```yaml
# First Monday of March, June, September, December at 07:00 UTC
- cron: "0 7 1-7 3,6,9,12 1"
```

cron **ORs** day-of-month with day-of-week when both are restricted. So this matches the 1st-7th **and** every Monday of those months — roughly **ten fires per quarter instead of one**, each a 30-minute job holding `contents: write` and `pull-requests: write`.

Identical to the defect the DR drill reminder carried until #235. That one was caught because it visibly opened ten duplicate issues; this one just quietly burned Actions minutes.

## Fix

Adds the missing first-Monday gate as a **separate job** rather than an `if:` on each step, so the condition lives in one place and a step added later cannot forget it. `workflow_dispatch` still bypasses.

## Verification

- YAML parses; `benchmark` carries `needs: gate` and `if: needs.gate.outputs.proceed == 'true'`
- gate logic evaluated for today (dom=26, dow=3) → **skip**, which is correct

## Sweep context

Every cron across all 14 org repos was checked for a restricted DOM combined with a restricted DOW. Two hits: `dr-drill-reminder.yml` (already mitigated in #235, though its cron is still misleading) and this one, which was unmitigated.