### PR TITLE
docs(wiki): resolve merge conflict markers shipped to the public wiki

### DIFF
--- a/.github/wiki/Commands.md
+++ b/.github/wiki/Commands.md
@@ -12,11 +12,8 @@ tree in `cmd/commands/`. Run `make cmd-inventory` to refresh.
 | `nself account` | Manage your nSelf account, sessions, licenses, team, and devices | — | devices, licenses, login, logout, status, team, transfer |
 | `nself admin` | Manage the nSelf Admin dashboard | — | connect, health, logs, projects, start, stop |
 | `nself ai` | Manage the nSelf AI plugin and local LLM stack | — | chat, local, pool |
-<<<<<<< HEAD
 | `nself ai-studio` | Google AI Studio integration for local nSelf instances | — | bridge |
-=======
 | `nself alerts` | Manage Prometheus alert rules and silences | — | list, silence, test |
->>>>>>> worktree-agent-a68c0a637e3f75d46
 | `nself api` | API versioning and deprecation tooling for operators | — | changelog, deprecation-check, version |
 | `nself backup` | Backup operations: create, list, restore, verify, prune, config, status, init-key | — | config, create, drill, init-key, list, prune, restore, restore-remote, resume, schedule, status, stream, verify |
 | `nself billing` | Billing operations: usage, invoice-preview, report, retry-event | — | invoice-preview, report, retry-event, usage |
@@ -51,11 +48,8 @@ tree in `cmd/commands/`. Run `make cmd-inventory` to refresh.
 | `nself mcp` | Start the nSelf MCP server | — | — |
 | `nself migrate` | Detect and migrate legacy artifacts to the current nSelf version | — | detect, firebase, from-bash, generate, rollback, run, supabase, watch |
 | `nself migrate-from-v099` | Migrate v0.9.9 home-level state (license key, channel, ssh keys) to v1.x layout | — | — |
-<<<<<<< HEAD
 | `nself model` | Manage local AI models via Ollama | — | benchmark, list, pull, remove, update |
-=======
 | `nself monitor` | Monitoring stack management | — | upgrade-dashboards |
->>>>>>> worktree-agent-a68c0a637e3f75d46
 | `nself oauth` | Manage OAuth provider tokens | — | refresh |
 | `nself ops` | Ops-profile deployment and management | — | deploy |
 | `nself pitr` | Point-in-time recovery: enable, disable, status, base-backup, restore | — | base-backup, disable, enable, restore, status |

--- a/.github/wiki/_Sidebar.md
+++ b/.github/wiki/_Sidebar.md
@@ -21,11 +21,7 @@
 - _Networking:_ [[cmd-ssl]] · [[cmd-trust]] · [[cmd-dns-setup]]
 - _Security:_ [[cmd-security]] · [[cmd-secrets]]
 - _Tenancy:_ [[cmd-tenant]] · [[cmd-billing]]
-<<<<<<< HEAD
-- _Plugins:_ [[cmd-plugin]] · [[cmd-license]] · [[cmd-dogfood]] (extracted, CLI-R11) · [[cmd-k8s]] (extracted, CLI-R11)
-=======
-- _Plugins:_ [[cmd-plugin]] · [[cmd-license]] · [[cmd-dogfood]] (extracted, CLI-R11) · [[cmd-encryption]] (extracted, CLI-R11) · [[cmd-waf]] (extracted, CLI-R11) · [[cmd-federation]] (extracted, CLI-R11) · [[cmd-mail]] (extracted, CLI-R11) · [[cmd-dlq]] (extracted, CLI-R11)
->>>>>>> worktree-agent-af24993dee207e6e9
+- _Plugins:_ [[cmd-plugin]] · [[cmd-license]] · [[cmd-dogfood]] (extracted, CLI-R11) · [[cmd-k8s]] (extracted, CLI-R11) · [[cmd-encryption]] (extracted, CLI-R11) · [[cmd-waf]] (extracted, CLI-R11) · [[cmd-federation]] (extracted, CLI-R11) · [[cmd-mail]] (extracted, CLI-R11) · [[cmd-dlq]] (extracted, CLI-R11)
 - _AI:_ [[cmd-ai]] · [[cmd-claw]] · [[cmd-model]]
 - _Templates:_ [[cmd-template]]
 - _Utilities:_ [[cmd-exec]] · [[cmd-clean]] · [[cmd-reset]] · [[cmd-update]] · [[cmd-upgrade]] · [[cmd-version]] · [[cmd-admin]] · [[cmd-migrate]] · [[cmd-migrate-firebase]] · [[cmd-migrate-supabase]] · [[cmd-completion]]


### PR DESCRIPTION
Commands.md and _Sidebar.md both carried unresolved conflict markers on main
(<<<<<<< HEAD / ======= / >>>>>>> worktree-agent-...), so the public GitHub
Wiki has been rendering raw git conflict syntax to readers.

Both conflicts were two concurrent branches adding different rows to the same
hand-maintained list, not genuinely competing edits, so each resolves to the
union rather than a choice:

  _Sidebar.md  Plugins line: k8s from one side, encryption/waf/federation/mail/
               dlq from the other. Verified all nine target pages exist before
               merging the lists, so no link points at a missing page.
  Commands.md  ai-studio vs alerts, and model vs monitor. None are core
               commands (confirmed against a built binary); all four are
               CLI-R11 plugin extractions, which this table also covers. Kept
               alphabetical to match the surrounding rows.

Neither conflict sits inside the BEGIN/END GENERATED:command-table block, so
regenerating did not clear them and would not have. They needed resolving by
hand.

wikigen -check and wiki-link-audit.sh both pass.