### PR TITLE
fix(license): every license command failed on machines upgraded from an older layout

### DIFF
--- a/internal/license/cache.go
+++ b/internal/license/cache.go
@@ -121,7 +121,7 @@ func WriteCache(entry *CacheEntry) error {
 		return err
 	}
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := ensureDir(dir); err != nil {
 		return fmt.Errorf("creating cache directory: %w", err)
 	}
 	data, err := json.MarshalIndent(entry, "", "  ")

--- a/internal/license/ensure_dir.go
+++ b/internal/license/ensure_dir.go
@@ -1,0 +1,71 @@
+package license
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Making the license directory usable when an older layout left a file there.
+//
+// Purpose: license paths under $HOME are created with MkdirAll. An older nSelf
+// stored the license as a regular FILE at $HOME/.nself/license, with no
+// extension. MkdirAll against that path returns ENOTDIR, so on an upgraded
+// machine every license operation failed with a message naming neither the
+// cause nor the fix:
+//
+//	Error: setting license key: remove /Users/<u>/.nself/license/key: not a directory
+//
+// MigrateLicenseFromV1 handles the separate `license.json` case and does not
+// apply here.
+//
+// Inputs: a directory a caller is about to create.
+//
+// Outputs: nil once the path exists as a directory.
+//
+// Constraints: the migration is deliberately narrow. It fires ONLY for the
+// license directory itself, because that is the one path a known older layout
+// occupied with a file. Callers pass other directories here too, including
+// $HOME/.nself, and silently renaming whatever sits at an arbitrary path would
+// be far more destructive than the bug it fixes. Anything else that is not a
+// directory is reported, not moved. The legacy file is never deleted: it is
+// the user's license and may be the only copy.
+
+// ensureDir creates dir. If the known legacy license file occupies the path it
+// is moved aside first; any other non-directory is an error.
+func ensureDir(dir string) error {
+	info, err := os.Lstat(dir)
+	switch {
+	case err == nil && info.IsDir():
+		return nil
+
+	case err == nil && isLegacyLicenseFilePath(dir):
+		// Keep it: this is the user's license data, and the problem is a layout
+		// collision rather than a reason to discard it.
+		moved := fmt.Sprintf("%s.legacy-%d", dir, time.Now().Unix())
+		if rerr := os.Rename(dir, moved); rerr != nil {
+			return fmt.Errorf("a file exists at %s where a directory is required, "+
+				"and it could not be moved to %s: %w", dir, moved, rerr)
+		}
+		fmt.Fprintf(os.Stderr,
+			"note: %s was a file from an older nSelf layout; moved to %s\n", dir, moved)
+
+	case err == nil:
+		// Not the known legacy artifact. Say so plainly instead of renaming a
+		// path this code has no business moving.
+		return fmt.Errorf("%s exists but is not a directory; move or remove it and retry", dir)
+
+	case !os.IsNotExist(err):
+		return fmt.Errorf("checking %s: %w", dir, err)
+	}
+
+	return os.MkdirAll(dir, 0700)
+}
+
+// isLegacyLicenseFilePath reports whether dir is the license directory itself,
+// the only path a previous layout is known to have occupied with a file.
+func isLegacyLicenseFilePath(dir string) bool {
+	return strings.HasSuffix(filepath.ToSlash(dir), "/"+licenseDir)
+}

--- a/internal/license/ensure_dir_test.go
+++ b/internal/license/ensure_dir_test.go
@@ -1,0 +1,111 @@
+package license
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEnsureDir_MovesAsideLegacyFile pins the upgrade path that was broken.
+//
+// An older nSelf stored the license as a regular file at ~/.nself/license.
+// Every current license operation calls MkdirAll on that same path, which
+// returns ENOTDIR against a file, so on an upgraded machine `nself license set`
+// failed with "remove .../license/key: not a directory" and no way forward.
+func TestEnsureDir_MovesAsideLegacyFile(t *testing.T) {
+	root := t.TempDir()
+	// Must be the real license path: the migration is scoped to it on purpose,
+	// so that an arbitrary non-directory elsewhere is reported rather than
+	// silently renamed.
+	dir := filepath.Join(root, licenseDir)
+	if err := os.MkdirAll(filepath.Dir(dir), 0700); err != nil {
+		t.Fatalf("seeding parent: %v", err)
+	}
+
+	const legacy = "legacy license payload"
+	if err := os.WriteFile(dir, []byte(legacy), 0600); err != nil {
+		t.Fatalf("seeding legacy file: %v", err)
+	}
+
+	if err := ensureDir(dir); err != nil {
+		t.Fatalf("ensureDir over a legacy file: %v", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat after ensureDir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("path is still not a directory")
+	}
+
+	// The legacy file must survive: it is the user's license data.
+	entries, err := os.ReadDir(filepath.Dir(dir))
+	if err != nil {
+		t.Fatalf("reading root: %v", err)
+	}
+	var kept string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "license.legacy-") {
+			kept = filepath.Join(filepath.Dir(dir), e.Name())
+		}
+	}
+	if kept == "" {
+		t.Fatal("legacy file was not preserved: it holds the user's license and must never be deleted")
+	}
+	data, err := os.ReadFile(kept)
+	if err != nil || string(data) != legacy {
+		t.Errorf("preserved file does not hold the original contents: %q, err=%v", data, err)
+	}
+}
+
+// TestEnsureDir_NormalCases covers the paths that must keep behaving as MkdirAll.
+func TestEnsureDir_NormalCases(t *testing.T) {
+	root := t.TempDir()
+
+	fresh := filepath.Join(root, "a", "b")
+	if err := ensureDir(fresh); err != nil {
+		t.Fatalf("creating a fresh nested dir: %v", err)
+	}
+	if info, err := os.Stat(fresh); err != nil || !info.IsDir() {
+		t.Fatalf("fresh dir not created: err=%v", err)
+	}
+
+	// Idempotent: an existing directory is left exactly as it is.
+	marker := filepath.Join(fresh, "keep")
+	if err := os.WriteFile(marker, []byte("x"), 0600); err != nil {
+		t.Fatalf("writing marker: %v", err)
+	}
+	if err := ensureDir(fresh); err != nil {
+		t.Fatalf("ensureDir on an existing dir: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("existing directory contents were disturbed: %v", err)
+	}
+}
+
+// TestEnsureDir_RefusesToMoveUnrelatedFile pins the scoping decision.
+//
+// Callers pass directories other than the license dir here, including
+// $HOME/.nself. Renaming whatever happens to sit at an arbitrary path would be
+// more destructive than the bug the migration fixes, so anything that is not
+// the known legacy license file must be reported instead of moved.
+func TestEnsureDir_RefusesToMoveUnrelatedFile(t *testing.T) {
+	root := t.TempDir()
+	other := filepath.Join(root, ".nself")
+	if err := os.WriteFile(other, []byte("not a license"), 0600); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	err := ensureDir(other)
+	if err == nil {
+		t.Fatal("ensureDir silently moved a file it has no business moving")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Errorf("error should say the path is not a directory, got: %v", err)
+	}
+	if _, statErr := os.Stat(other); statErr != nil {
+		t.Errorf("the unrelated file was moved or removed: %v", statErr)
+	}
+}

--- a/internal/license/key_files.go
+++ b/internal/license/key_files.go
@@ -1,0 +1,43 @@
+package license
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Key-file housekeeping for the license directory.
+//
+// Split out of keys.go, which crossed the repo's 300-line file cap. The cap is
+// a ratchet: raising the budget is the wrong move when the file genuinely has
+// two responsibilities, and key storage housekeeping is separable from key
+// parsing and validation.
+
+// clearAllKeyFiles removes all key files from the license directory.
+//
+// A removal target that sits under a path which is not a directory cannot
+// exist, so ENOTDIR means the same thing here as ENOENT: nothing to clear.
+// The IsNotExist guard alone did not cover that, and callers surfaced the raw
+// errno instead ("remove .../license/key: not a directory").
+func clearAllKeyFiles(dir string) error {
+	// Primary.
+	path := dir + "/" + keyFile
+	if err := os.Remove(path); err != nil && !isAbsentPath(err) {
+		return err
+	}
+	// Numbered.
+	for i := 2; i <= 10; i++ {
+		path := fmt.Sprintf("%s/%s.%d", dir, keyFile, i)
+		if err := os.Remove(path); err != nil && !isAbsentPath(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// isAbsentPath reports whether err means the target is not there to act on,
+// covering both a missing entry and a parent that is not a directory.
+func isAbsentPath(err error) bool {
+	return os.IsNotExist(err) || errors.Is(err, syscall.ENOTDIR)
+}

--- a/internal/license/keys.go
+++ b/internal/license/keys.go
@@ -127,7 +127,7 @@ func AddKey(key string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := ensureDir(dir); err != nil {
 		return fmt.Errorf("creating license directory: %w", err)
 	}
 
@@ -236,12 +236,17 @@ func SetKeyReplaceAll(key string) (int, error) {
 	existing := collectStoredKeys(dir)
 	count := len(existing)
 
-	if err := clearAllKeyFiles(dir); err != nil {
-		return 0, err
+	// ensureDir first: clearAllKeyFiles removes paths UNDER dir, so if an older
+	// layout left a regular file at dir itself, every remove returns ENOTDIR
+	// before the directory is ever repaired. Doing the work before making its
+	// precondition true is what produced "remove .../license/key: not a
+	// directory" on upgraded machines.
+	if err := ensureDir(dir); err != nil {
+		return 0, fmt.Errorf("creating license directory: %w", err)
 	}
 
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return 0, fmt.Errorf("creating license directory: %w", err)
+	if err := clearAllKeyFiles(dir); err != nil {
+		return 0, err
 	}
 
 	path := dir + "/" + keyFile
@@ -274,21 +279,4 @@ func collectStoredKeys(dir string) []string {
 	}
 
 	return keys
-}
-
-// clearAllKeyFiles removes all key files from the license directory.
-func clearAllKeyFiles(dir string) error {
-	// Primary.
-	path := dir + "/" + keyFile
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	// Numbered.
-	for i := 2; i <= 10; i++ {
-		path := fmt.Sprintf("%s/%s.%d", dir, keyFile, i)
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-	}
-	return nil
 }

--- a/internal/license/manager.go
+++ b/internal/license/manager.go
@@ -69,7 +69,7 @@ func SetKey(key string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := ensureDir(dir); err != nil {
 		return fmt.Errorf("creating license directory: %w", err)
 	}
 
@@ -207,7 +207,7 @@ func MigrateLicenseFromV1(home string) error {
 	}
 
 	// Ensure v2 directory exists.
-	if err := os.MkdirAll(v2Dir, 0700); err != nil {
+	if err := ensureDir(v2Dir); err != nil {
 		return fmt.Errorf("creating v2 license directory: %w", err)
 	}
 

--- a/internal/license/owner.go
+++ b/internal/license/owner.go
@@ -58,7 +58,7 @@ func SetOwnerKey(key string) error {
 		return err
 	}
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := ensureDir(dir); err != nil {
 		return fmt.Errorf("creating owner license directory: %w", err)
 	}
 	if err := os.WriteFile(path, []byte(key), 0600); err != nil {

--- a/internal/license/revocation.go
+++ b/internal/license/revocation.go
@@ -127,7 +127,7 @@ func WriteRevocationCache(c *RevocationCache) error {
 		return err
 	}
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := ensureDir(dir); err != nil {
 		return fmt.Errorf("creating cache directory: %w", err)
 	}
 	data, err := json.MarshalIndent(c, "", "  ")

--- a/internal/license/revoke.go
+++ b/internal/license/revoke.go
@@ -64,7 +64,7 @@ func RevokeLicense() error {
 		return err
 	}
 	dir := filepath.Dir(markerPath)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := ensureDir(dir); err != nil {
 		return fmt.Errorf("creating cache directory: %w", err)
 	}
 	marker := RevokedMarker{WipedAt: time.Now().Unix()}


### PR DESCRIPTION
An older nSelf stored the license as a regular file at ~/.nself/license. The
current code treats that path as a directory, so on an upgraded machine every
license operation died with a message that named neither the cause nor a fix:

  Error: setting license key: remove /Users/<u>/.nself/license/key: not a directory

Found by running `nself license set` with a real key on a machine that still
had the old file (dated June 28). MigrateLicenseFromV1 covers the separate
license.json case and does not apply.

Two defects, both fixed:

- Ordering. SetKeyReplaceAll called clearAllKeyFiles(dir) BEFORE ensureDir(dir).
  clearAllKeyFiles removes paths UNDER dir, so with a file at dir every removal
  returned ENOTDIR before the directory was ever repaired. Doing the work
  before making its precondition true is the same shape as the postgres
  readiness bug in #259.

- Errno. clearAllKeyFiles guarded only os.IsNotExist. A target under a
  non-directory cannot exist either, so ENOTDIR means the same thing; it now
  treats both as "nothing to clear" instead of surfacing the raw errno.

The migration is deliberately narrow. It fires only for the license directory
itself, because that is the one path the older layout is known to have occupied
with a file. Callers pass other directories to ensureDir too, including
~/.nself, and renaming whatever sits at an arbitrary path would be far more
destructive than the bug it fixes. Anything else that is not a directory is
reported and left alone, which is what TestSetOwnerKey_MkdirFails and
TestRevokeLicense_MkdirAllFail already asserted and still assert.

The legacy file is never deleted. It is the user's license and may be the only
copy, so it is renamed alongside its replacement and the new name is printed.

keys.go crossed the 300-line cap with these changes, so the key-file
housekeeping moved to key_files.go rather than raising the ratchet budget.

Verified against the real broken layout: `nself license set` now exits 0, the
legacy file is preserved, and the directory is created. Negative-tested by
reverting ensureDir to a plain MkdirAll, which fails
TestEnsureDir_MovesAsideLegacyFile.