### PR TITLE
ci: pin govulncheck and go-licenses instead of installing @latest

### DIFF
--- a/.github/workflows/deep-qa-block.yml
+++ b/.github/workflows/deep-qa-block.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
           bash .github/scripts/govuln-gate.sh
 
       - name: Generate report stub

--- a/.github/workflows/govuln.yml
+++ b/.github/workflows/govuln.yml
@@ -26,7 +26,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: Run govulncheck (allowlist gate)
         env:

--- a/.github/workflows/govulncheck-nightly.yml
+++ b/.github/workflows/govulncheck-nightly.yml
@@ -38,7 +38,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: Run govulncheck (JSON)
         id: scan

--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -31,7 +31,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
+        run: go install github.com/google/go-licenses@v1.6.0
 
       - name: Check for disallowed licenses
         env:

--- a/.github/workflows/license-gate-unit-test.yml
+++ b/.github/workflows/license-gate-unit-test.yml
@@ -36,7 +36,7 @@ jobs:
           cache: false  # temp workspace — no go.sum to cache
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
+        run: go install github.com/google/go-licenses@v1.6.0
 
       - name: Build synthetic AGPL test workspace
         id: scaffold

--- a/.github/workflows/license-gate.yml
+++ b/.github/workflows/license-gate.yml
@@ -32,7 +32,7 @@ jobs:
           cache: true
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
+        run: go install github.com/google/go-licenses@v1.6.0
 
       - name: Check Go dependency licenses (AGPL/SSPL block)
         env:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
       - name: Run govulncheck
         env:
           GOFLAGS: -mod=vendor


### PR DESCRIPTION
## Why now

The **License Gate went red on `main`** at 18:24 today:

```
go install github.com/google/go-licenses@latest
... verifying go.mod: google.golang.org/grpc@v1.46.0:
    reading https://sum.golang.org/tile/8/0/x040/374:
    stream error: INTERNAL_ERROR; received from peer
```

A checksum-database hiccup, not a license violation — but it still reported as a failed **compliance** gate on main.

## The wider problem

Seven workflows install a tool with `@latest`, so tool behaviour can change with no commit in this repo:

| Tool | Workflows |
|---|---|
| `govulncheck@latest` | 4 |
| `go-licenses@latest` | 3 |

We already paid for this pattern once. `ruff` was pinned only as `>=0.4`; CI resolved **0.16.3** and a routine version bump suddenly failed on **20 lint violations** unrelated to the change under test. For a *security* gate the exposure is worse, because drift in either direction is wrong: it can start reporting noise, or quietly stop reporting at all.

## Change

Pins **govulncheck v1.7.0** and **go-licenses v1.6.0**. Both are the current `@latest`, so this is behaviourally a no-op — it only removes the nondeterminism and one network flake source. Dependabot still proposes upgrades; they now arrive as reviewable PRs instead of landing silently mid-run.

## Verification

- all workflow YAML parses
- both pinned versions resolve on proxy.golang.org (HTTP 200)
- `grep '@latest' .github/workflows/*.yml` → no matches remaining