### PR TITLE
fix(nginx): tmpfs was writable by the workers but not the root master

### DIFF
--- a/internal/compose/core_services_auth_nginx.go
+++ b/internal/compose/core_services_auth_nginx.go
@@ -170,9 +170,22 @@ func (g *Generator) buildNginxService(dc *DockerCompose) ServiceConfig {
 			"./nginx/includes:/etc/nginx/includes:ro",
 			"./ssl:/etc/nginx/ssl:ro",
 		},
+		// mode=0777 because two different uids write here. The master starts as
+		// root (the generated nginx.conf declares `user nginx;`, which requires
+		// it) and creates /var/cache/nginx/client_temp and the pid file at
+		// startup; the workers it forks run as uid 101 and write to the same
+		// paths afterwards. CapDrop: ALL removes root's write bypass, so a tmpfs
+		// owned by 101 alone left the master unable to mkdir and nginx exited:
+		//   [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
+		//
+		// The uid/gid stay 101 so the workers own what they create. These are
+		// per-container tmpfs mounts holding scratch state, not a boundary
+		// between principals, so the permissive mode costs nothing. Widening
+		// the capability set to DAC_OVERRIDE instead would grant write bypass
+		// across the whole filesystem to fix two scratch directories.
 		Tmpfs: []string{
-			"/var/cache/nginx:uid=101,gid=101",
-			"/var/run:uid=101,gid=101",
+			"/var/cache/nginx:uid=101,gid=101,mode=0777",
+			"/var/run:uid=101,gid=101,mode=0777",
 		},
 		Healthcheck: &Healthcheck{
 			Test:        []string{"CMD-SHELL", "wget --no-check-certificate --no-verbose --tries=1 -O /dev/null https://127.0.0.1/health 2>/dev/null || exit 1"},

--- a/internal/compose/nginx_user_test.go
+++ b/internal/compose/nginx_user_test.go
@@ -52,6 +52,14 @@ func TestNginxWorkersStayUnprivileged(t *testing.T) {
 		if !contains(m, "uid=101") || !contains(m, "gid=101") {
 			t.Errorf("tmpfs %q should be owned by the unprivileged nginx worker (uid=101,gid=101)", m)
 		}
+		// The root master creates client_temp and the pid file here before
+		// forking workers, and CapDrop: ALL denies it a write bypass, so the
+		// mode has to admit both. Without this nginx exits with
+		// mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied).
+		if !contains(m, "mode=0777") {
+			t.Errorf("tmpfs %q needs mode=0777: the root master and the uid-101 "+
+				"workers both write here, and CapDrop ALL removes root's write bypass", m)
+		}
 	}
 }
 


### PR DESCRIPTION
Third and last of the nginx startup failures. With the certificates finally
readable (#273, #274), nginx got further and then exited on:

  [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)

This one was introduced by #273. Two uids write to these mounts: the master
starts as root, because the generated nginx.conf declares `user nginx;`, and
creates client_temp and the pid file before forking; the workers then run as
uid 101. While the container ran wholly as 101 that was consistent. Once the
master became root, a tmpfs owned by 101 alone locked it out, since CapDrop:
ALL removes root's write bypass.

Adds mode=0777 to both mounts, keeping uid/gid 101 so workers still own what
they create. These are per-container tmpfs mounts holding scratch state, not a
boundary between principals. The alternative was adding DAC_OVERRIDE, which
grants write bypass across the entire filesystem to fix two scratch
directories.

Verified by mutation: dropping mode=0777 fails TestNginxWorkersStayUnprivileged.