### PR TITLE
ci(e2e): the health wait demanded a state the running stack cannot reach

### DIFF
--- a/scripts/golden-path.sh
+++ b/scripts/golden-path.sh
@@ -218,9 +218,21 @@ wait_healthy() {
   local interval=3
   local elapsed=0
   log "Waiting for services healthy (timeout ${timeout}s)..."
+  # `nself doctor` exits 0 when everything passes, 2 when there are warnings but
+  # no failures, and 1 on a real failure (cmd/commands/doctor.go). Accept 0 and
+  # 2 here: a warning is not an unhealthy service.
+  #
+  # Demanding exit 0 made this loop unsatisfiable. Once the stack is up, doctor
+  # warns that ports 80, 443, 5432, 8080 and 4000 are "already in use" -- by our
+  # own containers -- and that the JWT secret lives in .env.secrets rather than
+  # .env, which is where it belongs. None of those can clear while the stack is
+  # running, so the wait could only ever time out, and did, for as long as the
+  # smoke has existed.
   while (( elapsed < timeout )); do
-    if nself doctor --quick >/dev/null 2>&1; then
-      ok "All services healthy after ${elapsed}s"
+    nself doctor --quick >/dev/null 2>&1
+    local rc=$?
+    if (( rc == 0 || rc == 2 )); then
+      ok "All services healthy after ${elapsed}s (doctor exit ${rc})"
       return 0
     fi
     sleep "${interval}"


### PR DESCRIPTION
wait_healthy looped on `nself doctor --quick` and required exit 0. doctor exits
0 when everything passes, 2 when there are warnings but no failures, and 1 on a
real failure (cmd/commands/doctor.go:254).

Once the stack is up, doctor always warns. It reports ports 80, 443, 5432, 8080
and 4000 as "already in use", which is true and is our own containers holding
them, and that HASURA_GRAPHQL_JWT_SECRET is in .env.secrets rather than .env,
which is where it belongs. None of those clear while the stack runs, so the
loop could only ever run out the clock. It is the same shape as the other gates
found this week: a success condition that cannot occur.

Accepts 0 and 2, keeps waiting on 1. A warning is not an unhealthy service.

Not fixed here, and worth its own change: the port check counts this project's
own containers as a conflict. It exists to catch a port clash BEFORE start, so
after start it is reporting the expected state as a problem. Fixing that would
remove five of the six warnings rather than tolerating them.