### PR TITLE
feat(access): add nself access grant/revoke/list for SSH key management

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -1,5 +1,54 @@
 [
   {
+    "name": "access",
+    "path": "nself access",
+    "short": "Manage SSH key access on an already-deployed server",
+    "hidden": false,
+    "group_id": "advanced",
+    "subcommands": [
+      {
+        "name": "grant",
+        "path": "nself access grant",
+        "short": "Grant a person SSH key access to a host",
+        "hidden": false,
+        "flags": [
+          "--docker",
+          "--dry-run",
+          "--expires",
+          "--host",
+          "--identity",
+          "--key",
+          "--sudo",
+          "--user"
+        ]
+      },
+      {
+        "name": "list",
+        "path": "nself access list",
+        "short": "List who has SSH key access to a host",
+        "hidden": false,
+        "flags": [
+          "--host",
+          "--identity",
+          "--json"
+        ]
+      },
+      {
+        "name": "revoke",
+        "path": "nself access revoke",
+        "short": "Revoke a person's SSH key access to a host",
+        "hidden": false,
+        "flags": [
+          "--dry-run",
+          "--force",
+          "--host",
+          "--identity",
+          "--user"
+        ]
+      }
+    ]
+  },
+  {
     "name": "account",
     "path": "nself account",
     "short": "Manage your nSelf account, sessions, licenses, team, and devices",

--- a/.github/command-surface-budget.txt
+++ b/.github/command-surface-budget.txt
@@ -3,4 +3,11 @@
 # of .claude/tasks/cli-review-tickets-2026-08-23.md).
 # internal/repoqa/command_surface_test.go fails if the real count rises above
 # this, and separately if this number is left higher than reality.
-49
+#
+# 2026-08-26: +1 for `access` (issue #238). Deliberate exception, not
+# creep: hcloud only injects SSH keys at server-creation time and `nself
+# security` covers firewall/fail2ban/sshd only, so granting or revoking a
+# teammate's SSH key on an already-deployed host had no CLI path at all.
+# `nself access grant/revoke/list` is the command surface named directly
+# in #238's proposed shape.
+50

--- a/.github/surface-parity.json
+++ b/.github/surface-parity.json
@@ -2,6 +2,15 @@
   "generated_by": "tools/parity",
   "rows": [
     {
+      "name": "access",
+      "path": "nself access",
+      "group_id": "advanced",
+      "wiki_page": true,
+      "mcp_tool": false,
+      "env_vars": "documented",
+      "openapi": "n/a (see below)"
+    },
+    {
       "name": "account",
       "path": "nself account",
       "group_id": "account",

--- a/.github/surface-parity.md
+++ b/.github/surface-parity.md
@@ -12,6 +12,7 @@ One row per top-level command (CLI-R17), scored against the four surfaces a comm
 
 | Command | Group | Wiki Page | MCP Tool | Env Vars | OpenAPI Route |
 |---|---|---|---|---|---|
+| `nself access` | advanced | yes | no | documented | n/a (see below) |
 | `nself account` | account | yes | no | undocumented: NSELF_NO_BROWSER | n/a (see below) |
 | `nself admin` | account | yes | no | undocumented: ADMIN_PORT | n/a (see below) |
 | `nself backup` | data | yes | yes | n/a | n/a (see below) |
@@ -62,4 +63,4 @@ One row per top-level command (CLI-R17), scored against the four surfaces a comm
 | `nself verify-sbom` | advanced | yes | no | n/a | n/a (see below) |
 | `nself version` | account | yes | no | undocumented: BENCH_RESULTS_FILE | n/a (see below) |
 
-Total: 49 commands. Missing wiki page: 0. No MCP tool: 32. Env vars found but undocumented: 17.
+Total: 50 commands. Missing wiki page: 0. No MCP tool: 33. Env vars found but undocumented: 17.

--- a/.github/wiki/Commands.md
+++ b/.github/wiki/Commands.md
@@ -100,10 +100,11 @@ tree in `cmd/commands/`. Run `make cmd-inventory` to refresh.
 ## Complete index
 
 Generated from the cobra registration tree in `cmd/commands/`.
-Run `make cmd-inventory` to refresh. **Total top-level commands: 49**
+Run `make cmd-inventory` to refresh. **Total top-level commands: 50**
 
 | Command | Short Description | Group | Subcommands |
 |---|---|---|---|
+| `nself access` | Manage SSH key access on an already-deployed server | advanced | grant, list, revoke |
 | `nself account` | Manage your nSelf account, sessions, licenses, team, and devices | account | devices, licenses, login, logout, status, team, transfer |
 | `nself admin` | Manage the nSelf Admin dashboard | account | connect, health, logs, projects, start, stop |
 | `nself backup` | Backup operations: create, list, restore, verify, prune, config, status, init-key | data | config, create, drill, init-key, list, pitr, prune, restore, restore-remote, resume, schedule, status, stream, verify |

--- a/.github/wiki/_Sidebar.md
+++ b/.github/wiki/_Sidebar.md
@@ -19,7 +19,7 @@
 - _Data:_ [[cmd-db]] · [[cmd-backup]] · [[cmd-dr]] · [[cmd-queue]] · [[cmd-webhooks]]
 - _Config:_ [[cmd-config]] · [[cmd-service]] · [[cmd-env]] · [[cmd-promote]]
 - _Networking:_ [[cmd-ssl]] · [[cmd-trust]] · [[cmd-dns-setup]]
-- _Security:_ [[cmd-security]] · [[cmd-secrets]]
+- _Security:_ [[cmd-access]] · [[cmd-security]] · [[cmd-secrets]]
 - _Tenancy:_ [[cmd-tenant]] · [[cmd-billing]]
 <<<<<<< HEAD
 - _Plugins:_ [[cmd-plugin]] · [[cmd-license]] · [[cmd-dogfood]] (extracted, CLI-R11) · [[cmd-k8s]] (extracted, CLI-R11)
@@ -283,9 +283,9 @@
 
 <!-- BEGIN GENERATED:command-list -->
 
-**All commands (49)**
+**All commands (50)**
 
-- _A:_ [[cmd-account]] · [[cmd-admin]]
+- _A:_ [[cmd-access]] · [[cmd-account]] · [[cmd-admin]]
 - _B:_ [[cmd-backup]] · [[cmd-build]] · [[cmd-bundle]]
 - _C:_ [[cmd-ci]] · [[cmd-clean]] · [[cmd-completion]] · [[cmd-config]]
 - _D:_ [[cmd-db]] · [[cmd-deploy]] · [[cmd-dev]] · [[cmd-doctor]]

--- a/.github/wiki/cmd-access.md
+++ b/.github/wiki/cmd-access.md
@@ -1,0 +1,139 @@
+# nself access
+
+<!-- BEGIN PROSE:summary -->
+> Manage SSH key access on an already-deployed server.
+<!-- END PROSE:summary -->
+
+## Synopsis
+
+```
+nself access <subcommand> [flags]
+```
+
+## Description
+
+<!-- BEGIN PROSE:description -->
+Grant, revoke, and list SSH key access on a running nself host, without a raw
+`ssh` session and hand-edited `authorized_keys`.
+
+`nself security` hardens a host (firewall, fail2ban, sshd config) but has no
+concept of individual keys or people. `hcloud ssh-key create` only injects a
+key when a server is created, so it does nothing for a host that is already
+running. `nself access` fills that gap: it manages `authorized_keys` entries
+directly, over SSH, on a host that is already live.
+
+## Usage
+
+```
+nself access <subcommand> [flags]
+```
+
+### nself access grant
+Add a person's public key to a host's `authorized_keys`, or update it if they
+already have one. Re-granting the identical key is a no-op. Granting a
+different key, or different `--sudo`/`--docker`/`--expires` metadata, for the
+same `--user` replaces that person's single managed line rather than adding a
+second one.
+
+Before writing anything, the current `authorized_keys` is backed up to a
+timestamped sibling file, and the key's SHA256 fingerprint is echoed back so
+you can verify it against what the person sent you.
+
+```bash
+nself access grant --host root@203.0.113.5 --user alice --key @alice.pub
+```
+
+Flags: `--host` (required, `[user@]host`), `--identity` (local private key
+used to connect, defaults to `~/.ssh/id_ed25519`), `--user` (required, a
+label for whose key this is), `--key` (required, public key material or
+`@path/to/file`), `--sudo` and `--docker` (record the intended privilege
+level as metadata only, this command does not itself change OS group
+membership), `--expires` (optional `YYYY-MM-DD`), `--dry-run` (print the
+resulting diff, change nothing).
+
+### nself access revoke
+Remove a person's public key from a host's `authorized_keys`.
+
+Refuses to remove the last remaining key on the host, since that would lock
+out all SSH access, unless `--force` is given. This is the one command in
+`nself access` that can end a session mid-flight if pointed at the wrong
+host, so `--dry-run` is worth running first against anything that matters.
+
+```bash
+nself access revoke --host root@203.0.113.5 --user alice
+```
+
+Flags: `--host` (required), `--identity`, `--user` (required), `--force`
+(allow removing the last remaining key), `--dry-run`.
+
+### nself access list
+Show every person `nself access` has granted a key to on a host, their
+fingerprint, recorded `--sudo`/`--docker`/`--expires` metadata, and whether
+that expiry has passed. Also reports how many keys in the file were not
+granted by this command (the original key the host shipped with, for
+example) so those are visibly accounted for rather than silently ignored.
+
+```bash
+nself access list --host root@203.0.113.5
+```
+
+Flags: `--host` (required), `--identity`, `--json` (machine-readable output).
+<!-- END PROSE:description -->
+
+## Flags
+
+<!-- BEGIN GENERATED:flags -->
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--help`, `-h` | — | Show help |
+<!-- END GENERATED:flags -->
+
+## Subcommands
+
+<!-- BEGIN GENERATED:subcommands -->
+| Name | Description |
+|------|-------------|
+| `grant` | Grant a person SSH key access to a host |
+| `list` | List who has SSH key access to a host |
+| `revoke` | Revoke a person's SSH key access to a host |
+<!-- END GENERATED:subcommands -->
+
+## Examples
+
+<!-- BEGIN PROSE:examples -->
+```bash
+# Grant alice access using a key file
+nself access grant --host root@203.0.113.5 --user alice --key @alice.pub
+```
+
+```bash
+# Grant bob access with an inline key and sudo metadata
+nself access grant --host root@203.0.113.5 --user bob --key "ssh-ed25519 AAAA... bob@laptop" --sudo
+```
+
+```bash
+# Grant carol access with an expiry date
+nself access grant --host root@203.0.113.5 --user carol --key @carol.pub --expires 2026-12-31
+```
+
+```bash
+# Preview a grant without changing anything
+nself access grant --host root@203.0.113.5 --user dave --key @dave.pub --dry-run
+```
+
+```bash
+# See who currently has access, then revoke someone who left
+nself access list --host root@203.0.113.5
+nself access revoke --host root@203.0.113.5 --user alice
+```
+<!-- END PROSE:examples -->
+
+## See Also
+
+<!-- BEGIN PROSE:see-also -->
+- [[cmd-security]], firewall, fail2ban, and sshd hardening for the same host
+- [[cmd-deploy]], the SSH transport `nself access` mirrors for connecting to staging and production
+- [[Commands]], full command index
+<!-- END PROSE:see-also -->
+
+← [[Commands]] | [[Home]] →

--- a/.github/wiki/llms.txt
+++ b/.github/wiki/llms.txt
@@ -14,7 +14,23 @@ nself build   # generate docker-compose + nginx
 nself start   # boot the stack
 ```
 
-## Commands (49)
+## Commands (50)
+
+### nself access
+
+Manage SSH key access on an already-deployed server
+
+```
+nself access <subcommand> [flags]
+```
+
+Subcommands:
+
+- `grant` — Grant a person SSH key access to a host
+- `list` — List who has SSH key access to a host
+- `revoke` — Revoke a person's SSH key access to a host
+
+Full page: [[cmd-access]]
 
 ### nself account
 

--- a/cmd/commands/access.go
+++ b/cmd/commands/access.go
@@ -1,0 +1,100 @@
+// Package commands — access.go
+//
+// `nself access` manages SSH keys on an already-deployed server: granting a
+// teammate access, revoking it, and listing who currently has it. This is
+// distinct from `nself security`, which hardens firewall/fail2ban/sshd on
+// the host but has no concept of individual keys or users, and distinct from
+// `hcloud ssh-key create`, which only injects a key at server-creation time
+// and does nothing for a server that is already running.
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// accessCmd is the parent command for `nself access ...`.
+var accessCmd = &cobra.Command{
+	Use:   "access",
+	Short: "Manage SSH key access on an already-deployed server",
+	Long: `Grant, revoke, and list SSH key access on a running nself host.
+
+Subcommands:
+  nself access grant    Add (or update) a person's key in authorized_keys
+  nself access revoke   Remove a person's key from authorized_keys
+  nself access list     Show who currently has access
+
+Every grant and revoke:
+  - is idempotent: re-granting the same key for the same person is a no-op
+  - backs up authorized_keys with a timestamp before making any change
+  - prints the key's fingerprint back for verification
+  - is recorded in a local audit log (~/.nself/access-audit.log)
+
+Revoke refuses to remove the last remaining key on a host unless --force is
+given, since that would lock out all SSH access. Pass --dry-run on grant or
+revoke to see the resulting authorized_keys diff without changing anything.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var accessGrantCmd = &cobra.Command{
+	Use:   "grant",
+	Short: "Grant a person SSH key access to a host",
+	Long: `Add a person's public key to a host's authorized_keys, or update it if
+they already have one.
+
+--sudo and --docker record the intended privilege level as metadata for
+audit and inventory purposes; this command does not itself modify OS group
+membership. Use your normal provisioning path (e.g. usermod -aG) for that.`,
+	Example: `  nself access grant --host root@203.0.113.5 --user alice --key @alice.pub
+  nself access grant --host root@203.0.113.5 --user bob --key "ssh-ed25519 AAAA... bob@laptop" --sudo
+  nself access grant --host root@203.0.113.5 --user carol --key @carol.pub --expires 2026-12-31
+  nself access grant --host root@203.0.113.5 --user dave --key @dave.pub --dry-run`,
+	RunE: runAccessGrant,
+}
+
+var accessRevokeCmd = &cobra.Command{
+	Use:   "revoke",
+	Short: "Revoke a person's SSH key access to a host",
+	Long: `Remove a person's public key from a host's authorized_keys.
+
+Refuses to remove the last remaining key on the host — that would lock out
+all SSH access — unless --force is given.`,
+	Example: `  nself access revoke --host root@203.0.113.5 --user alice
+  nself access revoke --host root@203.0.113.5 --user alice --dry-run
+  nself access revoke --host root@203.0.113.5 --user alice --force`,
+	RunE: runAccessRevoke,
+}
+
+var accessListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List who has SSH key access to a host",
+	Example: `  nself access list --host root@203.0.113.5
+  nself access list --host root@203.0.113.5 --json`,
+	RunE: runAccessList,
+}
+
+func init() {
+	for _, c := range []*cobra.Command{accessGrantCmd, accessRevokeCmd, accessListCmd} {
+		c.Flags().String("host", "", "SSH connection target, [user@]host (required)")
+		c.Flags().String("identity", "", "local SSH private key used to connect (default: ~/.ssh/id_ed25519)")
+	}
+
+	accessGrantCmd.Flags().String("user", "", "label identifying whose key this is (required)")
+	accessGrantCmd.Flags().String("key", "", "public key material, or @path/to/file (required)")
+	accessGrantCmd.Flags().Bool("sudo", false, "record sudo as the intended privilege level")
+	accessGrantCmd.Flags().Bool("docker", false, "record docker-group access as the intended privilege level")
+	accessGrantCmd.Flags().String("expires", "", "optional expiry date, YYYY-MM-DD")
+	accessGrantCmd.Flags().Bool("dry-run", false, "print the resulting authorized_keys diff, change nothing")
+
+	accessRevokeCmd.Flags().String("user", "", "label identifying whose key to remove (required)")
+	accessRevokeCmd.Flags().Bool("force", false, "allow removing the last remaining key on the host")
+	accessRevokeCmd.Flags().Bool("dry-run", false, "print the resulting authorized_keys diff, change nothing")
+
+	accessListCmd.Flags().Bool("json", false, "output as JSON")
+
+	accessCmd.AddCommand(accessGrantCmd)
+	accessCmd.AddCommand(accessRevokeCmd)
+	accessCmd.AddCommand(accessListCmd)
+	RootCmd.AddCommand(accessCmd)
+}

--- a/cmd/commands/access_grant.go
+++ b/cmd/commands/access_grant.go
@@ -1,0 +1,84 @@
+package commands
+
+// Purpose: `nself access grant` handler — validates flags, loads the public
+// key, and delegates to access.Grant, then reports the fingerprint and any
+// backup path back to the operator.
+// Inputs: --host, --identity, --user, --key, --sudo, --docker, --expires,
+// --dry-run.
+// Outputs: printed confirmation (or dry-run diff) plus the granted key's
+// fingerprint; a non-nil error on any validation or transport failure.
+
+import (
+	"fmt"
+
+	"github.com/nself-org/cli/internal/access"
+	"github.com/nself-org/cli/internal/ui"
+
+	"github.com/spf13/cobra"
+)
+
+func runAccessGrant(cmd *cobra.Command, args []string) error {
+	user, _ := cmd.Flags().GetString("user")
+	if user == "" {
+		return fmt.Errorf("--user is required")
+	}
+	keyArg, _ := cmd.Flags().GetString("key")
+	if keyArg == "" {
+		return fmt.Errorf("--key is required, e.g. --key @teammate.pub")
+	}
+	sudo, _ := cmd.Flags().GetBool("sudo")
+	docker, _ := cmd.Flags().GetBool("docker")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	expiresRaw, _ := cmd.Flags().GetString("expires")
+
+	expires, err := parseExpiry(expiresRaw)
+	if err != nil {
+		return err
+	}
+
+	key, err := access.LoadPublicKeyArg(keyArg)
+	if err != nil {
+		return fmt.Errorf("invalid --key: %w", err)
+	}
+
+	t, err := newAccessTransport(cmd)
+	if err != nil {
+		return err
+	}
+
+	ui.CommandHeader("nself access grant", t.Describe())
+
+	result, err := access.Grant(cmd.Context(), t, access.GrantRequest{
+		User: user, Key: key, Sudo: sudo, Docker: docker, Expires: expires, DryRun: dryRun,
+	})
+	if err != nil {
+		return fmt.Errorf("grant access for %s on %s: %w", user, t.Describe(), err)
+	}
+
+	if dryRun {
+		ui.Info("Dry run: no changes made. Resulting authorized_keys diff:")
+		fmt.Print(result.Diff)
+		return nil
+	}
+
+	if result.AlreadyGranted {
+		ui.Success(fmt.Sprintf("%s already has this exact key granted (%s)", user, result.Fingerprint))
+		return nil
+	}
+
+	if result.BackupPath != "" {
+		ui.Info("Backed up authorized_keys to " + result.BackupPath)
+	}
+	ui.Success(fmt.Sprintf("Granted %s access to %s", user, t.Describe()))
+	ui.Info("Fingerprint: " + result.Fingerprint)
+	if sudo {
+		ui.Warn("--sudo is recorded as metadata only; this command does not add " + user + " to the sudo group")
+	}
+	if docker {
+		ui.Warn("--docker is recorded as metadata only; this command does not add " + user + " to the docker group")
+	}
+	if expires != nil {
+		ui.Info("Expires: " + expires.Format("2006-01-02"))
+	}
+	return nil
+}

--- a/cmd/commands/access_list.go
+++ b/cmd/commands/access_list.go
@@ -1,0 +1,103 @@
+package commands
+
+// Purpose: `nself access list` handler — renders access.List's result as a
+// table (default) or JSON (--json).
+// Inputs: --host, --identity, --json.
+// Outputs: a table (or JSON array) of managed entries, plus a note about any
+// foreign (non-nself-managed) keys sharing the file.
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/nself-org/cli/internal/access"
+	"github.com/nself-org/cli/internal/ui"
+
+	"github.com/spf13/cobra"
+)
+
+// accessListRow is the JSON representation of one managed entry.
+type accessListRow struct {
+	User        string `json:"user"`
+	Fingerprint string `json:"fingerprint"`
+	Sudo        bool   `json:"sudo"`
+	Docker      bool   `json:"docker"`
+	Expires     string `json:"expires,omitempty"`
+	Expired     bool   `json:"expired"`
+	Granted     string `json:"granted"`
+}
+
+func runAccessList(cmd *cobra.Command, args []string) error {
+	jsonOut, _ := cmd.Flags().GetBool("json")
+
+	t, err := newAccessTransport(cmd)
+	if err != nil {
+		return err
+	}
+
+	if !jsonOut {
+		ui.CommandHeader("nself access list", t.Describe())
+	}
+
+	result, err := access.List(cmd.Context(), t)
+	if err != nil {
+		return fmt.Errorf("list access on %s: %w", t.Describe(), err)
+	}
+
+	now := time.Now()
+	rows := make([]accessListRow, 0, len(result.Entries))
+	for _, e := range result.Entries {
+		row := accessListRow{
+			User:        e.User,
+			Fingerprint: e.Fingerprint(),
+			Sudo:        e.Sudo,
+			Docker:      e.Docker,
+			Expired:     e.Expired(now),
+			Granted:     e.Granted.UTC().Format(time.RFC3339),
+		}
+		if e.Expires != nil {
+			row.Expires = e.Expires.Format("2006-01-02")
+		}
+		rows = append(rows, row)
+	}
+
+	if jsonOut {
+		return ui.PrintJSON(rows)
+	}
+
+	if len(rows) == 0 {
+		fmt.Println("No nself-managed keys found. Run 'nself access grant' to add one.")
+	} else {
+		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "USER\tFINGERPRINT\tSUDO\tDOCKER\tEXPIRES\tSTATUS")
+		for _, r := range rows {
+			sudo, docker, status := "no", "no", "active"
+			if r.Sudo {
+				sudo = "yes"
+			}
+			if r.Docker {
+				docker = "yes"
+			}
+			if r.Expired {
+				status = "expired"
+			}
+			expires := r.Expires
+			if expires == "" {
+				expires = "-"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", r.User, r.Fingerprint, sudo, docker, expires, status)
+		}
+		if err := tw.Flush(); err != nil {
+			return fmt.Errorf("flush table: %w", err)
+		}
+	}
+
+	if result.ForeignCount > 0 {
+		ui.Warn(fmt.Sprintf(
+			"%d key(s) in authorized_keys were not granted by nself access and are left untouched",
+			result.ForeignCount))
+	}
+	return nil
+}

--- a/cmd/commands/access_revoke.go
+++ b/cmd/commands/access_revoke.go
@@ -1,0 +1,59 @@
+package commands
+
+// Purpose: `nself access revoke` handler — delegates to access.Revoke and
+// surfaces the ErrLastKey lockout guard as an actionable error rather than a
+// raw wrapped message.
+// Inputs: --host, --identity, --user, --force, --dry-run.
+// Outputs: printed confirmation (or dry-run diff) plus the revoked key's
+// fingerprint; a non-nil error when the user is unknown or the lockout guard
+// trips.
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/nself-org/cli/internal/access"
+	"github.com/nself-org/cli/internal/ui"
+
+	"github.com/spf13/cobra"
+)
+
+func runAccessRevoke(cmd *cobra.Command, args []string) error {
+	user, _ := cmd.Flags().GetString("user")
+	if user == "" {
+		return fmt.Errorf("--user is required")
+	}
+	force, _ := cmd.Flags().GetBool("force")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	t, err := newAccessTransport(cmd)
+	if err != nil {
+		return err
+	}
+
+	ui.CommandHeader("nself access revoke", t.Describe())
+
+	result, err := access.Revoke(cmd.Context(), t, access.RevokeRequest{
+		User: user, Force: force, DryRun: dryRun,
+	})
+	if err != nil {
+		if errors.Is(err, access.ErrLastKey) {
+			ui.Error(err.Error())
+			return fmt.Errorf("revoke access for %s on %s: last key on host", user, t.Describe())
+		}
+		return fmt.Errorf("revoke access for %s on %s: %w", user, t.Describe(), err)
+	}
+
+	if dryRun {
+		ui.Info("Dry run: no changes made. Resulting authorized_keys diff:")
+		fmt.Print(result.Diff)
+		return nil
+	}
+
+	if result.BackupPath != "" {
+		ui.Info("Backed up authorized_keys to " + result.BackupPath)
+	}
+	ui.Success(fmt.Sprintf("Revoked %s's access to %s", user, t.Describe()))
+	ui.Info("Fingerprint: " + result.Fingerprint)
+	return nil
+}

--- a/cmd/commands/access_test.go
+++ b/cmd/commands/access_test.go
@@ -1,0 +1,202 @@
+package commands
+
+// Tests exercise the `nself access` cobra wiring end to end against a
+// LocalFileTransport fixture (via the newAccessTransport indirection in
+// access_transport.go) — never against a real SSH connection. See
+// internal/access/manager_test.go for the deeper grant/revoke/list behavior
+// tests; these tests confirm the CLI layer wires flags to that package
+// correctly.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nself-org/cli/internal/access"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const testKeyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMHXHuK8L4SFSmmpHWBnzPFAcJGYHjABCulfo5ZbKvum alice@laptop"
+
+// withFixtureTransport points newAccessTransport at a LocalFileTransport
+// rooted in a temp file for the duration of the test, restoring the real
+// (SSH-backed) factory afterward.
+func withFixtureTransport(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authorized_keys")
+
+	restoreAudit := access.SetAuditLogPathForTest(filepath.Join(dir, "audit.log"))
+	old := newAccessTransport
+	newAccessTransport = func(cmd *cobra.Command) (access.Transport, error) {
+		return access.NewLocalFileTransport(path), nil
+	}
+	t.Cleanup(func() {
+		newAccessTransport = old
+		restoreAudit()
+	})
+	return path
+}
+
+// resetFlags restores every flag on cmd to its registered default so tests
+// calling RunE repeatedly on the shared package-level command vars don't leak
+// state between each other.
+func resetFlags(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+}
+
+func TestAccessCmd_Structure(t *testing.T) {
+	names := map[string]bool{}
+	for _, c := range accessCmd.Commands() {
+		names[c.Name()] = true
+	}
+	for _, want := range []string{"grant", "revoke", "list"} {
+		if !names[want] {
+			t.Errorf("missing subcommand: %s", want)
+		}
+	}
+}
+
+func TestAccessGrantCmd_RequiredFlags(t *testing.T) {
+	for _, name := range []string{"host", "identity", "user", "key", "sudo", "docker", "expires", "dry-run"} {
+		if accessGrantCmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing --%s flag on access grant", name)
+		}
+	}
+}
+
+func TestAccessRevokeCmd_RequiredFlags(t *testing.T) {
+	for _, name := range []string{"host", "identity", "user", "force", "dry-run"} {
+		if accessRevokeCmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing --%s flag on access revoke", name)
+		}
+	}
+}
+
+func TestAccessListCmd_RequiredFlags(t *testing.T) {
+	for _, name := range []string{"host", "identity", "json"} {
+		if accessListCmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing --%s flag on access list", name)
+		}
+	}
+}
+
+func TestRunAccessGrant_MissingUser(t *testing.T) {
+	defer resetFlags(accessGrantCmd)
+	withFixtureTransport(t)
+	accessGrantCmd.SetContext(context.Background())
+	_ = accessGrantCmd.Flags().Set("key", testKeyLine)
+
+	if err := runAccessGrant(accessGrantCmd, nil); err == nil {
+		t.Fatal("expected error when --user is missing")
+	}
+}
+
+func TestRunAccessGrant_MissingKey(t *testing.T) {
+	defer resetFlags(accessGrantCmd)
+	withFixtureTransport(t)
+	accessGrantCmd.SetContext(context.Background())
+	_ = accessGrantCmd.Flags().Set("user", "alice")
+
+	if err := runAccessGrant(accessGrantCmd, nil); err == nil {
+		t.Fatal("expected error when --key is missing")
+	}
+}
+
+func TestRunAccessGrant_InvalidExpiry(t *testing.T) {
+	defer resetFlags(accessGrantCmd)
+	withFixtureTransport(t)
+	accessGrantCmd.SetContext(context.Background())
+	_ = accessGrantCmd.Flags().Set("user", "alice")
+	_ = accessGrantCmd.Flags().Set("key", testKeyLine)
+	_ = accessGrantCmd.Flags().Set("expires", "not-a-date")
+
+	if err := runAccessGrant(accessGrantCmd, nil); err == nil {
+		t.Fatal("expected error for a malformed --expires value")
+	}
+}
+
+func TestRunAccessGrant_MissingHost(t *testing.T) {
+	defer resetFlags(accessGrantCmd)
+	// Deliberately do not call withFixtureTransport: this exercises the real
+	// buildAccessTransport path, which must reject an empty --host before
+	// ever touching SSH.
+	accessGrantCmd.SetContext(context.Background())
+	_ = accessGrantCmd.Flags().Set("user", "alice")
+	_ = accessGrantCmd.Flags().Set("key", testKeyLine)
+
+	if err := runAccessGrant(accessGrantCmd, nil); err == nil {
+		t.Fatal("expected error when --host is missing")
+	}
+}
+
+func TestAccessGrantListRevoke_EndToEnd(t *testing.T) {
+	path := withFixtureTransport(t)
+	ctx := context.Background()
+
+	defer resetFlags(accessGrantCmd)
+	accessGrantCmd.SetContext(ctx)
+	_ = accessGrantCmd.Flags().Set("host", "root@fixture")
+	_ = accessGrantCmd.Flags().Set("user", "alice")
+	_ = accessGrantCmd.Flags().Set("key", testKeyLine)
+	if err := runAccessGrant(accessGrantCmd, nil); err != nil {
+		t.Fatalf("runAccessGrant: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected authorized_keys to be created: %v", err)
+	}
+
+	defer resetFlags(accessListCmd)
+	accessListCmd.SetContext(ctx)
+	_ = accessListCmd.Flags().Set("host", "root@fixture")
+	if err := runAccessList(accessListCmd, nil); err != nil {
+		t.Fatalf("runAccessList: %v", err)
+	}
+
+	defer resetFlags(accessRevokeCmd)
+	accessRevokeCmd.SetContext(ctx)
+	_ = accessRevokeCmd.Flags().Set("host", "root@fixture")
+	_ = accessRevokeCmd.Flags().Set("user", "alice")
+	_ = accessRevokeCmd.Flags().Set("force", "true")
+	if err := runAccessRevoke(accessRevokeCmd, nil); err != nil {
+		t.Fatalf("runAccessRevoke: %v", err)
+	}
+}
+
+func TestRunAccessRevoke_MissingUser(t *testing.T) {
+	defer resetFlags(accessRevokeCmd)
+	withFixtureTransport(t)
+	accessRevokeCmd.SetContext(context.Background())
+
+	if err := runAccessRevoke(accessRevokeCmd, nil); err == nil {
+		t.Fatal("expected error when --user is missing")
+	}
+}
+
+func TestDefaultIdentityPath_NonEmpty(t *testing.T) {
+	if defaultIdentityPath() == "" {
+		t.Error("defaultIdentityPath() must never be empty")
+	}
+}
+
+func TestParseExpiry_EmptyIsNil(t *testing.T) {
+	got, err := parseExpiry("")
+	if err != nil {
+		t.Fatalf("parseExpiry(\"\"): %v", err)
+	}
+	if got != nil {
+		t.Errorf("parseExpiry(\"\") = %v, want nil", got)
+	}
+}
+
+func TestParseExpiry_InvalidFormat(t *testing.T) {
+	if _, err := parseExpiry("31-12-2026"); err == nil {
+		t.Fatal("expected error for non-ISO date format")
+	}
+}

--- a/cmd/commands/access_transport.go
+++ b/cmd/commands/access_transport.go
@@ -1,0 +1,73 @@
+package commands
+
+// Purpose: shared flag handling for the `nself access` subcommands — turning
+// --host/--identity into an access.Transport, and --expires into a
+// *time.Time. Split out of access.go so the cobra wiring stays a plain
+// command tree.
+// Inputs: a *cobra.Command carrying --host/--identity flags.
+// Outputs: an access.Transport (always SSHTransport in the real CLI —
+// LocalFileTransport is exercised only by tests in internal/access and
+// access_test.go) or a parse error.
+// Constraints: --host has no default; a hardcoded IP here would be exactly
+// the kind of accidental-production-target footgun this command exists to
+// prevent, so the operator must always name the host explicitly.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/nself-org/cli/internal/access"
+
+	"github.com/spf13/cobra"
+)
+
+// newAccessTransport is a package-level indirection so access_test.go can
+// substitute a fixture Transport (LocalFileTransport over a temp dir)
+// without any of the grant/revoke/list handlers knowing the difference. The
+// real CLI never reassigns it — every live invocation resolves through
+// buildAccessTransport to SSHTransport.
+var newAccessTransport = buildAccessTransport
+
+// buildAccessTransport resolves --host/--identity into a Transport. It
+// never invokes ssh itself; SSHTransport only runs commands when Grant,
+// Revoke, or List actually call Read/Backup/Write.
+func buildAccessTransport(cmd *cobra.Command) (access.Transport, error) {
+	host, _ := cmd.Flags().GetString("host")
+	if host == "" {
+		return nil, fmt.Errorf("--host is required, e.g. --host root@203.0.113.5")
+	}
+
+	identity, _ := cmd.Flags().GetString("identity")
+	if identity == "" {
+		identity = defaultIdentityPath()
+	}
+
+	return &access.SSHTransport{Host: host, IdentityPath: identity}, nil
+}
+
+// defaultIdentityPath mirrors the fallback used by 'nself deploy' for its own
+// SSH key: NSELF_DEPLOY_KEY_PATH, then ~/.ssh/id_ed25519.
+func defaultIdentityPath() string {
+	if k := os.Getenv("NSELF_DEPLOY_KEY_PATH"); k != "" {
+		return k
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "id_ed25519"
+	}
+	return filepath.Join(home, ".ssh", "id_ed25519")
+}
+
+// parseExpiry parses --expires (YYYY-MM-DD), returning nil for an empty flag.
+func parseExpiry(raw string) (*time.Time, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	t, err := time.Parse("2006-01-02", raw)
+	if err != nil {
+		return nil, fmt.Errorf("--expires must be YYYY-MM-DD, got %q: %w", raw, err)
+	}
+	return &t, nil
+}

--- a/cmd/commands/error_harness_test.go
+++ b/cmd/commands/error_harness_test.go
@@ -43,6 +43,11 @@ type errorHarnessCase struct {
 // "invalid-flag" uses a clearly unknown flag name that cobra will reject.
 // "unknown-sub" uses a subcommand name that does not exist.
 var errorHarnessCases = []errorHarnessCase{
+	// ── access ─────────────────────────────────────────────────────────────
+	{"access", []string{"access"}, "(a) no project dir"},
+	{"access", []string{"access", "--no-such-flag-xyz"}, "(b) invalid flag"},
+	{"access", []string{"access", "unknownsub_xyz"}, "(c) unknown sub"},
+
 	// ── admin ──────────────────────────────────────────────────────────────
 	{"admin", []string{"admin"}, "(a) no project dir"},
 	{"admin", []string{"admin", "--no-such-flag-xyz"}, "(b) invalid flag"},

--- a/cmd/commands/groups.go
+++ b/cmd/commands/groups.go
@@ -106,6 +106,7 @@ var commandGroupAssignments = map[string]string{
 	"telemetry":   groupAccount,
 
 	// Advanced & Enterprise.
+	"access":      groupAdvanced,
 	"security":    groupAdvanced,
 	"verify-sbom": groupAdvanced,
 }

--- a/internal/access/audit.go
+++ b/internal/access/audit.go
@@ -1,0 +1,85 @@
+package access
+
+// Purpose: a local, append-only audit trail of every grant/revoke mutation,
+// so "was this key actually granted" never again depends on someone's
+// memory of a manual ssh session (the failure mode issue #238 was filed
+// against). The log lives on the operator's own machine, not the remote
+// host — it records who ran what, not a remote-side event.
+// Inputs: an auditRecord per mutation.
+// Outputs: one key=value line appended to ~/.nself/access-audit.log.
+// Constraints: never writes private key material, only fingerprints; a
+// failure to write the audit line is reported to the caller but must never
+// block or reverse the grant/revoke it is recording.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// auditRecord is one grant/revoke event.
+type auditRecord struct {
+	Action      string // "grant" or "revoke"
+	Host        string
+	User        string
+	Fingerprint string
+	Sudo        bool
+	Docker      bool
+	Expires     *time.Time
+}
+
+// currentAuditLogPath is a function variable so tests can redirect audit
+// output to a temp file instead of the operator's real home directory.
+// SetAuditLogPathForTest is the only intended caller of the setter half.
+var currentAuditLogPath = defaultAuditLogPath
+
+// defaultAuditLogPath returns ~/.nself/access-audit.log, falling back to a
+// temp-dir path when the home directory can't be resolved (mirrors the
+// fallback convention in internal/plugin/paths.go).
+func defaultAuditLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".nself", "access-audit.log")
+	}
+	return filepath.Join(home, ".nself", "access-audit.log")
+}
+
+// SetAuditLogPathForTest redirects the audit log to path for the duration of
+// a test and returns a restore function to call in a defer.
+func SetAuditLogPathForTest(path string) func() {
+	old := currentAuditLogPath
+	currentAuditLogPath = func() string { return path }
+	return func() { currentAuditLogPath = old }
+}
+
+// writeAudit appends one line to the local access audit log.
+func writeAudit(r auditRecord) error {
+	path := currentAuditLogPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create audit log dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open audit log: %w", err)
+	}
+	defer f.Close()
+
+	line := fmt.Sprintf("ts=%s action=%s host=%s user=%s fingerprint=%s sudo=%t docker=%t",
+		time.Now().UTC().Format(time.RFC3339),
+		sanitizeField(r.Action), sanitizeField(r.Host), sanitizeField(r.User),
+		r.Fingerprint, r.Sudo, r.Docker)
+	if r.Expires != nil {
+		line += " expires=" + r.Expires.UTC().Format("2006-01-02")
+	}
+	line += "\n"
+
+	_, err = f.WriteString(line)
+	return err
+}
+
+// sanitizeField removes characters that could break the key=value log format.
+func sanitizeField(s string) string {
+	return strings.NewReplacer(" ", "_", "\n", "", "\r", "", "=", "_").Replace(s)
+}

--- a/internal/access/entry.go
+++ b/internal/access/entry.go
@@ -1,0 +1,119 @@
+package access
+
+// Purpose: the on-disk representation of one nself-managed authorized_keys
+// line, and the parsing/rendering between that line and an Entry value.
+// Inputs: a raw authorized_keys line (parseEntry) or an Entry (render).
+// Outputs: an Entry plus an ok flag distinguishing nself-managed lines from
+// foreign ones (someone else's key, blank lines, plain comments).
+// Constraints: unrecognized or malformed managed-looking lines are treated
+// as foreign rather than erroring — a corrupt tag must never block grant/
+// revoke/list on the rest of the file.
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// tagPrefix marks the comment field of a line this package owns. Everything
+// after it is "key=value" pairs separated by ';'.
+const tagPrefix = "nself-access:"
+
+// Entry is one nself-managed authorized_keys line: a single public key
+// granted to a named person, with optional privilege metadata and expiry.
+type Entry struct {
+	// User is the label identifying whose key this is (e.g. a teammate's
+	// name), not necessarily a Unix account — grant/revoke key entries by
+	// this label, independent of which OS account authorized_keys belongs to.
+	User string
+	Key  PublicKey
+
+	// Sudo and Docker record the intended privilege level for this grant.
+	// They are audit/inventory metadata only: this package does not itself
+	// modify OS group membership. See the access wiki page for the reasoning.
+	Sudo   bool
+	Docker bool
+
+	Expires *time.Time
+	Granted time.Time
+}
+
+// Fingerprint is a convenience wrapper around Key.Fingerprint. A managed
+// entry's key has already been validated once at grant time, so a parse
+// error here (which should not happen) degrades to an empty string rather
+// than panicking a caller that only wants a display value.
+func (e Entry) Fingerprint() string {
+	fp, _ := e.Key.Fingerprint()
+	return fp
+}
+
+// Expired reports whether e carries an expiry that has passed as of now.
+func (e Entry) Expired(now time.Time) bool {
+	return e.Expires != nil && now.After(*e.Expires)
+}
+
+// render produces the full authorized_keys line for e.
+func (e Entry) render() string {
+	tag := fmt.Sprintf("user=%s;sudo=%t;docker=%t;granted=%s",
+		e.User, e.Sudo, e.Docker, e.Granted.UTC().Format(time.RFC3339))
+	if e.Expires != nil {
+		tag += ";expires=" + e.Expires.UTC().Format("2006-01-02")
+	}
+	return e.Key.Line() + " " + tagPrefix + tag
+}
+
+// parseEntry parses one authorized_keys line as a managed entry. ok is false
+// for lines this package does not own (foreign keys, blanks, plain
+// comments, or a managed-looking line whose key no longer parses) — callers
+// must preserve those lines verbatim rather than altering them.
+func parseEntry(line string) (Entry, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 3 {
+		return Entry{}, false
+	}
+
+	var tagField string
+	for _, f := range fields[2:] {
+		if strings.HasPrefix(f, tagPrefix) {
+			tagField = strings.TrimPrefix(f, tagPrefix)
+			break
+		}
+	}
+	if tagField == "" {
+		return Entry{}, false
+	}
+
+	key, err := ParsePublicKey(fields[0] + " " + fields[1])
+	if err != nil {
+		return Entry{}, false
+	}
+
+	e := Entry{Key: key}
+	for _, kv := range strings.Split(tagField, ";") {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		switch parts[0] {
+		case "user":
+			e.User = parts[1]
+		case "sudo":
+			e.Sudo, _ = strconv.ParseBool(parts[1])
+		case "docker":
+			e.Docker, _ = strconv.ParseBool(parts[1])
+		case "granted":
+			if t, err := time.Parse(time.RFC3339, parts[1]); err == nil {
+				e.Granted = t
+			}
+		case "expires":
+			if t, err := time.Parse("2006-01-02", parts[1]); err == nil {
+				e.Expires = &t
+			}
+		}
+	}
+	if e.User == "" {
+		return Entry{}, false
+	}
+	return e, true
+}

--- a/internal/access/file.go
+++ b/internal/access/file.go
@@ -1,0 +1,111 @@
+package access
+
+// Purpose: an in-memory model of one authorized_keys file that preserves the
+// original line order and every foreign (non-nself-managed) line exactly as
+// found, while indexing nself-managed entries by their user label for O(1)
+// lookup, replace, and remove.
+// Inputs: raw authorized_keys bytes (parseAuthFile).
+// Outputs: rendered authorized_keys bytes (render) after upsert/remove.
+// Constraints: never reorders or rewrites a foreign line; the lockout guard
+// in manager.go depends on totalKeyLines counting every key line, managed or
+// not, since removing anyone's last key locks out that account either way.
+
+import "strings"
+
+// authFile is the parsed content of one authorized_keys file.
+type authFile struct {
+	lines   []string       // original order; managed lines are replaced in place
+	managed map[string]int // user label -> index into lines
+}
+
+// parseAuthFile parses raw authorized_keys content. Empty content parses to
+// an empty file rather than an error — a missing or new authorized_keys file
+// is the normal starting point for the first grant on a host.
+func parseAuthFile(content []byte) *authFile {
+	f := &authFile{managed: map[string]int{}}
+	text := strings.TrimRight(string(content), "\n")
+	if text == "" {
+		return f
+	}
+	for _, line := range strings.Split(text, "\n") {
+		f.lines = append(f.lines, line)
+		if e, ok := parseEntry(line); ok {
+			f.managed[e.User] = len(f.lines) - 1
+		}
+	}
+	return f
+}
+
+// totalKeyLines counts every line that carries an actual key, managed or
+// foreign — blank lines and pure comments don't count. This is the count the
+// revoke lockout guard checks against: it is the number of keys that could
+// still log in, not the number of lines in the file.
+func (f *authFile) totalKeyLines() int {
+	n := 0
+	for _, l := range f.lines {
+		t := strings.TrimSpace(l)
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// get returns the managed entry for user, if one exists.
+func (f *authFile) get(user string) (Entry, bool) {
+	idx, ok := f.managed[user]
+	if !ok {
+		return Entry{}, false
+	}
+	return parseEntry(f.lines[idx])
+}
+
+// upsert replaces the existing managed line for e.User in place, preserving
+// its position, or appends a new line when e.User has no existing entry.
+func (f *authFile) upsert(e Entry) {
+	line := e.render()
+	if idx, ok := f.managed[e.User]; ok {
+		f.lines[idx] = line
+		return
+	}
+	f.lines = append(f.lines, line)
+	f.managed[e.User] = len(f.lines) - 1
+}
+
+// remove deletes the managed line for user, if present, and reports whether
+// it found one to delete.
+func (f *authFile) remove(user string) bool {
+	idx, ok := f.managed[user]
+	if !ok {
+		return false
+	}
+	f.lines = append(f.lines[:idx], f.lines[idx+1:]...)
+	delete(f.managed, user)
+	for u, i := range f.managed {
+		if i > idx {
+			f.managed[u] = i - 1
+		}
+	}
+	return true
+}
+
+// render serializes the file back to authorized_keys bytes, newline-terminated.
+func (f *authFile) render() []byte {
+	if len(f.lines) == 0 {
+		return []byte{}
+	}
+	return []byte(strings.Join(f.lines, "\n") + "\n")
+}
+
+// entries returns every nself-managed entry, in no particular order; callers
+// that need a stable order (e.g. `nself access list`) sort the result.
+func (f *authFile) entries() []Entry {
+	out := make([]Entry, 0, len(f.managed))
+	for _, idx := range f.managed {
+		if e, ok := parseEntry(f.lines[idx]); ok {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/internal/access/file_test.go
+++ b/internal/access/file_test.go
@@ -1,0 +1,99 @@
+package access
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseAuthFile_PreservesForeignLines(t *testing.T) {
+	content := "# a comment\n\nssh-rsa AAAAB3NzaC1yc2E foreign-key\n"
+	f := parseAuthFile([]byte(content))
+	if len(f.managed) != 0 {
+		t.Errorf("expected no managed entries, got %d", len(f.managed))
+	}
+	if got := string(f.render()); got != content {
+		t.Errorf("render() = %q, want unchanged %q", got, content)
+	}
+}
+
+func TestParseAuthFile_MalformedTagTreatedAsForeign(t *testing.T) {
+	// A line that starts the nself-access: tag but has no "user=" key must not
+	// be treated as managed — a corrupt tag must never block the rest of the
+	// file from being read.
+	line := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMHXHuK8L4SFSmmpHWBnzPFAcJGYHjABCulfo5ZbKvum nself-access:sudo=true"
+	f := parseAuthFile([]byte(line + "\n"))
+	if len(f.managed) != 0 {
+		t.Errorf("expected the malformed tag line to be treated as foreign, got %d managed", len(f.managed))
+	}
+	if f.totalKeyLines() != 1 {
+		t.Errorf("totalKeyLines() = %d, want 1 (still counts as a key)", f.totalKeyLines())
+	}
+}
+
+func TestAuthFile_UpsertThenRemove(t *testing.T) {
+	f := parseAuthFile(nil)
+	e := Entry{User: "alice"}
+	akey, _ := ParsePublicKey(aliceKeyLine)
+	e.Key = akey
+
+	f.upsert(e)
+	if _, ok := f.get("alice"); !ok {
+		t.Fatal("expected alice to be present after upsert")
+	}
+	if f.totalKeyLines() != 1 {
+		t.Errorf("totalKeyLines() = %d, want 1", f.totalKeyLines())
+	}
+
+	if !f.remove("alice") {
+		t.Fatal("remove() = false, want true")
+	}
+	if _, ok := f.get("alice"); ok {
+		t.Error("expected alice to be gone after remove")
+	}
+	if f.totalKeyLines() != 0 {
+		t.Errorf("totalKeyLines() = %d, want 0", f.totalKeyLines())
+	}
+}
+
+func TestAuthFile_RemoveReindexesLaterEntries(t *testing.T) {
+	f := parseAuthFile(nil)
+	akey, _ := ParsePublicKey(aliceKeyLine)
+	bkey, _ := ParsePublicKey(bobKeyLine)
+	f.upsert(Entry{User: "alice", Key: akey})
+	f.upsert(Entry{User: "bob", Key: bkey})
+
+	if !f.remove("alice") {
+		t.Fatal("remove(alice) = false")
+	}
+	bob, ok := f.get("bob")
+	if !ok {
+		t.Fatal("bob missing after removing alice")
+	}
+	if bob.User != "bob" {
+		t.Errorf("bob.User = %q after reindex", bob.User)
+	}
+}
+
+func TestAuthFile_RemoveUnknownUser(t *testing.T) {
+	f := parseAuthFile(nil)
+	if f.remove("nobody") {
+		t.Error("remove() of an unknown user should return false")
+	}
+}
+
+func TestEntry_RenderRoundTrip(t *testing.T) {
+	akey, _ := ParsePublicKey(aliceKeyLine)
+	e := Entry{User: "alice", Key: akey, Sudo: true, Docker: false}
+	line := e.render()
+	if !strings.Contains(line, "user=alice") || !strings.Contains(line, "sudo=true") || !strings.Contains(line, "docker=false") {
+		t.Errorf("render() missing expected fields: %s", line)
+	}
+
+	parsed, ok := parseEntry(line)
+	if !ok {
+		t.Fatalf("parseEntry() failed to parse its own render() output: %s", line)
+	}
+	if parsed.User != "alice" || !parsed.Sudo || parsed.Docker {
+		t.Errorf("round-tripped entry = %+v", parsed)
+	}
+}

--- a/internal/access/key.go
+++ b/internal/access/key.go
@@ -1,0 +1,101 @@
+// Package access implements the business logic behind `nself access grant /
+// revoke / list` — managing SSH public keys in the authorized_keys file of an
+// already-deployed nself host. It never touches private key material: every
+// entry point here accepts or produces public keys and fingerprints only.
+//
+// Purpose: fill the gap where hcloud only injects SSH keys at server-creation
+// time, leaving no CLI path to grant or revoke access on a running box
+// without hand-editing authorized_keys over a raw ssh session.
+// Inputs: a Transport (SSHTransport in production, LocalFileTransport in
+// tests) plus a parsed PublicKey and request options.
+// Outputs: GrantResult / RevokeResult / ListResult describing what changed,
+// including the key fingerprint for verification.
+// Constraints: idempotent grant, timestamped backup before every mutation,
+// a lockout guard on revoke, and an audit line per mutation. See
+// manager.go, transport.go, and audit.go for the pieces of that contract.
+package access
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// knownKeyTypes are the SSH public key algorithm identifiers this package
+// accepts in an authorized_keys line. FIDO2/U2F "sk-" types are deliberately
+// excluded: their security-key application string can't be verified without
+// real hardware, which is out of scope for static authorized_keys management.
+var knownKeyTypes = map[string]bool{
+	"ssh-ed25519":         true,
+	"ssh-rsa":             true,
+	"ecdsa-sha2-nistp256": true,
+	"ecdsa-sha2-nistp384": true,
+	"ecdsa-sha2-nistp521": true,
+}
+
+// PublicKey is a parsed SSH public key: its algorithm identifier and the
+// base64-encoded key blob. A PublicKey never carries private key material.
+type PublicKey struct {
+	Type string
+	Data string // base64, undecoded
+}
+
+// Fingerprint returns the key's fingerprint in the same format `ssh-keygen
+// -lf` prints: "SHA256:<unpadded base64 of sha256(key blob)>".
+func (k PublicKey) Fingerprint() (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(k.Data)
+	if err != nil {
+		return "", fmt.Errorf("decode key data: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return "SHA256:" + base64.RawStdEncoding.EncodeToString(sum[:]), nil
+}
+
+// Line renders "<type> <data>" with no comment. Callers append their own
+// nself-managed tag comment (see entry.go).
+func (k PublicKey) Line() string {
+	return k.Type + " " + k.Data
+}
+
+// ParsePublicKey parses a single authorized_keys-style public key line
+// ("<type> <base64> [comment...]"), ignoring any comment. It refuses input
+// that looks like a private key without echoing that input anywhere, so a
+// pasted private key is never reflected back to the terminal or a log line.
+func ParsePublicKey(input string) (PublicKey, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return PublicKey{}, fmt.Errorf("empty key")
+	}
+	if strings.Contains(trimmed, "PRIVATE KEY") || strings.HasPrefix(trimmed, "-----BEGIN") {
+		return PublicKey{}, fmt.Errorf("input looks like a private key, refusing to process it")
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) < 2 {
+		return PublicKey{}, fmt.Errorf(`not a valid public key: expected "<type> <base64> [comment]"`)
+	}
+	keyType, data := fields[0], fields[1]
+	if !knownKeyTypes[keyType] {
+		return PublicKey{}, fmt.Errorf("unrecognized key type %q", keyType)
+	}
+	if _, err := base64.StdEncoding.DecodeString(data); err != nil {
+		return PublicKey{}, fmt.Errorf("key data is not valid base64: %w", err)
+	}
+	return PublicKey{Type: keyType, Data: data}, nil
+}
+
+// LoadPublicKeyArg resolves the `--key <pubkey|@file>` convention: a leading
+// '@' means read the key from the given file path, otherwise arg is the key
+// material itself.
+func LoadPublicKeyArg(arg string) (PublicKey, error) {
+	if strings.HasPrefix(arg, "@") {
+		path := strings.TrimPrefix(arg, "@")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return PublicKey{}, fmt.Errorf("read key file %s: %w", path, err)
+		}
+		return ParsePublicKey(string(data))
+	}
+	return ParsePublicKey(arg)
+}

--- a/internal/access/key_test.go
+++ b/internal/access/key_test.go
@@ -1,0 +1,135 @@
+package access
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Real ed25519 test key pairs (private keys never committed; only the public
+// half is used below). Fingerprints were cross-checked against
+// `ssh-keygen -lf` at generation time.
+const (
+	aliceKeyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMHXHuK8L4SFSmmpHWBnzPFAcJGYHjABCulfo5ZbKvum alice@laptop"
+	aliceFP      = "SHA256:xSHvs9nsoAaHR9Qv9VEm9Y6DcfkbzATUCdhmauT0wPE"
+
+	bobKeyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDmqUPnm+iR5W527+R5Ywlz6xa4buFbxjsuRNndFuV0x bob@laptop"
+	bobFP      = "SHA256:LKOm0DCMdjvdbE/MMP/x5Z76+9erJDhRdDYPydH3yL0"
+)
+
+func TestParsePublicKey_ValidKey(t *testing.T) {
+	k, err := ParsePublicKey(aliceKeyLine)
+	if err != nil {
+		t.Fatalf("ParsePublicKey: %v", err)
+	}
+	if k.Type != "ssh-ed25519" {
+		t.Errorf("Type = %q, want ssh-ed25519", k.Type)
+	}
+	fp, err := k.Fingerprint()
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+	if fp != aliceFP {
+		t.Errorf("Fingerprint = %q, want %q", fp, aliceFP)
+	}
+}
+
+func TestParsePublicKey_SecondKeyDifferentFingerprint(t *testing.T) {
+	k, err := ParsePublicKey(bobKeyLine)
+	if err != nil {
+		t.Fatalf("ParsePublicKey: %v", err)
+	}
+	fp, _ := k.Fingerprint()
+	if fp != bobFP {
+		t.Errorf("Fingerprint = %q, want %q", fp, bobFP)
+	}
+	if fp == aliceFP {
+		t.Error("bob's fingerprint must not equal alice's")
+	}
+}
+
+func TestParsePublicKey_RejectsPrivateKeyLookingInput(t *testing.T) {
+	_, err := ParsePublicKey("-----BEGIN OPENSSH PRIVATE KEY-----\nsomefakecontent\n-----END OPENSSH PRIVATE KEY-----")
+	if err == nil {
+		t.Fatal("expected error for private-key-looking input")
+	}
+	if strings.Contains(err.Error(), "fakecontent") {
+		t.Error("error message must not echo the raw input")
+	}
+}
+
+func TestParsePublicKey_RejectsEmpty(t *testing.T) {
+	if _, err := ParsePublicKey(""); err == nil {
+		t.Fatal("expected error for empty input")
+	}
+	if _, err := ParsePublicKey("   "); err == nil {
+		t.Fatal("expected error for whitespace-only input")
+	}
+}
+
+func TestParsePublicKey_RejectsUnknownType(t *testing.T) {
+	_, err := ParsePublicKey("ssh-made-up AAAAB3NzaC1yc2EAAAADAQABAAABAQ== comment")
+	if err == nil {
+		t.Fatal("expected error for unrecognized key type")
+	}
+}
+
+func TestParsePublicKey_RejectsBadBase64(t *testing.T) {
+	_, err := ParsePublicKey("ssh-ed25519 not-valid-base64!!! comment")
+	if err == nil {
+		t.Fatal("expected error for invalid base64 key data")
+	}
+}
+
+func TestParsePublicKey_RejectsSingleField(t *testing.T) {
+	if _, err := ParsePublicKey("ssh-ed25519"); err == nil {
+		t.Fatal("expected error for a single-field line")
+	}
+}
+
+func TestParsePublicKey_IgnoresComment(t *testing.T) {
+	k, err := ParsePublicKey("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMHXHuK8L4SFSmmpHWBnzPFAcJGYHjABCulfo5ZbKvum this comment is discarded")
+	if err != nil {
+		t.Fatalf("ParsePublicKey: %v", err)
+	}
+	fp, _ := k.Fingerprint()
+	if fp != aliceFP {
+		t.Errorf("Fingerprint = %q, want %q", fp, aliceFP)
+	}
+}
+
+func TestLoadPublicKeyArg_InlineKey(t *testing.T) {
+	k, err := LoadPublicKeyArg(aliceKeyLine)
+	if err != nil {
+		t.Fatalf("LoadPublicKeyArg: %v", err)
+	}
+	fp, _ := k.Fingerprint()
+	if fp != aliceFP {
+		t.Errorf("Fingerprint = %q, want %q", fp, aliceFP)
+	}
+}
+
+func TestLoadPublicKeyArg_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alice.pub")
+	if err := os.WriteFile(path, []byte(aliceKeyLine+"\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	k, err := LoadPublicKeyArg("@" + path)
+	if err != nil {
+		t.Fatalf("LoadPublicKeyArg: %v", err)
+	}
+	fp, _ := k.Fingerprint()
+	if fp != aliceFP {
+		t.Errorf("Fingerprint = %q, want %q", fp, aliceFP)
+	}
+}
+
+func TestLoadPublicKeyArg_MissingFile(t *testing.T) {
+	_, err := LoadPublicKeyArg("@/nonexistent/path/to/key.pub")
+	if err == nil {
+		t.Fatal("expected error for missing key file")
+	}
+}

--- a/internal/access/manager.go
+++ b/internal/access/manager.go
@@ -1,0 +1,203 @@
+package access
+
+// Purpose: orchestrates Grant, Revoke, and List against a Transport —
+// reading the current authorized_keys, deciding what changes, backing up
+// before any mutation, writing the result, and recording an audit line.
+// Inputs: a Transport and a GrantRequest / RevokeRequest.
+// Outputs: GrantResult / RevokeResult / ListResult, each carrying the
+// fingerprint(s) involved for on-screen verification.
+// Constraints: Grant is idempotent (re-granting the same key for the same
+// user is a no-op); Revoke refuses to remove the last remaining key on the
+// host without --force (ErrLastKey); --dry-run never calls Transport.Backup
+// or Transport.Write.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ErrLastKey is returned by Revoke when removing the requested key would
+// leave the host with zero authorized keys — the lockout failure mode this
+// command exists to prevent.
+var ErrLastKey = errors.New("refusing to remove the last remaining authorized key: this would lock out all SSH access to the host; pass --force to override")
+
+// GrantRequest describes one `nself access grant` invocation.
+type GrantRequest struct {
+	User    string
+	Key     PublicKey
+	Sudo    bool
+	Docker  bool
+	Expires *time.Time
+	DryRun  bool
+}
+
+// GrantResult reports what Grant did or would do.
+type GrantResult struct {
+	AlreadyGranted bool
+	Fingerprint    string
+	BackupPath     string
+	Diff           string
+}
+
+// Grant adds or updates req.User's managed key on t. Re-granting the exact
+// same key with the same --sudo/--docker/--expires for the same user is a
+// no-op (AlreadyGranted=true) — it never duplicates a line. Granting a
+// different key, or different metadata, for an existing user replaces that
+// user's single managed line in place.
+func Grant(ctx context.Context, t Transport, req GrantRequest) (GrantResult, error) {
+	fp, err := req.Key.Fingerprint()
+	if err != nil {
+		return GrantResult{}, fmt.Errorf("invalid key: %w", err)
+	}
+
+	current, err := t.Read(ctx)
+	if err != nil {
+		return GrantResult{}, fmt.Errorf("read authorized_keys from %s: %w", t.Describe(), err)
+	}
+	file := parseAuthFile(current)
+
+	existing, hadExisting := file.get(req.User)
+	if hadExisting {
+		existingFP, _ := existing.Key.Fingerprint()
+		if existingFP == fp && existing.Sudo == req.Sudo && existing.Docker == req.Docker &&
+			sameExpiry(existing.Expires, req.Expires) {
+			return GrantResult{AlreadyGranted: true, Fingerprint: fp}, nil
+		}
+	}
+
+	entry := Entry{
+		User:    req.User,
+		Key:     req.Key,
+		Sudo:    req.Sudo,
+		Docker:  req.Docker,
+		Expires: req.Expires,
+		Granted: time.Now(),
+	}
+
+	var diff strings.Builder
+	if hadExisting {
+		fmt.Fprintf(&diff, "- %s\n", existing.render())
+	}
+	fmt.Fprintf(&diff, "+ %s\n", entry.render())
+
+	if req.DryRun {
+		return GrantResult{Fingerprint: fp, Diff: diff.String()}, nil
+	}
+
+	file.upsert(entry)
+
+	backupPath, err := t.Backup(ctx)
+	if err != nil {
+		return GrantResult{}, fmt.Errorf("backup authorized_keys on %s: %w", t.Describe(), err)
+	}
+	if err := t.Write(ctx, file.render()); err != nil {
+		return GrantResult{}, fmt.Errorf("write authorized_keys on %s: %w", t.Describe(), err)
+	}
+
+	auditErr := writeAudit(auditRecord{
+		Action: "grant", Host: t.Describe(), User: req.User,
+		Fingerprint: fp, Sudo: req.Sudo, Docker: req.Docker, Expires: req.Expires,
+	})
+
+	result := GrantResult{Fingerprint: fp, BackupPath: backupPath, Diff: diff.String()}
+	if auditErr != nil {
+		return result, fmt.Errorf("granted, but failed to write audit log: %w", auditErr)
+	}
+	return result, nil
+}
+
+// RevokeRequest describes one `nself access revoke` invocation.
+type RevokeRequest struct {
+	User   string
+	Force  bool
+	DryRun bool
+}
+
+// RevokeResult reports what Revoke did or would do.
+type RevokeResult struct {
+	Fingerprint string
+	BackupPath  string
+	Diff        string
+}
+
+// Revoke removes req.User's managed key from t. It refuses to proceed
+// (ErrLastKey) when the target host would be left with zero authorized keys,
+// unless req.Force is set.
+func Revoke(ctx context.Context, t Transport, req RevokeRequest) (RevokeResult, error) {
+	current, err := t.Read(ctx)
+	if err != nil {
+		return RevokeResult{}, fmt.Errorf("read authorized_keys from %s: %w", t.Describe(), err)
+	}
+	file := parseAuthFile(current)
+
+	existing, ok := file.get(req.User)
+	if !ok {
+		return RevokeResult{}, fmt.Errorf("no nself-managed key found for user %q on %s", req.User, t.Describe())
+	}
+	fp := existing.Fingerprint()
+
+	if file.totalKeyLines() <= 1 && !req.Force {
+		return RevokeResult{}, ErrLastKey
+	}
+
+	diff := fmt.Sprintf("- %s\n", existing.render())
+	if req.DryRun {
+		return RevokeResult{Fingerprint: fp, Diff: diff}, nil
+	}
+
+	file.remove(req.User)
+
+	backupPath, err := t.Backup(ctx)
+	if err != nil {
+		return RevokeResult{}, fmt.Errorf("backup authorized_keys on %s: %w", t.Describe(), err)
+	}
+	if err := t.Write(ctx, file.render()); err != nil {
+		return RevokeResult{}, fmt.Errorf("write authorized_keys on %s: %w", t.Describe(), err)
+	}
+
+	auditErr := writeAudit(auditRecord{Action: "revoke", Host: t.Describe(), User: req.User, Fingerprint: fp})
+
+	result := RevokeResult{Fingerprint: fp, BackupPath: backupPath, Diff: diff}
+	if auditErr != nil {
+		return result, fmt.Errorf("revoked, but failed to write audit log: %w", auditErr)
+	}
+	return result, nil
+}
+
+// ListResult reports every nself-managed entry found, plus a count of
+// foreign (non-nself-managed) key lines sharing the file.
+type ListResult struct {
+	Entries      []Entry
+	ForeignCount int
+}
+
+// List reads t's authorized_keys and returns every nself-managed entry,
+// sorted by user label.
+func List(ctx context.Context, t Transport) (ListResult, error) {
+	current, err := t.Read(ctx)
+	if err != nil {
+		return ListResult{}, fmt.Errorf("read authorized_keys from %s: %w", t.Describe(), err)
+	}
+	file := parseAuthFile(current)
+
+	entries := file.entries()
+	sort.Slice(entries, func(i, j int) bool { return entries[i].User < entries[j].User })
+
+	return ListResult{
+		Entries:      entries,
+		ForeignCount: file.totalKeyLines() - len(entries),
+	}, nil
+}
+
+// sameExpiry reports whether a and b represent the same expiry, treating two
+// nil pointers as equal.
+func sameExpiry(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Equal(*b)
+}

--- a/internal/access/manager_test.go
+++ b/internal/access/manager_test.go
@@ -1,0 +1,381 @@
+package access
+
+// Tests drive Grant/Revoke/List exclusively through LocalFileTransport
+// against a temp-dir fixture standing in for a remote authorized_keys file —
+// SSHTransport is never exercised here or anywhere else in this suite, so
+// running these tests never opens a network connection to any host.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newFixture(t *testing.T) (*LocalFileTransport, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authorized_keys")
+	restore := SetAuditLogPathForTest(filepath.Join(dir, "audit.log"))
+	t.Cleanup(restore)
+	return NewLocalFileTransport(path), path
+}
+
+func aliceKey(t *testing.T) PublicKey {
+	t.Helper()
+	k, err := ParsePublicKey(aliceKeyLine)
+	if err != nil {
+		t.Fatalf("parse alice key: %v", err)
+	}
+	return k
+}
+
+func bobKey(t *testing.T) PublicKey {
+	t.Helper()
+	k, err := ParsePublicKey(bobKeyLine)
+	if err != nil {
+		t.Fatalf("parse bob key: %v", err)
+	}
+	return k
+}
+
+func TestGrant_NewUser(t *testing.T) {
+	tp, path := newFixture(t)
+	ctx := context.Background()
+
+	res, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)})
+	if err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+	if res.AlreadyGranted {
+		t.Error("first grant must not be AlreadyGranted")
+	}
+	if res.Fingerprint != aliceFP {
+		t.Errorf("Fingerprint = %q, want %q", res.Fingerprint, aliceFP)
+	}
+	if res.BackupPath != "" {
+		t.Errorf("BackupPath = %q, want empty (nothing existed to back up)", res.BackupPath)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !strings.Contains(string(data), "nself-access:user=alice") {
+		t.Errorf("authorized_keys does not contain alice's managed entry:\n%s", data)
+	}
+}
+
+func TestGrant_IdempotentReGrant(t *testing.T) {
+	tp, path := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("first grant: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after first grant: %v", err)
+	}
+
+	res, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)})
+	if err != nil {
+		t.Fatalf("re-grant: %v", err)
+	}
+	if !res.AlreadyGranted {
+		t.Error("re-granting the identical key must report AlreadyGranted")
+	}
+	if res.Fingerprint != aliceFP {
+		t.Errorf("Fingerprint = %q, want %q", res.Fingerprint, aliceFP)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after re-grant: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("re-grant must not change the file:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+
+	// Never a duplicate line: exactly one line carries alice's tag.
+	count := strings.Count(string(after), "nself-access:user=alice")
+	if count != 1 {
+		t.Errorf("expected exactly 1 managed line for alice, found %d", count)
+	}
+}
+
+func TestGrant_DifferentKeyReplacesEntry(t *testing.T) {
+	tp, path := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("first grant: %v", err)
+	}
+	res, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: bobKey(t)})
+	if err != nil {
+		t.Fatalf("second grant: %v", err)
+	}
+	if res.AlreadyGranted {
+		t.Error("granting a different key for the same user must not be AlreadyGranted")
+	}
+	if res.Fingerprint != bobFP {
+		t.Errorf("Fingerprint = %q, want %q", res.Fingerprint, bobFP)
+	}
+	if res.BackupPath == "" {
+		t.Error("expected a backup path before replacing an existing key")
+	}
+	if _, err := os.Stat(res.BackupPath); err != nil {
+		t.Errorf("backup file does not exist at %s: %v", res.BackupPath, err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if strings.Count(string(data), "nself-access:user=alice") != 1 {
+		t.Errorf("expected exactly one managed line for alice after replacement:\n%s", data)
+	}
+	if !strings.Contains(string(data), bobKeyLine[:40]) {
+		t.Errorf("expected bob's key material in the file after replacement:\n%s", data)
+	}
+}
+
+func TestGrant_DryRunMutatesNothing(t *testing.T) {
+	tp, path := newFixture(t)
+	ctx := context.Background()
+
+	res, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t), DryRun: true})
+	if err != nil {
+		t.Fatalf("Grant dry-run: %v", err)
+	}
+	if res.Fingerprint != aliceFP {
+		t.Errorf("Fingerprint = %q, want %q", res.Fingerprint, aliceFP)
+	}
+	if !strings.Contains(res.Diff, "+ ") {
+		t.Errorf("dry-run diff should show an addition, got: %q", res.Diff)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("dry-run must not create authorized_keys, stat err = %v", err)
+	}
+}
+
+func TestGrant_RecordsSudoDockerExpiry(t *testing.T) {
+	tp, _ := newFixture(t)
+	ctx := context.Background()
+	expires := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	if _, err := Grant(ctx, tp, GrantRequest{
+		User: "alice", Key: aliceKey(t), Sudo: true, Docker: true, Expires: &expires,
+	}); err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+
+	list, err := List(ctx, tp)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(list.Entries))
+	}
+	e := list.Entries[0]
+	if !e.Sudo || !e.Docker {
+		t.Errorf("Sudo=%v Docker=%v, want both true", e.Sudo, e.Docker)
+	}
+	if e.Expires == nil || !e.Expires.Equal(expires) {
+		t.Errorf("Expires = %v, want %v", e.Expires, expires)
+	}
+}
+
+func TestRevoke_RemovesEntry(t *testing.T) {
+	tp, path := newFixture(t)
+	ctx := context.Background()
+
+	// Grant two users so revoking one never trips the lockout guard.
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("grant alice: %v", err)
+	}
+	if _, err := Grant(ctx, tp, GrantRequest{User: "bob", Key: bobKey(t)}); err != nil {
+		t.Fatalf("grant bob: %v", err)
+	}
+
+	res, err := Revoke(ctx, tp, RevokeRequest{User: "alice"})
+	if err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if res.Fingerprint != aliceFP {
+		t.Errorf("Fingerprint = %q, want %q", res.Fingerprint, aliceFP)
+	}
+	if res.BackupPath == "" {
+		t.Error("expected a backup path before revoking")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if strings.Contains(string(data), "user=alice") {
+		t.Errorf("alice's entry should be gone:\n%s", data)
+	}
+	if !strings.Contains(string(data), "user=bob") {
+		t.Errorf("bob's entry should remain:\n%s", data)
+	}
+}
+
+func TestRevoke_UnknownUser(t *testing.T) {
+	tp, _ := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	if _, err := Revoke(ctx, tp, RevokeRequest{User: "nobody"}); err == nil {
+		t.Fatal("expected error revoking an unknown user")
+	}
+}
+
+func TestRevoke_LastKeyRefusedWithoutForce(t *testing.T) {
+	tp, path := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	_, err := Revoke(ctx, tp, RevokeRequest{User: "alice"})
+	if err == nil {
+		t.Fatal("expected ErrLastKey when revoking the only remaining key")
+	}
+	if !errors.Is(err, ErrLastKey) {
+		t.Errorf("err = %v, want ErrLastKey", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !strings.Contains(string(data), "user=alice") {
+		t.Error("refused revoke must leave the key in place")
+	}
+}
+
+func TestRevoke_LastKeyAllowedWithForce(t *testing.T) {
+	tp, path := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	if _, err := Revoke(ctx, tp, RevokeRequest{User: "alice", Force: true}); err != nil {
+		t.Fatalf("Revoke with --force: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if strings.Contains(string(data), "user=alice") {
+		t.Error("forced revoke should remove the last key")
+	}
+}
+
+func TestRevoke_DryRunMutatesNothing(t *testing.T) {
+	tp, path := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("grant alice: %v", err)
+	}
+	if _, err := Grant(ctx, tp, GrantRequest{User: "bob", Key: bobKey(t)}); err != nil {
+		t.Fatalf("grant bob: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	res, err := Revoke(ctx, tp, RevokeRequest{User: "alice", DryRun: true})
+	if err != nil {
+		t.Fatalf("Revoke dry-run: %v", err)
+	}
+	if !strings.Contains(res.Diff, "- ") {
+		t.Errorf("dry-run diff should show a removal, got: %q", res.Diff)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after dry-run: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("dry-run revoke must not change the file")
+	}
+}
+
+func TestList_ReturnsSortedEntriesAndForeignCount(t *testing.T) {
+	tp, path := newFixture(t)
+	ctx := context.Background()
+
+	// Seed a foreign (non-nself-managed) key directly, as if it were the
+	// original key the host shipped with.
+	foreign := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7... original-root-key\n"
+	if err := os.WriteFile(path, []byte(foreign), 0o600); err != nil {
+		t.Fatalf("seed foreign key: %v", err)
+	}
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "bob", Key: bobKey(t)}); err != nil {
+		t.Fatalf("grant bob: %v", err)
+	}
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("grant alice: %v", err)
+	}
+
+	list, err := List(ctx, tp)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list.Entries) != 2 {
+		t.Fatalf("expected 2 managed entries, got %d", len(list.Entries))
+	}
+	if list.Entries[0].User != "alice" || list.Entries[1].User != "bob" {
+		t.Errorf("entries not sorted by user: %v, %v", list.Entries[0].User, list.Entries[1].User)
+	}
+	if list.ForeignCount != 1 {
+		t.Errorf("ForeignCount = %d, want 1", list.ForeignCount)
+	}
+}
+
+func TestList_EmptyFile(t *testing.T) {
+	tp, _ := newFixture(t)
+	list, err := List(context.Background(), tp)
+	if err != nil {
+		t.Fatalf("List on missing file: %v", err)
+	}
+	if len(list.Entries) != 0 || list.ForeignCount != 0 {
+		t.Errorf("expected an empty result, got %+v", list)
+	}
+}
+
+func TestGrant_AuditLogWritten(t *testing.T) {
+	tp, _ := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+
+	data, err := os.ReadFile(currentAuditLogPath())
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	line := string(data)
+	if !strings.Contains(line, "action=grant") || !strings.Contains(line, "user=alice") ||
+		!strings.Contains(line, aliceFP) {
+		t.Errorf("audit log missing expected fields: %s", line)
+	}
+	if strings.Contains(line, "PRIVATE") {
+		t.Error("audit log must never contain private key material")
+	}
+}

--- a/internal/access/transport.go
+++ b/internal/access/transport.go
@@ -1,0 +1,37 @@
+package access
+
+// Purpose: the seam between authorized_keys business logic (manager.go,
+// file.go, entry.go) and wherever the file actually lives. Production code
+// talks to a real host over SSH (SSHTransport, transport_ssh.go); tests talk
+// to a plain file (LocalFileTransport, transport_local.go) so grant/revoke/
+// list are exercised without ever opening a network connection — the CLI
+// test suite must never SSH to a real host, staging or production included.
+// Inputs: none (interface only).
+// Outputs: none (interface only).
+// Constraints: an implementation must never log or return private key
+// material — it only ever reads and writes the public authorized_keys file.
+
+import "context"
+
+// Transport reads, backs up, and writes one remote (or fixture) authorized_keys
+// file.
+type Transport interface {
+	// Describe returns a short human-readable label for error messages and
+	// audit lines, e.g. "root@5.75.235.42" or a fixture's file path.
+	Describe() string
+
+	// Read returns the current authorized_keys content, or (nil, nil) if the
+	// file does not exist yet — a fresh host with no managed keys is not an
+	// error.
+	Read(ctx context.Context) ([]byte, error)
+
+	// Backup copies the current file to a timestamped sibling before any
+	// mutation and returns its path. If the file does not exist yet, Backup
+	// is a no-op that returns "".
+	Backup(ctx context.Context) (string, error)
+
+	// Write replaces the authorized_keys content and ensures the result is
+	// readable only by its owner (0600), matching the CLI's env-file
+	// permission rule.
+	Write(ctx context.Context, content []byte) error
+}

--- a/internal/access/transport_local.go
+++ b/internal/access/transport_local.go
@@ -1,0 +1,87 @@
+package access
+
+// Purpose: a Transport backed by a plain local file, used two ways: (1) as
+// the fixture every test in this package and cmd/commands/access_test.go
+// drives, standing in for a remote authorized_keys file with no network
+// involved; (2) as the real implementation when an operator points `nself
+// access` at a local path directly (e.g. a mounted volume or a dry-run
+// against a scratch copy).
+// Inputs: a filesystem path.
+// Outputs: file reads/writes/backups at that path.
+// Constraints: Write always leaves the file at 0600; Backup never errors on
+// a missing source file, since granting the very first key on a host is the
+// common case.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// LocalFileTransport implements Transport against a file on the local
+// filesystem.
+type LocalFileTransport struct {
+	Path string
+
+	// now is overridable in tests for deterministic backup filenames.
+	now func() time.Time
+}
+
+// NewLocalFileTransport returns a Transport rooted at path.
+func NewLocalFileTransport(path string) *LocalFileTransport {
+	return &LocalFileTransport{Path: path, now: time.Now}
+}
+
+func (t *LocalFileTransport) Describe() string { return t.Path }
+
+// Read returns the file's content, or (nil, nil) if it does not exist yet.
+func (t *LocalFileTransport) Read(ctx context.Context) ([]byte, error) {
+	data, err := os.ReadFile(t.Path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", t.Path, err)
+	}
+	return data, nil
+}
+
+// Backup copies the current file to "<path>.bak.<UTC timestamp>" and returns
+// that path, or "" if there was nothing to back up.
+func (t *LocalFileTransport) Backup(ctx context.Context) (string, error) {
+	data, err := os.ReadFile(t.Path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read %s for backup: %w", t.Path, err)
+	}
+
+	nowFn := t.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	backupPath := fmt.Sprintf("%s.bak.%s", t.Path, nowFn().UTC().Format("20060102T150405Z"))
+	if err := os.WriteFile(backupPath, data, 0o600); err != nil {
+		return "", fmt.Errorf("write backup %s: %w", backupPath, err)
+	}
+	return backupPath, nil
+}
+
+// Write replaces the file's content, creating its parent directory (0700) if
+// needed, and leaves the file at 0600.
+func (t *LocalFileTransport) Write(ctx context.Context, content []byte) error {
+	dir := filepath.Dir(t.Path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	if err := os.WriteFile(t.Path, content, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", t.Path, err)
+	}
+	// os.WriteFile applies the given mode only when creating the file; an
+	// existing file keeps its prior permissions. Chmod explicitly so a
+	// pre-existing 0644 authorized_keys is corrected on every write.
+	return os.Chmod(t.Path, 0o600)
+}

--- a/internal/access/transport_local_test.go
+++ b/internal/access/transport_local_test.go
@@ -1,0 +1,105 @@
+package access
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestLocalFileTransport_ReadMissingFile(t *testing.T) {
+	tp := NewLocalFileTransport(filepath.Join(t.TempDir(), "authorized_keys"))
+	data, err := tp.Read(context.Background())
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if data != nil {
+		t.Errorf("expected nil data for a missing file, got %q", data)
+	}
+}
+
+func TestLocalFileTransport_BackupMissingFileIsNoop(t *testing.T) {
+	tp := NewLocalFileTransport(filepath.Join(t.TempDir(), "authorized_keys"))
+	path, err := tp.Backup(context.Background())
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected no backup path for a missing source file, got %q", path)
+	}
+}
+
+func TestLocalFileTransport_WriteCreatesParentAnd0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "authorized_keys")
+	tp := NewLocalFileTransport(path)
+
+	if err := tp.Write(context.Background(), []byte("ssh-ed25519 AAAA test\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// Windows has no Unix permission bits: Mode().Perm() always reports 0666
+	// there regardless of what was requested. Only assert the real invariant
+	// on platforms that have one.
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("mode = %o, want 0600", perm)
+		}
+	}
+}
+
+func TestLocalFileTransport_BackupThenWriteRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authorized_keys")
+	tp := NewLocalFileTransport(path)
+	ctx := context.Background()
+
+	original := "ssh-ed25519 AAAA original\n"
+	if err := tp.Write(ctx, []byte(original)); err != nil {
+		t.Fatalf("initial write: %v", err)
+	}
+
+	backupPath, err := tp.Backup(ctx)
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if backupPath == "" {
+		t.Fatal("expected a non-empty backup path")
+	}
+	if !strings.HasPrefix(backupPath, path+".bak.") {
+		t.Errorf("backupPath = %q, want prefix %q", backupPath, path+".bak.")
+	}
+
+	backedUp, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(backedUp) != original {
+		t.Errorf("backup content = %q, want %q", backedUp, original)
+	}
+
+	// Writing new content must not disturb the backup already taken.
+	if err := tp.Write(ctx, []byte("ssh-ed25519 AAAA replaced\n")); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	stillThere, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("re-read backup: %v", err)
+	}
+	if string(stillThere) != original {
+		t.Error("backup content changed after a later write to the live file")
+	}
+}
+
+func TestLocalFileTransport_Describe(t *testing.T) {
+	tp := NewLocalFileTransport("/tmp/fixture/authorized_keys")
+	if tp.Describe() != "/tmp/fixture/authorized_keys" {
+		t.Errorf("Describe() = %q", tp.Describe())
+	}
+}

--- a/internal/access/transport_ssh.go
+++ b/internal/access/transport_ssh.go
@@ -1,0 +1,126 @@
+package access
+
+// Purpose: the production Transport — runs `ssh` against a real host to
+// read, back up, and write its authorized_keys file. This is the only
+// implementation `nself access` wires up outside tests; the test suite
+// exercises grant/revoke/list exclusively through LocalFileTransport
+// (transport_local.go) so it never opens a network connection to any host,
+// staging or production included.
+// Inputs: an SSH connection target and the operator's local identity file.
+// Outputs: remote command execution over ssh.
+// Constraints: never reads the identity file's content — only passes its
+// path to the ssh binary via -i — and never logs command output beyond what
+// the caller explicitly does with a Read result (public key material only).
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+)
+
+// SSHTransport implements Transport by running the ssh binary against a
+// real host.
+type SSHTransport struct {
+	// Host is "[user@]host" — the ssh connection target, e.g. "root@5.75.235.42".
+	Host string
+
+	// IdentityPath is the local private key used to authenticate the SSH
+	// connection (the operator's own key, distinct from any key being
+	// granted or revoked).
+	IdentityPath string
+
+	// RemotePath is the authorized_keys path on the remote host. Defaults to
+	// "~/.ssh/authorized_keys" (relative to whichever account Host connects
+	// as) when empty.
+	RemotePath string
+}
+
+func (t *SSHTransport) remotePath() string {
+	if t.RemotePath != "" {
+		return t.RemotePath
+	}
+	return "~/.ssh/authorized_keys"
+}
+
+func (t *SSHTransport) Describe() string { return t.Host }
+
+func (t *SSHTransport) sshArgs() []string {
+	return []string{
+		"-i", t.IdentityPath,
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "ForwardAgent=no",
+		"-o", "BatchMode=yes",
+	}
+}
+
+// runRemote executes command on the remote host and returns its stdout.
+func (t *SSHTransport) runRemote(ctx context.Context, command string) ([]byte, error) {
+	args := append(t.sshArgs(), t.Host, command)
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ssh %s %q: %w: %s", t.Host, command, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// Read returns the remote authorized_keys content, or (nil, nil) if the file
+// does not exist on the remote host.
+func (t *SSHTransport) Read(ctx context.Context) ([]byte, error) {
+	remote := t.remotePath()
+	out, err := t.runRemote(ctx, fmt.Sprintf("cat %s 2>/dev/null || true", shellQuote(remote)))
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Backup copies the remote file to a timestamped sibling and returns that
+// remote path, or "" if there was nothing to back up.
+func (t *SSHTransport) Backup(ctx context.Context) (string, error) {
+	remote := t.remotePath()
+	backup := remote + ".bak." + time.Now().UTC().Format("20060102T150405Z")
+	script := fmt.Sprintf(
+		"if [ -f %s ]; then cp -p %s %s && echo %s; fi",
+		shellQuote(remote), shellQuote(remote), shellQuote(backup), shellQuote(backup))
+	out, err := t.runRemote(ctx, script)
+	if err != nil {
+		return "", fmt.Errorf("backup %s on %s: %w", remote, t.Host, err)
+	}
+	if strings.TrimSpace(string(out)) == "" {
+		return "", nil
+	}
+	return backup, nil
+}
+
+// Write replaces the remote authorized_keys content, creating its parent
+// directory (0700) first, and leaves the file at 0600.
+func (t *SSHTransport) Write(ctx context.Context, content []byte) error {
+	remote := t.remotePath()
+	dir := path.Dir(remote)
+	script := fmt.Sprintf(
+		"mkdir -p %s && chmod 700 %s && cat > %s && chmod 600 %s",
+		shellQuote(dir), shellQuote(dir), shellQuote(remote), shellQuote(remote))
+
+	args := append(t.sshArgs(), t.Host, script)
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd.Stdin = bytes.NewReader(content)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("write %s on %s: %w: %s", remote, t.Host, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// shellQuote wraps s in single quotes for safe interpolation into a remote
+// shell command, escaping any embedded single quote.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}


### PR DESCRIPTION
## Summary

- Adds `nself access grant/revoke/list` (#238): SSH key management on an already-deployed host. Fills the gap between `nself security` (firewall/fail2ban/sshd hardening only) and `hcloud ssh-key create` (only injects keys at server-creation time).
- Grant is idempotent per `--user` label, backs up `authorized_keys` with a UTC timestamp before any write, echoes the SHA256 fingerprint back, and supports `--sudo`/`--docker`/`--expires` as recorded metadata (this command does not itself modify OS group membership — documented as a known limitation on the wiki page).
- Revoke refuses to remove the last remaining key on a host without `--force` (the lockout failure mode the issue was filed to prevent).
- Both grant and revoke support `--dry-run`, which prints the resulting `authorized_keys` diff and performs no remote mutation.
- SSH is behind an injectable `access.Transport` interface: `SSHTransport` (production, `internal/access/transport_ssh.go`) vs. `LocalFileTransport` (test fixture, `internal/access/transport_local.go`). The test suite exercises grant/revoke/list exclusively against `LocalFileTransport` over a temp file — it never opens a network connection, and never touches staging, production, or any other real host.
- Every grant/revoke mutation appends one line to a local audit log (`~/.nself/access-audit.log`), fingerprints and labels only, never private key material.

## Why two generated-file changes are included

- `.github/command-surface-budget.txt`: the CLI's command-surface ratchet (CLI-R11) only allows the top-level command count to fall. Adding `access` as a new top-level command (the exact shape #238 asks for) raises it from 49 to 50 — a deliberate, documented exception, not accidental creep. Justification is recorded in the file's own comment.
- `.github/surface-parity.md` / `.json`: regenerated via `make parity` to include the new command's row.
- `.github/wiki/cmd-access.md` added per the T03 template; `make cmd-inventory` and `make wiki-commands` regenerated `command-inventory.json`, `Commands.md`, `_Sidebar.md`, and `llms.txt` to match.

## Known limitation / follow-up (not in scope here)

- `--sudo`/`--docker` are recorded as audit metadata only; they do not run `usermod -aG` or similar. Documented on the wiki page and in `--help`.
- Per-host targeting is a raw `--host [user@]host` flag, independent of the existing `nself env target` / control-plane inventory. Wiring `--env staging|prod` through that inventory (so operators don't need to remember raw IPs) is a natural follow-up, left out here to keep this change scoped to the SSH-key-management gap in #238.
- Not wired into `admin/` (the parity matrix shows `no` for MCP tool coverage as informational, not a gate) — flagged here for the admin-lockstep coordination the PRI calls for, not addressed in this PR.
- Pre-existing, unrelated: `.github/wiki/_Sidebar.md` already has an unresolved git merge conflict (`<<<<<<< HEAD` / `>>>>>>> worktree-agent-...`) in its hand-curated Plugins section, from a merge already on `main` (commit d759ef65). Not touched by this PR — `make wiki-commands` only rewrites the generated block, which sits below that conflict. Flagging since it's live on `main` right now.

## Test plan

- [x] `make build`
- [x] `gofmt -l cmd internal` (empty)
- [x] `make vet`
- [x] `go test -mod=vendor ./...` (4568 passed)
- [x] `bash scripts/ci/flag-drift-audit.sh` (0 unregistered flags)
- [x] `make wiki-check` (50/50 pages current, 303 link targets resolve)
- [x] Negative-tested: broke the idempotency check, the dry-run short-circuit, and the last-key lockout guard one at a time in a scratch edit; confirmed `TestGrant_IdempotentReGrant`, `TestGrant_DryRunMutatesNothing`, and `TestRevoke_LastKeyRefusedWithoutForce` fail as expected, then restored and confirmed the full suite passes again.