### PR TITLE
ci(e2e): say when the license secret is missing instead of failing obscurely

### DIFF
--- a/.github/workflows/e2e-golden-path.yml
+++ b/.github/workflows/e2e-golden-path.yml
@@ -81,6 +81,19 @@ jobs:
           done
           docker info
 
+      # Length only, never the value: this tells us whether the secret reached
+      # the job at all, which "accepts 1 arg(s), received 0" three steps later
+      # does not.
+      - name: Check the license secret reached the job
+        env:
+          NSELF_PLUGIN_LICENSE_KEY_OWNER: ${{ secrets.NSELF_PLUGIN_LICENSE_KEY_OWNER }}
+        run: |
+          if [ -z "${NSELF_PLUGIN_LICENSE_KEY_OWNER}" ]; then
+            echo "NSELF_PLUGIN_LICENSE_KEY_OWNER is EMPTY in this job"
+          else
+            echo "NSELF_PLUGIN_LICENSE_KEY_OWNER present (${#NSELF_PLUGIN_LICENSE_KEY_OWNER} chars)"
+          fi
+
       - name: Run golden-path smoke
         env:
           NSELF_PLUGIN_LICENSE_KEY_OWNER: ${{ secrets.NSELF_PLUGIN_LICENSE_KEY_OWNER }}

--- a/scripts/golden-path.sh
+++ b/scripts/golden-path.sh
@@ -411,6 +411,22 @@ run_step 7 "nself doctor --quick" \
 [ "${STEP_STATUS[7]}" = "fail" ] && { write_report; exit 1; }
 
 # ── Step 8: license set ──────────────────────────────────────────────────────
+# Fail here with something readable rather than letting an empty variable become
+# a missing argument. Unset, the command below expands to `nself license set`
+# and cobra reports "accepts 1 arg(s), received 0", which says nothing about the
+# secret being absent.
+if [ -z "${NSELF_PLUGIN_LICENSE_KEY_OWNER:-}" ]; then
+  err "NSELF_PLUGIN_LICENSE_KEY_OWNER is empty."
+  err "Steps 8 to 10 need it: the ai and claw plugins are license-gated."
+  err "In CI it comes from the repository secret of the same name, wired into"
+  err "the \"Run golden-path smoke\" step in .github/workflows/e2e-golden-path.yml."
+  STEP_STATUS[8]="fail"
+  STEP_NOTE[8]="NSELF_PLUGIN_LICENSE_KEY_OWNER unset"
+  FAIL=$((FAIL + 1))
+  write_report
+  exit 1
+fi
+
 # Must come BEFORE the plugin installs below. ai and claw are license-gated, so
 # installing them first failed every run with
 #   error installing "ai": plugin "ai" requires a license key


### PR DESCRIPTION
With the license step correctly ordered ahead of the licensed plugin installs
(#279), step 8 failed with:

  Error: accepts 1 arg(s), received 0

That is cobra reporting a missing argument, because
NSELF_PLUGIN_LICENSE_KEY_OWNER expanded to nothing and
`nself license set ${VAR}` became `nself license set`. Nothing in the output
mentions a secret, which is the actual problem.

The script now checks the variable before using it and says what is missing,
which steps need it and where CI is supposed to supply it. The workflow logs
the secret's LENGTH (never its value) in its own step, so "did the secret reach
the job" is answerable directly rather than inferred from an argument-count
error three steps later.

The secret exists on the repository, so this is about finding out why it is not
arriving, with the failure naming its own cause either way.