### PR TITLE
fix(ci): nself ci resolved the repo root against backend/

### DIFF
--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -19,6 +19,24 @@ Detects the repo stack (Go, Node/TS, Flutter) and runs the appropriate
 lint, test, and build checks plus a gitleaks secret scan. Posts a
 "nself-ci" GitHub commit status via gh OAuth so branch protection can
 require nself-ci instead of billing-blocked GitHub Actions checks.
+
+### Which directory is gated
+
+`[repo-root]` is resolved against the directory you run the command from,
+and defaults to `.`. Unlike the stack lifecycle commands (`start`, `stop`,
+`status`, `logs`, `build`), `nself ci` is **not** redirected into a
+detected `backend/` sub-directory.
+
+That distinction matters in a monorepo. `nself start` from the repo root
+deliberately retargets `backend/`, because that is where the stack lives.
+`nself ci` must not: the gate belongs to the whole checkout, and the
+manifests it looks for (`package.json`, `pnpm-workspace.yaml`, `go.mod`)
+usually sit at the repo root while `backend/` holds only `.env`.
+
+Before this was fixed, `nself ci --check .` in such a repo announced
+"Detected monorepo layout. Using backend as project root" and gated
+`backend/` instead — overriding the path you passed. If you relied on that
+behaviour, pass the sub-directory explicitly: `nself ci ./backend`.
 <!-- END PROSE:description -->
 
 ## Flags

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -139,8 +139,12 @@ func init() {
 		// ── Monorepo detection ────────────────────────────────────────────────
 		// Run for all lifecycle commands so that stop, restart, logs, status,
 		// build, and exec work correctly from a monorepo root — not just start.
+		//
+		// Repo-scoped commands are excluded (isRepoScopedCommand): chdir'ing
+		// before RunE makes a relative [repo-root] argument resolve against
+		// backend/ instead of the directory the user typed it in.
 		noMonorepo, _ := cmd.Flags().GetBool("no-monorepo")
-		if !noMonorepo && !isSourceSafeCommand(cmd.Name()) {
+		if !noMonorepo && !isSourceSafeCommand(cmd.Name()) && !isRepoScopedCommand(cmd.Name()) {
 			if cwd, err := os.Getwd(); err == nil {
 				if backendRoot := config.DetectMonorepoRoot(cwd); backendRoot != "" {
 					fmt.Printf("→ Detected monorepo layout. Using %s as project root.\n", filepath.Base(backendRoot))

--- a/cmd/commands/root_repo_scoped_test.go
+++ b/cmd/commands/root_repo_scoped_test.go
@@ -1,0 +1,69 @@
+package commands
+
+// root_repo_scoped_test.go — Guards the repo-scoped command exemption.
+//
+// Purpose: `nself ci` operates on a source checkout, not a running stack, so it
+//          must be exempt from the monorepo redirect and the source-repo guard.
+//          Lifecycle commands must NOT be exempt — that redirect is why `stop`,
+//          `logs` and `status` work from a monorepo root.
+// Inputs:  command names.
+// Outputs: assertions on isRepoScopedCommand / isSourceSafeCommand.
+// Constraints: pure predicate tests; no filesystem, no chdir, no Docker.
+//
+// The bug this pins: PersistentPreRunE chdir'd into the detected backend/
+// before RunE, so `nself ci --check .` resolved "." against backend/ rather
+// than the directory the user typed it in. From inside ntask it announced
+// "Using backend as project root" and failed, because backend/ has no manifest
+// while the repo root has package.json and pnpm-workspace.yaml. It overrode an
+// explicitly passed path, which is what made it a correctness bug.
+
+import "testing"
+
+// TestRepoScopedCommands_ExemptFromRedirect pins which commands skip the
+// monorepo chdir. Adding a name here is a deliberate act: it means the command
+// takes a repo path and must see the user's cwd.
+func TestRepoScopedCommands_ExemptFromRedirect(t *testing.T) {
+	t.Parallel()
+
+	if !isRepoScopedCommand("ci") {
+		t.Error("ci must be repo-scoped: the monorepo redirect breaks its [repo-root] argument")
+	}
+
+	// Lifecycle commands rely on the redirect to work from a monorepo root.
+	// If any of these becomes exempt, `nself stop` from the repo root silently
+	// targets the wrong directory.
+	for _, name := range []string{"start", "stop", "restart", "status", "logs", "build", "exec", "reset"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if isRepoScopedCommand(name) {
+				t.Errorf("%q must NOT be repo-scoped — it needs the monorepo redirect", name)
+			}
+		})
+	}
+}
+
+// TestRepoScopedImpliesSourceSafe covers the other half of the exemption:
+// running `nself ci` inside a checkout is the entire point, so the
+// source-repo guard must not block it.
+func TestRepoScopedImpliesSourceSafe(t *testing.T) {
+	t.Parallel()
+
+	if !isSourceSafeCommand("ci") {
+		t.Error("ci must be source-safe: refusing to run inside a checkout defeats the gate")
+	}
+
+	// The pre-existing safe list must survive the change.
+	for _, name := range []string{"help", "version", "completion", "update", "upgrade", "doctor", "nself"} {
+		if !isSourceSafeCommand(name) {
+			t.Errorf("%q lost its source-safe exemption", name)
+		}
+	}
+
+	// And genuinely unsafe commands must still be blocked in a source repo.
+	for _, name := range []string{"start", "build", "reset"} {
+		if isSourceSafeCommand(name) {
+			t.Errorf("%q must NOT be source-safe — it would run against the nself checkout", name)
+		}
+	}
+}

--- a/cmd/commands/root_source_guard.go
+++ b/cmd/commands/root_source_guard.go
@@ -93,9 +93,38 @@ To override (testing only): export NSELF_ALLOW_SOURCE_DIR=1`, cwd)
 // isSourceSafeCommand returns true for commands that are safe to run from
 // anywhere, including the source repository.
 func isSourceSafeCommand(name string) bool {
+	if isRepoScopedCommand(name) {
+		return true
+	}
 	safe := map[string]bool{
 		"help": true, "version": true, "completion": true,
 		"update": true, "upgrade": true, "doctor": true, "nself": true,
 	}
 	return safe[name]
+}
+
+// isRepoScopedCommand returns true for commands that operate on a source
+// repository rather than on a running nSelf stack.
+//
+// These must be exempt from two behaviours that exist for stack lifecycle
+// commands and are actively wrong here:
+//
+//   - The source-repo guard. Refusing to run inside a checkout is right for
+//     `nself start`; for `nself ci` the checkout IS the subject.
+//   - The monorepo redirect. PersistentPreRunE chdirs into the detected
+//     backend/ before RunE, so `nself ci` resolved "." — and any relative
+//     [repo-root] argument — against backend/ instead of the repo. From
+//     inside ntask it announced "Using backend as project root" and failed,
+//     because backend/ has no manifest while the repo root has package.json
+//     and pnpm-workspace.yaml. It silently overrode an explicitly passed
+//     path, which is the part that makes it a correctness bug rather than a
+//     convenience one.
+//
+// Keeping this separate from isSourceSafeCommand records WHY each name is
+// exempt, so a future addition to either list does not silently inherit the
+// other's semantics.
+func isRepoScopedCommand(name string) bool {
+	return map[string]bool{
+		"ci": true,
+	}[name]
 }


### PR DESCRIPTION
One of the two open CLI gaps in `nself-cli-local-ci-gaps` that block `nself ci` from replacing server-side CI — the mechanism the two-server rule depends on.

## The bug

`nself ci` gates a source checkout, but `PersistentPreRunE` treats every non-safe command as a **stack lifecycle** command: it detects a monorepo and `chdir`s into `backend/` *before* `RunE`. So `ci` resolved `"."` — and any relative `[repo-root]` argument — against `backend/` instead of where the user typed it.

Reproduced on a minimal fixture (`backend/.env` at a root holding `package.json` + `pnpm-workspace.yaml`):

| | |
|---|---|
| before | `Detected monorepo layout. Using backend as project root.` → `repo: .../mono/backend` |
| after | `repo: .../mono` |

Same result with an explicit `.` and with no argument.

**Silently overriding an explicitly passed path** is what makes this a correctness bug rather than a convenience one. It is why `nself ci` fails from inside ntask: `backend/` has no manifest, while the repo root has both.

## Why a new predicate

`isSourceSafeCommand` gates **two unrelated behaviours** — the source-repo guard and the monorepo redirect. `ci` needs exemption from both, but for different reasons: running inside a checkout is the entire point, *and* the chdir breaks its argument.

Adding `ci` to that one list would have worked today and quietly mis-taught the next person. `isRepoScopedCommand` states the reason, and stops a future addition to either list inheriting the other's semantics.

## Verification

- Reproduced the failure, then confirmed the fix on the same fixture
- **Regression-checked**: `start`, `stop`, `restart`, `status`, `logs`, `build`, `exec`, `reset` all still redirect — `nself stop` from a monorepo root is unaffected
- Tests **fail when the exemption is removed** (verified, not assumed)
- Full suite: **84 packages pass, 0 fail**

## Still open

The other gap — `nself ci` cannot bootstrap its gate binary for an installed CLI (`nself-ci binary not found on PATH`) — is untouched here. Both must land before `nself-ci` can be a required check again.