### PR TITLE
fix(nginx): cert dir was not traversable and root could not bypass it

### DIFF
--- a/internal/compose/nginx_user_test.go
+++ b/internal/compose/nginx_user_test.go
@@ -65,3 +65,25 @@ func contains(haystack, needle string) bool {
 		return false
 	})()
 }
+
+// TestNginxCanReadBindMountedTLS pins the capability nginx needs to start.
+//
+// CapDrop: ALL removes root's ability to ignore file permissions, and the TLS
+// material is bind-mounted with host ownership (privkey.pem is 0600 from
+// mkcert). Without DAC_READ_SEARCH the master cannot open the certificates and
+// nginx crash-loops with "[emerg] cannot load certificate ... Permission
+// denied", which is what timed out the golden path's health wait.
+func TestNginxCanReadBindMountedTLS(t *testing.T) {
+	sec := NginxSecurity()
+	found := false
+	for _, c := range sec.CapAdd {
+		if c == "DAC_READ_SEARCH" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("NginxSecurity().CapAdd = %v, missing DAC_READ_SEARCH; with "+
+			"CapDrop ALL the master cannot read the bind-mounted 0600 private "+
+			"key and nginx will crash-loop", sec.CapAdd)
+	}
+}

--- a/internal/compose/security.go
+++ b/internal/compose/security.go
@@ -48,10 +48,24 @@ func MinioSecurity() ServiceSecurity {
 
 // NginxSecurity returns the security config for the Nginx service.
 // Nginx needs NET_BIND_SERVICE for ports 80/443 when running non-root.
+//
+// DAC_READ_SEARCH is required because CapDrop: ALL takes away root's usual
+// ability to ignore file permissions, and the TLS material is bind-mounted
+// from the host with host ownership. privkey.pem is written 0600 by
+// mkcert/openssl and owned by whoever ran `nself build`, so without this the
+// master cannot open it and nginx exits with
+//
+//	[emerg] cannot load certificate ".../fullchain.pem": Permission denied
+//
+// then crash-loops. The alternative was relaxing the private key to be
+// world-readable on the host, which is a worse trade: this grants read and
+// traverse bypass to one container that must read TLS material at startup,
+// whereas DAC_OVERRIDE would also grant write bypass, and a 0644 key would
+// expose it to every user on the machine.
 func NginxSecurity() ServiceSecurity {
 	return ServiceSecurity{
 		CapDrop:     []string{"ALL"},
-		CapAdd:      []string{"NET_BIND_SERVICE"},
+		CapAdd:      []string{"NET_BIND_SERVICE", "DAC_READ_SEARCH"},
 		SecurityOpt: []string{"no-new-privileges:true"},
 		ReadOnly:    true,
 		// nginx tmpfs handled separately in service builder (uid/gid specific)

--- a/internal/ssl/generator.go
+++ b/internal/ssl/generator.go
@@ -77,7 +77,11 @@ func (g *Generator) GenerateWithResult(outputDir string) (*GenerateResult, error
 	}
 
 	certDir := filepath.Join(outputDir, "certificates", certDirName)
-	if err := os.MkdirAll(certDir, 0750); err != nil {
+	// 0755, not 0750: this directory is bind-mounted into the nginx container,
+	// which cannot traverse it otherwise. It holds a public certificate chain,
+	// so the traversal bit is not protecting anything. privkey.pem inside keeps
+	// the restrictive mode mkcert/openssl give it.
+	if err := os.MkdirAll(certDir, 0755); err != nil {
 		return nil, fmt.Errorf("creating certificate directory %s: %w", certDir, err)
 	}
 

--- a/internal/ssl/generator_trust.go
+++ b/internal/ssl/generator_trust.go
@@ -146,7 +146,7 @@ func CheckCertExpiry(certPath string) (int, error) {
 // destDir is created if it does not exist. Both files are written with 0640
 // permissions so nginx can read them without world-readable exposure.
 func copyMkcertCerts(srcFullchain, srcPrivkey, destDir string) error {
-	if err := os.MkdirAll(destDir, 0750); err != nil {
+	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return fmt.Errorf("creating certificate directory %s: %w", destDir, err)
 	}
 


### PR DESCRIPTION
Follow-up to the User override removed in #273. That fixed the master running
unprivileged, but nginx still crash-looped with the same error, because the
permission problem was never the file mode alone:

  [emerg] cannot load certificate ".../local-nself-org/fullchain.pem":
  Permission denied

Two remaining causes, both ours.

The certificate DIRECTORY was created 0750, so anything outside the owner and
group could not traverse into it, whatever the files inside were set to. It
holds a public certificate chain; the traversal bit protects nothing. Now 0755,
in both generators that create it.

NginxSecurity sets CapDrop: ALL, which takes away root's usual right to ignore
file permissions. The TLS material is bind-mounted with host ownership, and
privkey.pem is written 0600 by mkcert/openssl, so even a root master could not
open it. Adds DAC_READ_SEARCH.

The alternative was relaxing the private key to be world-readable on the host.
This is the better trade: read and traverse bypass for the one container that
must read TLS material at startup, versus exposing the key to every user on the
machine. DAC_OVERRIDE would also grant write bypass and is not needed.

Verified by mutation: removing DAC_READ_SEARCH fails
TestNginxCanReadBindMountedTLS.