### PR TITLE
fix(nginx): TLS crash-loop from a non-root master that cannot read the certs

### DIFF
--- a/internal/compose/core_services_auth_nginx.go
+++ b/internal/compose/core_services_auth_nginx.go
@@ -133,9 +133,26 @@ func (g *Generator) buildNginxService(dc *DockerCompose) ServiceConfig {
 		Image:         ResolveImage("nginx", "nginx:alpine"),
 		ContainerName: fmt.Sprintf("%s_nginx", cfg.ProjectName),
 		Restart:       "unless-stopped",
-		User:          "101:101",
-		Networks:      []string{cfg.DockerNetwork},
-		DependsOn:     dependsOn,
+		// No User override on purpose. The nginx.conf this same tool generates
+		// declares `user nginx;` on line 4, which requires the MASTER process to
+		// start as root: it reads the TLS material and binds 80/443, then drops
+		// the workers to the nginx user itself.
+		//
+		// Forcing User: "101:101" here contradicted that config, and nginx said
+		// so on every boot ("the \"user\" directive makes sense only if the master
+		// process runs with super-user privileges, ignored"). It also broke TLS
+		// outright: ./ssl is bind-mounted, so the certificates keep their host
+		// ownership and mode, and uid 101 is neither their owner nor in their
+		// group. nginx died with
+		//   [emerg] cannot load certificate ".../fullchain.pem": Permission denied
+		// and crash-looped, on any host whose invoking uid is not 101 -- which on
+		// Linux is every host. Docker Desktop on macOS masks it by remapping
+		// ownership, so it only showed up on Linux and in CI.
+		//
+		// Workers still run unprivileged; the tmpfs uid/gid below stay 101 to
+		// match them.
+		Networks:  []string{cfg.DockerNetwork},
+		DependsOn: dependsOn,
 		Environment: map[string]string{
 			"BASE_DOMAIN":  cfg.BaseDomain,
 			"PROJECT_NAME": cfg.ProjectName,

--- a/internal/compose/nginx_user_test.go
+++ b/internal/compose/nginx_user_test.go
@@ -1,0 +1,67 @@
+package compose
+
+import "testing"
+
+// TestNginxMasterRunsAsRoot pins the fix for the TLS crash-loop.
+//
+// The nginx.conf this same tool generates declares `user nginx;` on line 4,
+// which only takes effect when the MASTER process starts as root: it reads the
+// TLS material and binds 80/443, then drops the workers to the nginx user.
+//
+// Setting User: "101:101" on the compose service contradicted that config, and
+// nginx said so on every boot ("the \"user\" directive makes sense only if the
+// master process runs with super-user privileges, ignored"). It also broke TLS
+// outright. ./ssl is bind-mounted, so certificates keep their host ownership
+// and mode; uid 101 is neither their owner nor in their group, so nginx died
+// with
+//
+//	[emerg] cannot load certificate ".../fullchain.pem": Permission denied
+//
+// and crash-looped on every host whose invoking uid is not 101, which on Linux
+// is all of them. Docker Desktop on macOS remaps ownership and hid it, so this
+// only ever surfaced on Linux and in CI, where it timed out the golden path's
+// service-health wait for weeks.
+//
+// If a User override is reintroduced here, this fails instead of shipping a
+// stack whose reverse proxy never starts.
+func TestNginxMasterRunsAsRoot(t *testing.T) {
+	cfg := minimalCfg()
+	g := NewGenerator(cfg)
+	svc := g.buildNginxService(&DockerCompose{Services: map[string]ServiceConfig{}})
+
+	if svc.User != "" {
+		t.Errorf("nginx service sets User=%q, but the generated nginx.conf "+
+			"declares `user nginx;` and needs a root master to read the "+
+			"bind-mounted TLS material and bind 80/443. A non-root master "+
+			"cannot read fullchain.pem and nginx crash-loops.", svc.User)
+	}
+}
+
+// TestNginxWorkersStayUnprivileged guards the other half: removing the User
+// override must not also remove the tmpfs uid/gid that match the unprivileged
+// workers the config drops to.
+func TestNginxWorkersStayUnprivileged(t *testing.T) {
+	cfg := minimalCfg()
+	g := NewGenerator(cfg)
+	svc := g.buildNginxService(&DockerCompose{Services: map[string]ServiceConfig{}})
+
+	if len(svc.Tmpfs) == 0 {
+		t.Fatal("nginx service declares no tmpfs; workers need writable cache and run dirs")
+	}
+	for _, m := range svc.Tmpfs {
+		if !contains(m, "uid=101") || !contains(m, "gid=101") {
+			t.Errorf("tmpfs %q should be owned by the unprivileged nginx worker (uid=101,gid=101)", m)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/internal/ssl/generator_trust.go
+++ b/internal/ssl/generator_trust.go
@@ -154,7 +154,12 @@ func copyMkcertCerts(srcFullchain, srcPrivkey, destDir string) error {
 	if err != nil {
 		return fmt.Errorf("reading %s: %w", srcFullchain, err)
 	}
-	if err := os.WriteFile(filepath.Join(destDir, "fullchain.pem"), chainData, 0640); err != nil {
+	// 0644: fullchain.pem is the public certificate chain, not a secret. It is
+	// served to every client that connects, so restricting reads buys nothing
+	// and breaks any consumer running under a different uid (nginx in its
+	// container being the one that matters here). privkey.pem below stays
+	// restricted, which is the file that actually needs it.
+	if err := os.WriteFile(filepath.Join(destDir, "fullchain.pem"), chainData, 0644); err != nil {
 		return fmt.Errorf("writing fullchain.pem to %s: %w", destDir, err)
 	}
 


### PR DESCRIPTION
nginx crash-looped on every Linux host with SSL enabled:

  [emerg] cannot load certificate "/etc/nginx/ssl/certificates/local-nself-org/
  fullchain.pem": BIO_new_file() failed (Permission denied)

Two things had to be true for that, and both were ours.

The compose service set User: "101:101" while the nginx.conf this same tool
generates declares `user nginx;` on line 4. That directive only takes effect
when the MASTER starts as root: it reads the TLS material and binds 80/443,
then drops the workers itself. nginx reported the contradiction on every boot
("the \"user\" directive makes sense only if the master process runs with
super-user privileges, ignored in /etc/nginx/nginx.conf:4") and nobody read it.

./ssl is bind-mounted, so certificates keep their host ownership and mode.
fullchain.pem was written 0640, and uid 101 is neither its owner nor in its
group, so the master could not open it and exited. Docker Desktop on macOS
remaps ownership and hid this, so it only ever appeared on Linux and in CI.

Removes the User override so the master runs as root and workers drop to nginx
per the generated config, and writes fullchain.pem 0644. That file is the
public certificate chain, served to every client that connects, so restricting
reads bought nothing. privkey.pem stays restricted; it is the one that matters.
The tmpfs uid/gid stay 101 to match the unprivileged workers.

This is what timed out the golden path's service-health wait: doctor's
checkContainerHealth fails any container whose state is not "running", and
nginx sat in Restarting.

Verified by mutation: reinstating the User override fails
TestNginxMasterRunsAsRoot.