### PR TITLE
fix(bluegreen): count container state, not just health, in soak gate

### DIFF
--- a/internal/deploy/bluegreen/bluegreen_exec.go
+++ b/internal/deploy/bluegreen/bluegreen_exec.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 )
 
@@ -97,6 +96,18 @@ func stopBlue(ctx context.Context, cfg DeployConfig) error {
 }
 
 // waitForHealth polls the health endpoint on the given env until healthy or timeout.
+//
+// Readiness uses the same containerHealthy predicate and the same
+// {{.Name}}\t{{.State}}\t{{.Health}} sampling as the soak gate's
+// measureErrorRate (bluegreen_traffic.go). This used to be a separate,
+// stricter check that required every docker compose ps line to literally
+// contain the substring "healthy". A container with no Docker healthcheck
+// (nginx, auth, any CS_N custom service) always reports empty Health, so it
+// never contained "healthy" and this wait could never succeed for a
+// perfectly good environment: the opposite failure from #270's fail-open
+// soak gate, on the same underlying question of what counts as healthy.
+// A "starting" Health value is still not ready, so the wait correctly keeps
+// polling instead of declaring readiness prematurely.
 func waitForHealth(ctx context.Context, cfg DeployConfig, env string, timeout time.Duration) error {
 	portOffset := cfg.BluePortOffset
 	if env == EnvGreen {
@@ -117,21 +128,10 @@ func waitForHealth(ctx context.Context, cfg DeployConfig, env string, timeout ti
 		out, err := exec.CommandContext(ctx,
 			"docker", "compose",
 			"-p", project,
-			"ps", "--format", "{{.Name}}\t{{.Health}}",
+			"ps", "--format", containerStatusFormat,
 		).Output()
 		if err == nil {
-			lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-			allHealthy := len(lines) > 0
-			for _, line := range lines {
-				if line == "" {
-					continue
-				}
-				if strings.Contains(line, "unhealthy") || !strings.Contains(line, "healthy") {
-					allHealthy = false
-					break
-				}
-			}
-			if allHealthy && len(lines) > 0 {
+			if ready, total := allContainersReady(string(out)); ready && total > 0 {
 				return nil
 			}
 		}

--- a/internal/deploy/bluegreen/bluegreen_test.go
+++ b/internal/deploy/bluegreen/bluegreen_test.go
@@ -354,3 +354,98 @@ func TestComposeProjectName(t *testing.T) {
 		t.Errorf("got %q, want %q", got, "nself-green")
 	}
 }
+
+// ── parseContainerStatusOutput (issue #270) ─────────────────────────────────
+//
+// The soak gate used to derive the entire error rate from {{.Health}}
+// alone, which is only populated for containers that declare a Docker
+// healthcheck (postgres, hasura). Every other service hit `continue` before
+// `total++`, so it was dropped from the denominator instead of being judged.
+// These tests assert both the error rate AND total (the denominator),
+// because the bug was a denominator bug: a crash-looping nginx with no
+// healthcheck reported 0.00% because it was never counted at all.
+
+func TestParseContainerStatusOutput_table(t *testing.T) {
+	cases := []struct {
+		name      string
+		out       string
+		wantRate  float64
+		wantTotal int
+	}{
+		{
+			name:      "running with no healthcheck counts healthy",
+			out:       "green_nginx\trunning\t",
+			wantRate:  0.0,
+			wantTotal: 1,
+		},
+		{
+			name:      "running with healthy healthcheck",
+			out:       "green_postgres\trunning\thealthy",
+			wantRate:  0.0,
+			wantTotal: 1,
+		},
+		{
+			name:      "running with unhealthy healthcheck",
+			out:       "green_hasura\trunning\tunhealthy",
+			wantRate:  100.0,
+			wantTotal: 1,
+		},
+		{
+			name:      "restarting with no healthcheck counts unhealthy",
+			out:       "green_nginx\trestarting\t",
+			wantRate:  100.0,
+			wantTotal: 1,
+		},
+		{
+			name:      "exited with no healthcheck counts unhealthy",
+			out:       "green_auth\texited\t",
+			wantRate:  100.0,
+			wantTotal: 1,
+		},
+		{
+			name:      "no containers reported",
+			out:       "",
+			wantRate:  0.0,
+			wantTotal: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rate, total := parseContainerStatusOutput(tc.out)
+			if total != tc.wantTotal {
+				t.Errorf("total = %d, want %d", total, tc.wantTotal)
+			}
+			if rate != tc.wantRate {
+				t.Errorf("rate = %.2f, want %.2f", rate, tc.wantRate)
+			}
+		})
+	}
+}
+
+// TestParseContainerStatusOutput_issue270Scenario reproduces the #270
+// failure scenario directly: nginx and auth declare no healthcheck (empty
+// Health) and are down, while postgres and hasura declare a healthcheck and
+// report healthy. Before the fix, nginx/auth had no Health value so they
+// were dropped from the denominator before anything was counted, leaving
+// only the two genuinely-healthy services and reporting a clean 0.00% no
+// matter how broken the rest of the environment was.
+func TestParseContainerStatusOutput_issue270Scenario(t *testing.T) {
+	out := strings.Join([]string{
+		"nself-green_nginx\trestarting\t",
+		"nself-green_auth\texited\t",
+		"nself-green_postgres\trunning\thealthy",
+		"nself-green_hasura\trunning\thealthy",
+	}, "\n")
+
+	rate, total := parseContainerStatusOutput(out)
+	if total != 4 {
+		t.Fatalf("total = %d, want 4 (nginx/auth must not be dropped from the denominator)", total)
+	}
+	if rate == 0.0 {
+		t.Fatalf("rate = 0.00%%, want > 0%% — a crash-looping nginx and a dead auth service must not report a clean soak")
+	}
+	if rate != 50.0 {
+		t.Errorf("rate = %.2f, want 50.00 (2 of 4 containers down)", rate)
+	}
+}

--- a/internal/deploy/bluegreen/bluegreen_test.go
+++ b/internal/deploy/bluegreen/bluegreen_test.go
@@ -449,3 +449,99 @@ func TestParseContainerStatusOutput_issue270Scenario(t *testing.T) {
 		t.Errorf("rate = %.2f, want 50.00 (2 of 4 containers down)", rate)
 	}
 }
+
+// ── allContainersReady (waitForHealth, issue #270 counterpart) ─────────────
+//
+// waitForHealth used to require every docker compose ps line to literally
+// contain the substring "healthy", so a container with no Docker
+// healthcheck (empty Health: nginx, auth, any CS_N custom service) could
+// never satisfy readiness: the opposite failure mode from the soak gate's
+// fail-open bug, on the same underlying question of what counts as healthy.
+
+func TestAllContainersReady_table(t *testing.T) {
+	cases := []struct {
+		name      string
+		out       string
+		wantReady bool
+		wantTotal int
+	}{
+		{
+			name:      "running with no healthcheck is ready",
+			out:       "green_nginx	running	",
+			wantReady: true,
+			wantTotal: 1,
+		},
+		{
+			name:      "running with healthy healthcheck is ready",
+			out:       "green_postgres	running	healthy",
+			wantReady: true,
+			wantTotal: 1,
+		},
+		{
+			name:      "starting is not ready",
+			out:       "green_hasura	running	starting",
+			wantReady: false,
+			wantTotal: 1,
+		},
+		{
+			name:      "unhealthy is not ready",
+			out:       "green_hasura	running	unhealthy",
+			wantReady: false,
+			wantTotal: 1,
+		},
+		{
+			name:      "restarting is not ready",
+			out:       "green_nginx	restarting	",
+			wantReady: false,
+			wantTotal: 1,
+		},
+		{
+			name:      "exited is not ready",
+			out:       "green_auth	exited	",
+			wantReady: false,
+			wantTotal: 1,
+		},
+		{
+			name:      "no containers reported is not ready",
+			out:       "",
+			wantReady: false,
+			wantTotal: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ready, total := allContainersReady(tc.out)
+			if total != tc.wantTotal {
+				t.Errorf("total = %d, want %d", total, tc.wantTotal)
+			}
+			if ready != tc.wantReady {
+				t.Errorf("ready = %v, want %v", ready, tc.wantReady)
+			}
+		})
+	}
+}
+
+// TestAllContainersReady_issue270Scenario mirrors
+// TestParseContainerStatusOutput_issue270Scenario but for the readiness
+// side: nginx and auth declare no healthcheck and ARE actually running
+// fine (unlike the soak scenario, where they were down) alongside a
+// healthy postgres and hasura. Before this fix, nginx/auth's empty Health
+// field meant their docker compose ps line never contained "healthy", so
+// this reported not-ready forever even though every container was fine.
+func TestAllContainersReady_issue270Scenario(t *testing.T) {
+	out := strings.Join([]string{
+		"nself-green_nginx\trunning\t",
+		"nself-green_auth\trunning\t",
+		"nself-green_postgres\trunning\thealthy",
+		"nself-green_hasura\trunning\thealthy",
+	}, "\n")
+
+	ready, total := allContainersReady(out)
+	if total != 4 {
+		t.Fatalf("total = %d, want 4", total)
+	}
+	if !ready {
+		t.Fatalf("ready = false, want true: nginx/auth running with no healthcheck must count as ready")
+	}
+}

--- a/internal/deploy/bluegreen/bluegreen_traffic.go
+++ b/internal/deploy/bluegreen/bluegreen_traffic.go
@@ -104,7 +104,7 @@ func measureErrorRate(ctx context.Context, cfg DeployConfig) (float64, error) {
 	out, err := exec.CommandContext(ctx,
 		"docker", "compose",
 		"-p", project,
-		"ps", "--format", "{{.Name}}\t{{.State}}\t{{.Health}}",
+		"ps", "--format", containerStatusFormat,
 	).Output()
 	if err != nil {
 		return 0.0, fmt.Errorf("querying green container status for project %s: %w", project, err)
@@ -117,20 +117,29 @@ func measureErrorRate(ctx context.Context, cfg DeployConfig) (float64, error) {
 	return errorRate, nil
 }
 
-// parseContainerStatusOutput parses tab-separated
-// "{{.Name}}\t{{.State}}\t{{.Health}}" lines from `docker compose ps` and
-// returns the error rate percentage together with the number of containers
-// counted (the denominator). Isolated from measureErrorRate so it can be
-// unit tested without shelling out to Docker.
-//
-// A container counts as healthy only when containerHealthy (below) accepts
-// it. Every parsed line is counted in total regardless of whether it has a
-// Health value — the original bug excluded healthcheck-less services (e.g.
-// nginx, auth) from the denominator entirely because it looked at Health
-// alone, which meant a crash-looping nginx was invisible to this gate.
-func parseContainerStatusOutput(out string) (errorRatePct float64, total int) {
+// containerStatus is one parsed row of docker compose ps output: the
+// State (running, exited, restarting, ...) and the optional Health value
+// (healthy, unhealthy, starting, or empty when no healthcheck is declared).
+type containerStatus struct {
+	state  string
+	health string
+}
+
+// containerStatusFormat is the shared docker compose ps --format used by
+// both measureErrorRate (soak gate) and waitForHealth (readiness wait), so
+// the two call sites read identical fields and can share one parser and
+// one accept-predicate (containerHealthy) instead of drifting apart the
+// way #270 (fail-open on Health alone) and its readiness-side counterpart
+// (fail-closed on the same missing Health) did.
+const containerStatusFormat = "{{.Name}}\t{{.State}}\t{{.Health}}"
+
+// parseContainerStatusLines parses tab-separated
+// "{{.Name}}\t{{.State}}\t{{.Health}}" lines from `docker compose ps` into
+// one containerStatus per non-blank line. Isolated from its callers so it
+// can be unit tested without shelling out to Docker.
+func parseContainerStatusLines(out string) []containerStatus {
 	lines := strings.Split(strings.TrimSpace(out), "\n")
-	unhealthy := 0
+	statuses := make([]containerStatus, 0, len(lines))
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -145,17 +154,54 @@ func parseContainerStatusOutput(out string) (errorRatePct float64, total int) {
 		if len(fields) >= 3 {
 			dockerHealth = strings.TrimSpace(fields[2])
 		}
-
-		total++
-		if !containerHealthy(state, dockerHealth) {
-			unhealthy++
-		}
+		statuses = append(statuses, containerStatus{state: state, health: dockerHealth})
 	}
+	return statuses
+}
 
+// parseContainerStatusOutput returns the error rate percentage together
+// with the number of containers counted (the denominator).
+//
+// A container counts as healthy only when containerHealthy (below) accepts
+// it. Every parsed line is counted in total regardless of whether it has a
+// Health value — the original bug excluded healthcheck-less services (e.g.
+// nginx, auth) from the denominator entirely because it looked at Health
+// alone, which meant a crash-looping nginx was invisible to this gate.
+func parseContainerStatusOutput(out string) (errorRatePct float64, total int) {
+	statuses := parseContainerStatusLines(out)
+	total = len(statuses)
 	if total == 0 {
 		return 0.0, 0
 	}
+
+	unhealthy := 0
+	for _, cs := range statuses {
+		if !containerHealthy(cs.state, cs.health) {
+			unhealthy++
+		}
+	}
 	return float64(unhealthy) / float64(total) * 100.0, total
+}
+
+// allContainersReady reports whether every container in out is ready
+// (containerHealthy accepts it) together with the number of containers
+// observed. Used by waitForHealth. total == 0 is never ready: no
+// containers reported means the environment could not be observed, which
+// must never be indistinguishable from "everything is healthy" (same
+// principle as the total == 0 case in parseContainerStatusOutput).
+func allContainersReady(out string) (ready bool, total int) {
+	statuses := parseContainerStatusLines(out)
+	total = len(statuses)
+	if total == 0 {
+		return false, 0
+	}
+
+	for _, cs := range statuses {
+		if !containerHealthy(cs.state, cs.health) {
+			return false, total
+		}
+	}
+	return true, total
 }
 
 // containerHealthy applies the same accept-predicate internal/health uses
@@ -164,7 +210,10 @@ func parseContainerStatusOutput(out string) (errorRatePct float64, total int) {
 // matching buildComposeHealthMap's "no healthcheck configured" convention
 // in internal/health/checker.go). A container whose State is not "running"
 // (exited, restarting, dead, ...) is never OK regardless of Health — that
-// is precisely the failure {{.Health}}-only sampling could not see.
+// is precisely the failure {{.Health}}-only sampling could not see. A
+// "starting" Health value (healthcheck running but not yet passed) is also
+// never OK, since it is neither "healthy" nor "running". waitForHealth
+// relies on this to keep waiting rather than declaring readiness prematurely.
 func containerHealthy(state, dockerHealth string) bool {
 	status := dockerHealth
 	if status == "" {

--- a/internal/deploy/bluegreen/bluegreen_traffic.go
+++ b/internal/deploy/bluegreen/bluegreen_traffic.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/nself-org/cli/internal/health"
 )
 
 // setNginxWeights writes the Nginx upstream block with the given canary percent
@@ -60,7 +62,9 @@ func reloadNginx(projectRoot string) error {
 }
 
 // soak monitors the green environment during the soak period.
-// Returns (rolledBack=true, err) when error rate exceeds threshold.
+// Returns (rolledBack=true, err) when error rate exceeds threshold, or when
+// the green environment cannot be observed at all (see measureErrorRate) —
+// an unobservable environment must never be promoted to production.
 func soak(ctx context.Context, cfg DeployConfig, duration time.Duration) (bool, error) {
 	deadline := time.Now().Add(duration)
 	pollInterval := 30 * time.Second
@@ -72,7 +76,10 @@ func soak(ctx context.Context, cfg DeployConfig, duration time.Duration) (bool, 
 		case <-time.After(pollInterval):
 		}
 
-		errorRate := measureErrorRate(ctx, cfg)
+		errorRate, err := measureErrorRate(ctx, cfg)
+		if err != nil {
+			return true, fmt.Errorf("soak measurement failed, rolling back: %w", err)
+		}
 		if errorRate > cfg.ErrorThresholdPct {
 			return true, fmt.Errorf("error rate %.2f%% exceeded threshold %.1f%%", errorRate, cfg.ErrorThresholdPct)
 		}
@@ -81,36 +88,87 @@ func soak(ctx context.Context, cfg DeployConfig, duration time.Duration) (bool, 
 }
 
 // measureErrorRate estimates the current error rate from green containers.
-// It checks docker compose ps for unhealthy containers and returns a rate.
-// When Prometheus is available, it queries the metrics endpoint instead.
-// Returns 0.0 when measurement is unavailable (fail-open for soak continuity).
-func measureErrorRate(ctx context.Context, cfg DeployConfig) float64 {
+// It checks docker compose ps for containers that are not running, or that
+// declare a failing healthcheck, and returns the resulting percentage. When
+// Prometheus is available, it queries the metrics endpoint instead.
+//
+// It returns an error when the green environment cannot be observed at all:
+// the docker command failing, or reporting zero containers. Both used to
+// return 0.0 ("no errors"), which made an unobservable environment
+// indistinguishable from a healthy one. soak() now treats any error from
+// this function as a soak failure and rolls back, so "couldn't measure" and
+// "measured and it's broken" both stop the promotion — the only difference
+// is which is reported.
+func measureErrorRate(ctx context.Context, cfg DeployConfig) (float64, error) {
 	project := composeProjectName(EnvGreen)
 	out, err := exec.CommandContext(ctx,
 		"docker", "compose",
 		"-p", project,
-		"ps", "--format", "{{.Health}}",
+		"ps", "--format", "{{.Name}}\t{{.State}}\t{{.Health}}",
 	).Output()
 	if err != nil {
-		return 0.0 // fail-open
+		return 0.0, fmt.Errorf("querying green container status for project %s: %w", project, err)
 	}
 
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	total := 0
+	errorRate, total := parseContainerStatusOutput(string(out))
+	if total == 0 {
+		return 0.0, fmt.Errorf("no containers reported for green project %s: cannot measure error rate", project)
+	}
+	return errorRate, nil
+}
+
+// parseContainerStatusOutput parses tab-separated
+// "{{.Name}}\t{{.State}}\t{{.Health}}" lines from `docker compose ps` and
+// returns the error rate percentage together with the number of containers
+// counted (the denominator). Isolated from measureErrorRate so it can be
+// unit tested without shelling out to Docker.
+//
+// A container counts as healthy only when containerHealthy (below) accepts
+// it. Every parsed line is counted in total regardless of whether it has a
+// Health value — the original bug excluded healthcheck-less services (e.g.
+// nginx, auth) from the denominator entirely because it looked at Health
+// alone, which meant a crash-looping nginx was invisible to this gate.
+func parseContainerStatusOutput(out string) (errorRatePct float64, total int) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
 	unhealthy := 0
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
+		fields := strings.Split(line, "\t")
+		state := ""
+		dockerHealth := ""
+		if len(fields) >= 2 {
+			state = strings.TrimSpace(fields[1])
+		}
+		if len(fields) >= 3 {
+			dockerHealth = strings.TrimSpace(fields[2])
+		}
+
 		total++
-		if strings.Contains(line, "unhealthy") {
+		if !containerHealthy(state, dockerHealth) {
 			unhealthy++
 		}
 	}
 
 	if total == 0 {
-		return 0.0
+		return 0.0, 0
 	}
-	return float64(unhealthy) / float64(total) * 100.0
+	return float64(unhealthy) / float64(total) * 100.0, total
+}
+
+// containerHealthy applies the same accept-predicate internal/health uses
+// for HealthResult.OK(): a container with no Docker healthcheck reports an
+// empty Health field and is judged on State alone ("running" counts as OK,
+// matching buildComposeHealthMap's "no healthcheck configured" convention
+// in internal/health/checker.go). A container whose State is not "running"
+// (exited, restarting, dead, ...) is never OK regardless of Health — that
+// is precisely the failure {{.Health}}-only sampling could not see.
+func containerHealthy(state, dockerHealth string) bool {
+	status := dockerHealth
+	if status == "" {
+		status = state
+	}
+	return health.HealthResult{Status: status}.OK()
 }


### PR DESCRIPTION
## Summary

Fixes #270: two opposite failures of the same predicate ("what counts as a healthy container") in the blue/green deploy pipeline. Fixing one without the other would have been worse than fixing neither: the readiness wait could refuse to pass on a perfectly good stack while the soak gate passed on a broken one.

### 1. Soak gate fail-open (the original report)

`measureErrorRate` (`internal/deploy/bluegreen/bluegreen_traffic.go`) derived the entire error rate from `docker compose ps --format {{.Health}}`, then skipped any empty-Health line **before** incrementing the denominator. `{{.Health}}` is only populated for services that declare a Docker healthcheck. Only postgres and hasura do (`internal/compose/core_services.go`). nginx, auth, and every `CS_N` custom service always report empty Health, so they were dropped from the count entirely instead of being judged. A green environment with a crash-looping nginx and a fine postgres/hasura reported a clean 0.00% and would have been promoted to production traffic.

### 2. Readiness wait fail-closed (found during review, same subsystem)

`waitForHealth` (`internal/deploy/bluegreen/bluegreen_exec.go`) had the inverse bug: it required every `docker compose ps` line to literally contain the substring "healthy", checking only Health and ignoring State entirely. A container with no healthcheck (nginx, auth, `CS_N` services again) always has empty Health, so it could never contain "healthy" and this wait could never succeed, even for a completely healthy green environment. A blue/green deploy of good code could time out waiting on its own readiness check.

## Fix

- Query `{{.Name}}\t{{.State}}\t{{.Health}}` instead of `{{.Health}}` alone, in both call sites.
- Shared `containerHealthy(state, dockerHealth)` (new in this PR) reuses `internal/health`'s exported `HealthResult.OK()` accept-predicate (`healthy || running`): a container with no healthcheck is judged on State alone (`running` is OK), and any State other than `running` (exited, restarting, dead, ...) is never OK regardless of Health. This is the same resolution rule `resolveServiceHealth`/`buildComposeHealthMap` use in `internal/health/checker.go`. I did not call `resolveServiceHealth` itself: it's unexported and tied to a per-known-service lookup (`config.Config` + `build.DetectServices`), whereas both blue/green call sites scan every container in a compose project directly. `OK()` is the actual shared decision surface and is exported for exactly this kind of cross-package reuse.
- Parsing is shared too: `parseContainerStatusLines` turns the tab-separated output into `[]containerStatus{state, health}` once; `parseContainerStatusOutput` (soak, returns an error rate) and `allContainersReady` (readiness, returns a bool) both consume it with different aggregation. `containerStatusFormat` is the one format string both call sites pass to `docker compose ps`.
- `starting` is preserved as "not ready" / "counts against the soak" on both sides. It matches neither `healthy` nor `running` in `HealthResult.OK()`, so `waitForHealth` keeps polling instead of declaring readiness prematurely, same as before this change.
- Both `total == 0` cases are fail-closed, not fail-open: an empty or failed `docker compose ps` result never reads as "everything is healthy" or "everything is ready". `measureErrorRate` returns `(float64, error)`, and `soak()` treats a measurement failure the same as a failed soak and rolls back (`soak()` already had a `rolledBack, err` path the caller in `bluegreen.go` handles identically to a threshold breach; no caller changes needed there). `allContainersReady` returns `ready=false` for zero containers, so `waitForHealth` keeps polling until its own timeout rather than treating "couldn't observe" as "ready".

## Tests

`internal/deploy/bluegreen/bluegreen_test.go`:
- `TestParseContainerStatusOutput_table` (soak, 6 cases) and `TestAllContainersReady_table` (readiness, 7 cases): running+empty health, running+healthy, running+unhealthy, starting, restarting, exited, and no-containers. Each asserts both the resulting value (rate or ready) and the denominator (total), since both original bugs were denominator bugs.
- `TestParseContainerStatusOutput_issue270Scenario`: nginx/auth down with no healthcheck, postgres/hasura healthy. Must NOT report 0.00%.
- `TestAllContainersReady_issue270Scenario`: nginx/auth running fine with no healthcheck, postgres/hasura healthy. Must report ready=true (the readiness-side mirror of the same scenario).

**Negative-tested, both fixes:**

Soak gate: reverted `parseContainerStatusOutput` to the old continue-before-`total++` behavior in a scratch copy, re-ran the new tests, confirmed 5 failures, restored the fix, confirmed all pass:
```
FAIL TestParseContainerStatusOutput_table/running_with_no_healthcheck_counts_healthy
FAIL TestParseContainerStatusOutput_table/restarting_with_no_healthcheck_counts_unhealthy
FAIL TestParseContainerStatusOutput_table/exited_with_no_healthcheck_counts_unhealthy
FAIL TestParseContainerStatusOutput_table (parent)
FAIL TestParseContainerStatusOutput_issue270Scenario
```

Readiness wait: reverted `allContainersReady` to the old Health-substring-only behavior in a scratch copy, re-ran the new tests, confirmed 3 failures (soak-side tests unaffected, confirming the two predicates are actually decoupled at the test level despite sharing `containerHealthy`), restored the fix, confirmed all 17 subtests across both features pass:
```
FAIL TestAllContainersReady_table/running_with_no_healthcheck_is_ready
FAIL TestAllContainersReady_table (parent)
FAIL TestAllContainersReady_issue270Scenario
```

## Test plan
- [x] `make build` — success
- [x] `gofmt -l cmd internal` — empty
- [x] `make vet` — clean
- [x] `go test -mod=vendor ./...` — 4533 passed, 93 packages
- [x] `bash scripts/ci/flag-drift-audit.sh` — 0 unregistered flags
- [x] `make wiki-check` — 49 command pages current, 302 link targets resolve
