### PR TITLE
fix(nginx): grant the master the capabilities its startup actually needs

### DIFF
--- a/internal/compose/nginx_user_test.go
+++ b/internal/compose/nginx_user_test.go
@@ -83,15 +83,28 @@ func contains(haystack, needle string) bool {
 // denied", which is what timed out the golden path's health wait.
 func TestNginxCanReadBindMountedTLS(t *testing.T) {
 	sec := NginxSecurity()
-	found := false
+	have := map[string]bool{}
 	for _, c := range sec.CapAdd {
-		if c == "DAC_READ_SEARCH" {
-			found = true
+		have[c] = true
+	}
+	// Each of these was found by nginx refusing to start without it. They are
+	// the only things the master does before dropping to the worker user.
+	for cap, why := range map[string]string{
+		"NET_BIND_SERVICE": "bind ports 80 and 443",
+		"DAC_READ_SEARCH":  "read the bind-mounted TLS material (0600 key, host ownership)",
+		"CHOWN":            "chown /var/cache/nginx/client_temp to the worker uid",
+		"SETUID":           "fork workers as the nginx user per `user nginx;`",
+		"SETGID":           "fork workers as the nginx group per `user nginx;`",
+	} {
+		if !have[cap] {
+			t.Errorf("NginxSecurity().CapAdd = %v, missing %s (needed to %s); "+
+				"with CapDrop ALL the master cannot start and nginx crash-loops",
+				sec.CapAdd, cap, why)
 		}
 	}
-	if !found {
-		t.Errorf("NginxSecurity().CapAdd = %v, missing DAC_READ_SEARCH; with "+
-			"CapDrop ALL the master cannot read the bind-mounted 0600 private "+
-			"key and nginx will crash-loop", sec.CapAdd)
+	if have["DAC_OVERRIDE"] {
+		t.Error("DAC_OVERRIDE should not be granted: DAC_READ_SEARCH covers " +
+			"reading and traversing the TLS material, while DAC_OVERRIDE would " +
+			"also grant write bypass across the filesystem")
 	}
 }

--- a/internal/compose/security.go
+++ b/internal/compose/security.go
@@ -64,8 +64,23 @@ func MinioSecurity() ServiceSecurity {
 // expose it to every user on the machine.
 func NginxSecurity() ServiceSecurity {
 	return ServiceSecurity{
-		CapDrop:     []string{"ALL"},
-		CapAdd:      []string{"NET_BIND_SERVICE", "DAC_READ_SEARCH"},
+		CapDrop: []string{"ALL"},
+		// The exact set a root-master nginx needs at startup, and nothing more.
+		// CapDrop: ALL means root here has no privileges except these.
+		//
+		//   NET_BIND_SERVICE  bind 80 and 443
+		//   DAC_READ_SEARCH   read the bind-mounted TLS material, which carries
+		//                     host ownership and a 0600 private key
+		//   CHOWN             hand the worker scratch dirs to uid 101 after
+		//                     creating them (chown("/var/cache/nginx/client_temp", 101))
+		//   SETUID / SETGID   fork the workers as the nginx user, which is what
+		//                     `user nginx;` in the generated config asks for
+		//
+		// Each was found by nginx refusing to start without it, one per run.
+		// DAC_OVERRIDE is deliberately NOT here: DAC_READ_SEARCH covers reading
+		// and traversing, which is all the TLS material needs, while
+		// DAC_OVERRIDE would also grant write bypass across the filesystem.
+		CapAdd:      []string{"NET_BIND_SERVICE", "DAC_READ_SEARCH", "CHOWN", "SETUID", "SETGID"},
 		SecurityOpt: []string{"no-new-privileges:true"},
 		ReadOnly:    true,
 		// nginx tmpfs handled separately in service builder (uid/gid specific)


### PR DESCRIPTION
Last of the nginx startup failures. The certificate now loads and nginx exits
on the next privileged thing it does:

  [emerg] chown("/var/cache/nginx/client_temp", 101) failed (1: Operation not permitted)

CapDrop: ALL means the root master has no privileges beyond what CapAdd grants,
and the master does exactly four privileged things before handing off to the
workers. Rather than discover them one CI run at a time, this grants the set:

  NET_BIND_SERVICE  bind 80 and 443
  DAC_READ_SEARCH   read the bind-mounted TLS material (0600 key, host owner)
  CHOWN             hand the worker scratch dirs to uid 101 after creating them
  SETUID / SETGID   fork workers as the nginx user, which `user nginx;` asks for

DAC_OVERRIDE is deliberately excluded and the test asserts its absence:
DAC_READ_SEARCH covers reading and traversing, which is all the TLS material
needs, whereas DAC_OVERRIDE would also grant write bypass across the filesystem.

This is still a small, enumerated set with a stated reason per capability,
rather than an unprivileged container that cannot start.