### PR TITLE
fix(doctor): resolve container names from PROJECT_NAME instead of hardcoding nself

### DIFF
--- a/internal/doctor/deep.go
+++ b/internal/doctor/deep.go
@@ -14,9 +14,9 @@ func DeepChecks(ctx context.Context, projectDir string, verbose bool) []CheckRes
 
 	results = append(results, HostChecks(ctx, verbose)...)
 	results = append(results, DockerDeepChecks(ctx, verbose)...)
-	results = append(results, PostgresChecks(ctx, verbose)...)
+	results = append(results, PostgresChecks(ctx, projectDir, verbose)...)
 	results = append(results, HasuraChecks(ctx, verbose)...)
-	results = append(results, NginxChecks(ctx, verbose)...)
+	results = append(results, NginxChecks(ctx, projectDir, verbose)...)
 	results = append(results, SSLChecks(ctx, verbose)...)
 	results = append(results, PingChecks(ctx, verbose)...)
 	results = append(results, PluginHealthChecks(ctx, projectDir, verbose)...)

--- a/internal/doctor/deep_db.go
+++ b/internal/doctor/deep_db.go
@@ -8,22 +8,26 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/nself-org/cli/internal/health"
 )
 
 // Purpose: Postgres and Hasura --deep checks — pg_isready, longest running
 // query, dead tuple ratio, last vacuum, plus Hasura's /healthz and metadata
 // consistency.
-// Inputs: a context and verbose flag.
+// Inputs: a context, the project directory (used to resolve the Postgres
+// container name via PROJECT_NAME), and verbose flag.
 // Outputs: []CheckResult per category.
 // Constraints: split out of deep.go (CLI-R12) as a pure move; no behavior
-// changed.
+// changed. Container name resolution added later — see project_name.go.
 
 // PostgresChecks verifies pg_isready, replication lag, longest query, dead tuples, vacuum.
-func PostgresChecks(ctx context.Context, verbose bool) []CheckResult {
+func PostgresChecks(ctx context.Context, projectDir string, verbose bool) []CheckResult {
 	var results []CheckResult
+	pgContainer := health.ContainerName(resolveProjectName(projectDir), "postgres")
 
 	// pg_isready
-	cmd := exec.CommandContext(ctx, "docker", "exec", "nself_postgres", "pg_isready", "-U", "postgres")
+	cmd := exec.CommandContext(ctx, "docker", "exec", pgContainer, "pg_isready", "-U", "postgres")
 	if err := cmd.Run(); err != nil {
 		results = append(results, CheckResult{Section: "postgres", Name: "pg_isready", Status: "fail", Message: "not ready"})
 		return results
@@ -31,7 +35,7 @@ func PostgresChecks(ctx context.Context, verbose bool) []CheckResult {
 	results = append(results, CheckResult{Section: "postgres", Name: "pg_isready", Status: "pass", Message: "accepting connections"})
 
 	// Longest running query <60s
-	cmd = exec.CommandContext(ctx, "docker", "exec", "nself_postgres", "psql", "-U", "postgres", "-t", "-c",
+	cmd = exec.CommandContext(ctx, "docker", "exec", pgContainer, "psql", "-U", "postgres", "-t", "-c",
 		"SELECT COALESCE(EXTRACT(EPOCH FROM MAX(now() - query_start))::int, 0) FROM pg_stat_activity WHERE state='active' AND pid != pg_backend_pid();")
 	out, err := cmd.Output()
 	if err == nil {
@@ -46,7 +50,7 @@ func PostgresChecks(ctx context.Context, verbose bool) []CheckResult {
 	}
 
 	// Dead tuple % <10%
-	cmd = exec.CommandContext(ctx, "docker", "exec", "nself_postgres", "psql", "-U", "postgres", "-t", "-c",
+	cmd = exec.CommandContext(ctx, "docker", "exec", pgContainer, "psql", "-U", "postgres", "-t", "-c",
 		"SELECT COALESCE(MAX(n_dead_tup::float / NULLIF(n_live_tup + n_dead_tup, 0) * 100)::int, 0) FROM pg_stat_user_tables;")
 	out, err = cmd.Output()
 	if err == nil {
@@ -54,7 +58,7 @@ func PostgresChecks(ctx context.Context, verbose bool) []CheckResult {
 		if pct > 10 {
 			results = append(results, CheckResult{Section: "postgres", Name: "Dead tuples", Status: "warn",
 				Message: fmt.Sprintf("%d%% dead tuples (>10%%)", pct),
-				FixCmd:  "docker exec nself_postgres psql -U postgres -c 'VACUUM ANALYZE;'"})
+				FixCmd:  fmt.Sprintf("docker exec %s psql -U postgres -c 'VACUUM ANALYZE;'", pgContainer)})
 		} else {
 			results = append(results, CheckResult{Section: "postgres", Name: "Dead tuples", Status: "pass",
 				Message: fmt.Sprintf("%d%% dead tuples", pct)})
@@ -62,7 +66,7 @@ func PostgresChecks(ctx context.Context, verbose bool) []CheckResult {
 	}
 
 	// Last vacuum <24h
-	cmd = exec.CommandContext(ctx, "docker", "exec", "nself_postgres", "psql", "-U", "postgres", "-t", "-c",
+	cmd = exec.CommandContext(ctx, "docker", "exec", pgContainer, "psql", "-U", "postgres", "-t", "-c",
 		"SELECT COALESCE(EXTRACT(EPOCH FROM MIN(now() - last_autovacuum))::int, 0) FROM pg_stat_user_tables WHERE last_autovacuum IS NOT NULL;")
 	out, err = cmd.Output()
 	if err == nil {

--- a/internal/doctor/deep_nginx.go
+++ b/internal/doctor/deep_nginx.go
@@ -8,21 +8,25 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/nself-org/cli/internal/health"
 )
 
 // Purpose: nginx/TLS/reachability --deep checks — config test, certificate
 // expiry, Let's Encrypt renewal cron, and the ping.nself.org health probe.
-// Inputs: a context and verbose flag.
+// Inputs: a context, the project directory (used to resolve the nginx
+// container name via PROJECT_NAME), and verbose flag.
 // Outputs: []CheckResult per category.
 // Constraints: split out of deep.go (CLI-R12) as a pure move; no behavior
-// changed.
+// changed. Container name resolution added later — see project_name.go.
 
 // NginxChecks verifies config test and SSL cert expiry.
-func NginxChecks(ctx context.Context, verbose bool) []CheckResult {
+func NginxChecks(ctx context.Context, projectDir string, verbose bool) []CheckResult {
 	var results []CheckResult
+	nginxContainer := health.ContainerName(resolveProjectName(projectDir), "nginx")
 
 	// nginx -t
-	cmd := exec.CommandContext(ctx, "docker", "exec", "nself_nginx", "nginx", "-t")
+	cmd := exec.CommandContext(ctx, "docker", "exec", nginxContainer, "nginx", "-t")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		results = append(results, CheckResult{Section: "nginx", Name: "Nginx config test", Status: "fail",
@@ -32,14 +36,14 @@ func NginxChecks(ctx context.Context, verbose bool) []CheckResult {
 	}
 
 	// SSL cert expiry >30d on all server_names
-	cmd = exec.CommandContext(ctx, "docker", "exec", "nself_nginx", "find", "/etc/letsencrypt/live", "-name", "fullchain.pem")
+	cmd = exec.CommandContext(ctx, "docker", "exec", nginxContainer, "find", "/etc/letsencrypt/live", "-name", "fullchain.pem")
 	out, err = cmd.Output()
 	if err == nil {
 		for _, certPath := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 			if certPath == "" {
 				continue
 			}
-			checkCmd := exec.CommandContext(ctx, "docker", "exec", "nself_nginx", "openssl", "x509",
+			checkCmd := exec.CommandContext(ctx, "docker", "exec", nginxContainer, "openssl", "x509",
 				"-enddate", "-noout", "-in", certPath)
 			certOut, err := checkCmd.Output()
 			if err != nil {

--- a/internal/doctor/hardening_check.go
+++ b/internal/doctor/hardening_check.go
@@ -26,7 +26,7 @@ const hardeningSection = "security"
 // projectDir is the nSelf working directory (same value passed to DeepChecks).
 func HardeningChecks(ctx context.Context, projectDir string) []CheckResult {
 	return []CheckResult{
-		checkHardeningRLS(ctx),
+		checkHardeningRLS(ctx, projectDir),
 		checkHardeningRateLimit(projectDir),
 		checkHardeningMFAThrottle(projectDir),
 		checkHardeningSSRFImport(projectDir),

--- a/internal/doctor/hardening_check_db.go
+++ b/internal/doctor/hardening_check_db.go
@@ -7,7 +7,9 @@ package doctor
 // Inputs:  ctx context.Context for docker exec / psql; projectDir string for
 //          the nself-audit plugin list check.
 // Outputs: CheckResult for each check — pass/warn/fail with remediation hint.
-// Constraints: Both checks invoke docker exec nself_postgres for DB access.
+// Constraints: Both checks invoke docker exec against the project's Postgres
+//              container (name resolved from PROJECT_NAME — see project_name.go)
+//              for DB access.
 //              checkAuditTrigger returns "pass"/"fail" (not CheckResult) so it
 //              can be reused from two call sites in checkHardeningAuditLog.
 //              auditTableName and auditTriggerName are exported as package-level
@@ -19,6 +21,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/nself-org/cli/internal/health"
 )
 
 // auditTableName is the canonical table created by the nself-audit plugin
@@ -31,7 +35,7 @@ const auditTriggerName = "trg_audit_immutable"
 
 // ─── SEC-HARDENING-01: RLS enabled + FORCE RLS on every np_* table ──────────
 
-func checkHardeningRLS(ctx context.Context) CheckResult {
+func checkHardeningRLS(ctx context.Context, projectDir string) CheckResult {
 	const checkID = "SEC-HARDENING-01"
 
 	// Query pg_class for np_* tables that are missing RLS enable or force.
@@ -44,8 +48,9 @@ func checkHardeningRLS(ctx context.Context) CheckResult {
 	   AND (NOT relrowsecurity OR NOT relforcerowsecurity)
 	 ORDER BY relname;`
 
+	pgContainer := health.ContainerName(resolveProjectName(projectDir), "postgres")
 	cmd := exec.CommandContext(ctx,
-		"docker", "exec", "nself_postgres",
+		"docker", "exec", pgContainer,
 		"psql", "-U", "postgres", "-t", "-c", query,
 	)
 	out, err := cmd.Output()
@@ -85,6 +90,7 @@ func checkHardeningRLS(ctx context.Context) CheckResult {
 
 func checkHardeningAuditLog(ctx context.Context, projectDir string) CheckResult {
 	const checkID = "SEC-HARDENING-07"
+	pgContainer := health.ContainerName(resolveProjectName(projectDir), "postgres")
 
 	// Check 1: nself-audit plugin listed as installed.
 	listCmd := exec.CommandContext(ctx, "nself", "plugin", "list", "--installed")
@@ -92,7 +98,7 @@ func checkHardeningAuditLog(ctx context.Context, projectDir string) CheckResult 
 	if listErr == nil && strings.Contains(string(listOut), "nself-audit") {
 		// Plugin is installed; also verify the append-only trigger is present
 		// to confirm the tamper-evident guarantee is actually in place.
-		triggerCheck := checkAuditTrigger(ctx)
+		triggerCheck := checkAuditTrigger(ctx, pgContainer)
 		if triggerCheck == "pass" {
 			return CheckResult{
 				Section: hardeningSection,
@@ -114,13 +120,13 @@ func checkHardeningAuditLog(ctx context.Context, projectDir string) CheckResult 
 	// The table is INSERT+SELECT only — UPDATE and DELETE are blocked by trigger.
 	query := fmt.Sprintf(`SELECT has_table_privilege(current_user, '%s', 'INSERT')::text;`, auditTableName)
 	cmd := exec.CommandContext(ctx,
-		"docker", "exec", "nself_postgres",
+		"docker", "exec", pgContainer,
 		"psql", "-U", "postgres", "-t", "-c", query,
 	)
 	out, err := cmd.Output()
 	if err == nil && strings.TrimSpace(string(out)) == "t" {
 		// Table writable — also verify append-only trigger.
-		triggerCheck := checkAuditTrigger(ctx)
+		triggerCheck := checkAuditTrigger(ctx, pgContainer)
 		if triggerCheck == "pass" {
 			return CheckResult{
 				Section: hardeningSection,
@@ -141,7 +147,7 @@ func checkHardeningAuditLog(ctx context.Context, projectDir string) CheckResult 
 	// Check 3: table exists but INSERT privilege not confirmed.
 	existsQuery := fmt.Sprintf(`SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name='%s')::text;`, auditTableName)
 	existsCmd := exec.CommandContext(ctx,
-		"docker", "exec", "nself_postgres",
+		"docker", "exec", pgContainer,
 		"psql", "-U", "postgres", "-t", "-c", existsQuery,
 	)
 	existsOut, existsErr := existsCmd.Output()
@@ -165,13 +171,16 @@ func checkHardeningAuditLog(ctx context.Context, projectDir string) CheckResult 
 
 // checkAuditTrigger verifies that the append-only trigger trg_audit_immutable
 // exists on np_audit_events. Returns "pass" if confirmed, "fail" otherwise.
-func checkAuditTrigger(ctx context.Context) string {
+// pgContainer is the already-resolved Postgres container name (see
+// resolveProjectName + health.ContainerName in the two call sites above) so
+// this does not need to reload config on every call.
+func checkAuditTrigger(ctx context.Context, pgContainer string) string {
 	triggerQuery := fmt.Sprintf(
 		`SELECT EXISTS(SELECT 1 FROM information_schema.triggers WHERE trigger_name='%s' AND event_object_table='%s')::text;`,
 		auditTriggerName, auditTableName,
 	)
 	triggerCmd := exec.CommandContext(ctx,
-		"docker", "exec", "nself_postgres",
+		"docker", "exec", pgContainer,
 		"psql", "-U", "postgres", "-t", "-c", triggerQuery,
 	)
 	triggerOut, triggerErr := triggerCmd.Output()

--- a/internal/doctor/hardening_check_nginx_zones.go
+++ b/internal/doctor/hardening_check_nginx_zones.go
@@ -16,6 +16,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/nself-org/cli/internal/health"
 )
 
 // checkHardeningNginxRateZones verifies nginx has limit_req_zone + limit_req
@@ -73,7 +75,8 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 
 	// Fallback: inspect nginx container config if local files not found.
 	if !hasAuthZone || !hasAPIZone {
-		cmd := exec.CommandContext(ctx, "docker", "exec", "nself_nginx",
+		nginxContainer := health.ContainerName(resolveProjectName(projectDir), "nginx")
+		cmd := exec.CommandContext(ctx, "docker", "exec", nginxContainer,
 			"grep", "-r", "limit_req", "/etc/nginx/")
 		out, err := cmd.Output()
 		if err == nil {

--- a/internal/doctor/project_name.go
+++ b/internal/doctor/project_name.go
@@ -1,0 +1,43 @@
+package doctor
+
+// project_name.go — resolves the nSelf PROJECT_NAME for the --deep and
+// hardening checks that shell out to a project's Postgres/nginx containers.
+//
+// Purpose: give every check in this package one place to turn a project
+// directory into the container-name prefix nSelf compose actually uses,
+// instead of each check hardcoding a literal container name.
+// Inputs: projectDir string — the nSelf working directory (same value
+// DeepChecks/HardeningChecks already receive).
+// Outputs: the project's PROJECT_NAME, or legacyProjectName when it cannot
+// be determined.
+// Constraints: must never error out of a doctor check — config.Load failures
+// degrade to the legacy default instead of surfacing as a check failure.
+// SPORT: cli/internal/doctor — container name derivation (unblocks part of
+// nself-org/web#127).
+
+import "github.com/nself-org/cli/internal/config"
+
+// legacyProjectName is the literal name several --deep/hardening checks
+// hardcoded before they resolved PROJECT_NAME from config. It stays as the
+// fallback when config.Load cannot determine a real project name (e.g.
+// doctor invoked outside an nSelf project directory, or an unreadable/oversized
+// env file), so that setups already relying on it — including this repo's own
+// dogfood stack — keep working exactly as before.
+const legacyProjectName = "nself"
+
+// resolveProjectName returns the configured PROJECT_NAME for projectDir. It
+// loads the same .env cascade the rest of the CLI uses (internal/config.Load),
+// so a project with a custom PROJECT_NAME (e.g. nself-org/web's "nself-web")
+// resolves to its real container prefix instead of the old hardcoded "nself".
+//
+// Falls back to legacyProjectName when config.Load errors or somehow yields
+// an empty project name — config.ApplyDefaults normally fills an unset
+// PROJECT_NAME with "myproject", so an empty result here only happens on a
+// genuine load failure.
+func resolveProjectName(projectDir string) string {
+	cfg, err := config.Load(projectDir)
+	if err != nil || cfg.ProjectName == "" {
+		return legacyProjectName
+	}
+	return cfg.ProjectName
+}

--- a/internal/doctor/project_name_test.go
+++ b/internal/doctor/project_name_test.go
@@ -1,0 +1,95 @@
+package doctor
+
+// project_name_test.go — regression coverage for resolveProjectName and the
+// container names derived from it.
+//
+// Before this fix, DockerDeepChecks' Postgres/nginx siblings and the
+// SEC-HARDENING-01/06/07 checks hardcoded "nself_postgres"/"nself_nginx" and
+// could never pass on a project with a custom PROJECT_NAME (confirmed on
+// nself-org/web, PROJECT_NAME=nself-web — see nself-org/web#127). These tests
+// pin down the three cases that matter: a custom PROJECT_NAME resolves to its
+// own container names, an unconfigured project still resolves to config's
+// real default ("myproject", not the old "nself" literal — see
+// internal/config/defaults.go applyDefaultsCore), and a project whose config
+// cannot be loaded at all falls back to the pre-fix "nself" literal so
+// setups that only ever worked because of that hardcoding are undisturbed.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nself-org/cli/internal/health"
+)
+
+func TestResolveProjectName_ContainerNames(t *testing.T) {
+	cases := []struct {
+		name         string
+		setup        func(t *testing.T, dir string) // writes (or omits) project config
+		wantProject  string
+		wantPostgres string
+		wantNginx    string
+	}{
+		{
+			name: "custom project name resolves to its own containers",
+			setup: func(t *testing.T, dir string) {
+				writeTestEnv(t, dir, "PROJECT_NAME=myproj\n")
+			},
+			wantProject:  "myproj",
+			wantPostgres: "myproj_postgres",
+			wantNginx:    "myproj_nginx",
+		},
+		{
+			name:         "unset project name resolves to config's real default, not the old literal",
+			setup:        func(t *testing.T, dir string) {}, // no .env at all
+			wantProject:  "myproject",
+			wantPostgres: "myproject_postgres",
+			wantNginx:    "myproject_nginx",
+		},
+		{
+			name: "unloadable config falls back to the legacy hardcoded name",
+			setup: func(t *testing.T, dir string) {
+				// A NUL byte makes config.Load reject the file outright
+				// (internal/config/loader.go's maxEnvFileSize/null-byte guard),
+				// simulating "project name cannot be resolved at all".
+				content := []byte("PROJECT_NAME=x\x00")
+				if err := os.WriteFile(filepath.Join(dir, ".env"), content, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantProject:  legacyProjectName,
+			wantPostgres: "nself_postgres",
+			wantNginx:    "nself_nginx",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Isolate from whatever PROJECT_NAME the host shell/CI runner may
+			// already export; t.Setenv restores the prior value on cleanup.
+			t.Setenv("PROJECT_NAME", "")
+
+			dir := t.TempDir()
+			tc.setup(t, dir)
+
+			got := resolveProjectName(dir)
+			if got != tc.wantProject {
+				t.Errorf("resolveProjectName(%q) = %q, want %q", dir, got, tc.wantProject)
+			}
+			if pg := health.ContainerName(got, "postgres"); pg != tc.wantPostgres {
+				t.Errorf("postgres container name = %q, want %q", pg, tc.wantPostgres)
+			}
+			if ng := health.ContainerName(got, "nginx"); ng != tc.wantNginx {
+				t.Errorf("nginx container name = %q, want %q", ng, tc.wantNginx)
+			}
+		})
+	}
+}
+
+// writeTestEnv writes content to a .env file in dir, failing the test on error.
+func writeTestEnv(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -46,10 +46,17 @@ type HealthReport struct {
 	Total     int            `json:"total"`
 }
 
-// containerName returns the Docker container name for a given service.
+// ContainerName returns the Docker container name for a given service.
 // nSelf compose uses the pattern {ProjectName}_{service} with hyphens replaced
 // by underscores in the service portion.
-func containerName(projectName, service string) string {
+//
+// Exported so other packages that need to shell out to a specific nSelf
+// container (e.g. internal/doctor's --deep and hardening checks) compute the
+// name the same way instead of hardcoding it — see CLI PRI lessons.md,
+// "container name derivation" (the dogfood Postgres/nginx checks were
+// hardcoded to nself_postgres/nself_nginx and could never pass on a project
+// with a custom PROJECT_NAME).
+func ContainerName(projectName, service string) string {
 	svc := strings.ReplaceAll(service, "-", "_")
 	return fmt.Sprintf("%s_%s", projectName, svc)
 }
@@ -154,7 +161,7 @@ func resolveServiceHealth(ctx context.Context, projectName, service string, comp
 
 	// Secondary lookup: explicit container_name used by nSelf compose generator.
 	// Pattern: {project}_{service} with hyphens → underscores.
-	cname := containerName(projectName, service)
+	cname := ContainerName(projectName, service)
 	if status, ok := composeHealth[cname]; ok {
 		return &HealthResult{
 			Service: service,

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -23,20 +23,20 @@ import (
 // hyphens in the service name to underscores, matching the nSelf compose naming
 // convention ("project_service").
 func TestContainerName_HyphenToUnderscore(t *testing.T) {
-	got := containerName("myproject", "minio-init")
+	got := ContainerName("myproject", "minio-init")
 	want := "myproject_minio_init"
 	if got != want {
-		t.Errorf("containerName(%q, %q) = %q, want %q", "myproject", "minio-init", got, want)
+		t.Errorf("ContainerName(%q, %q) = %q, want %q", "myproject", "minio-init", got, want)
 	}
 }
 
 // TestContainerName_PlainService verifies that a service name without hyphens
 // produces the expected "project_service" format.
 func TestContainerName_PlainService(t *testing.T) {
-	got := containerName("nclaw", "postgres")
+	got := ContainerName("nclaw", "postgres")
 	want := "nclaw_postgres"
 	if got != want {
-		t.Errorf("containerName(%q, %q) = %q, want %q", "nclaw", "postgres", got, want)
+		t.Errorf("ContainerName(%q, %q) = %q, want %q", "nclaw", "postgres", got, want)
 	}
 }
 

--- a/internal/health/checker_watch.go
+++ b/internal/health/checker_watch.go
@@ -151,7 +151,7 @@ func WatchHealth(ctx context.Context, cfg *config.Config, workdir string, interv
 // checkContainer queries the health of a single service by its compose service
 // name, resolving the full container name from the project prefix.
 func checkContainer(ctx context.Context, projectName, service string) (*HealthResult, error) {
-	name := containerName(projectName, service)
+	name := ContainerName(projectName, service)
 	start := time.Now()
 	status, err := docker.GetHealthStatus(ctx, name)
 	elapsed := time.Since(start)


### PR DESCRIPTION
## Summary

`nself doctor --deep` and the SEC-HARDENING-01/06/07 checks hardcoded the container names `nself_postgres` / `nself_nginx`, ignoring `PROJECT_NAME`. nSelf compose actually names containers `{PROJECT_NAME}_{service}`, so on any project with a custom `PROJECT_NAME` these checks could never pass. Confirmed in the wild: `nself-org/web` sets `PROJECT_NAME=nself-web` (its real containers are `nself-web_postgres` / `nself-web_nginx`), and its "Dogfood Check" workflow has failed 67/67 runs since 2026-04-28 partly because of this.

- Exported `internal/health.ContainerName` (was the unexported `containerName`) as the single place the `{project}_{service}` naming formula lives, since that's already the correct, tested pattern used elsewhere in the codebase.
- Added `internal/doctor/project_name.go` with `resolveProjectName(projectDir)`, which loads `PROJECT_NAME` via the existing `config.Load(projectDir)` cascade (the same one `cmd/commands/doctor_checks_config.go`'s `checkPasswordStrength` already uses) and falls back to the legacy literal `"nself"` only when config can't be loaded at all — so a setup that only worked because of the old hardcoding (this repo's own dogfood stack included) is unaffected.
- Replaced all 13 hardcoded occurrences (`internal/doctor/deep_nginx.go`, `deep_db.go`, `hardening_check_db.go`, `hardening_check_nginx_zones.go`) with the resolved name, including the `VACUUM ANALYZE` remediation `FixCmd` string that previously suggested a container that would never exist for a custom project name, and fixed the stale comment in `hardening_check_db.go`.
- `internal/doctor/deep_docker.go` (`DockerDeepChecks`) was left untouched — it inspects `docker ps` output generically and never hardcoded a container name, so there was nothing to fix there despite it sharing the same `(ctx, verbose)` call shape as `PostgresChecks`/`NginxChecks`.

**On the "don't assume `nself`" default:** `internal/config/defaults.go` confirms the real default `PROJECT_NAME` is `"myproject"`, not `"nself"`. For a project that never sets `PROJECT_NAME`, these checks now correctly resolve to `myproject_postgres`/`myproject_nginx` — which is what `nself build` actually names the containers, so this is a fix, not a regression, for that case too. The `"nself"` fallback is reserved for the narrow case where `config.Load` itself fails (unreadable/oversized env file), matching the pre-fix hardcoded behavior in that specific edge case.

Unblocks part of nself-org/web#127.

## Test plan

- [x] `make build` — exit 0
- [x] `gofmt -l cmd internal` — empty output
- [x] `make vet` — exit 0
- [x] `go test -mod=vendor ./...` — all packages pass, including `internal/doctor` and `internal/health`
- [x] `bash scripts/ci/flag-drift-audit.sh` — 0 unregistered flags
- [x] `make wiki-check` — all wiki pages current, all links resolve
- [x] New table-driven test `TestResolveProjectName_ContainerNames` (`internal/doctor/project_name_test.go`) covers: custom `PROJECT_NAME` → `myproj_postgres`/`myproj_nginx`; unset `PROJECT_NAME` → `myproject_postgres`/`myproject_nginx` (config's real default, unchanged behavior); unloadable config → legacy `nself_postgres`/`nself_nginx` fallback
- [x] Negative-tested: reverted the fix in a scratch copy — `go test ./internal/doctor/...` fails to build (`undefined: legacyProjectName`, `undefined: resolveProjectName`, `undefined: health.ContainerName`) — restored, tests pass again