### PR TITLE
fix(ci): nself ci could not find its gate on an installed CLI

### DIFF
--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -35,8 +35,37 @@ usually sit at the repo root while `backend/` holds only `.env`.
 
 Before this was fixed, `nself ci --check .` in such a repo announced
 "Detected monorepo layout. Using backend as project root" and gated
-`backend/` instead — overriding the path you passed. If you relied on that
+`backend/` instead, overriding the path you passed. If you relied on that
 behaviour, pass the sub-directory explicitly: `nself ci ./backend`.
+
+### Where the gate binary comes from
+
+The gates themselves live in a separate binary, `nself-ci`, built from the
+free `ci` plugin. `nself ci` resolves it in this order:
+
+1. `nself-ci` already on `PATH`.
+2. Plugin source next to the CLI checkout (`plugins/free/ci`), built on
+   demand. This is the developer path.
+3. Otherwise fetched once with `go install` and cached at
+   `~/.nself/bin/nself-ci`.
+
+Step 3 is what makes the command usable from a single-file install, where
+no plugin source is on disk. It requires a Go toolchain and runs only once
+per machine. Expect it to take a couple of minutes the first time: the gate
+module declares a newer Go than most machines have, so Go downloads a
+matching toolchain before building. Progress is printed, and the fetch is
+bounded at 10 minutes rather than left to stall.
+
+To skip the fetch entirely, put a pre-built `nself-ci` on your `PATH`:
+
+```bash
+git clone https://github.com/nself-org/plugins
+cd plugins/free/ci && go build -o ~/.nself/bin/nself-ci ./cmd/
+```
+
+Until this existed, an installed CLI failed with `nself-ci binary not found
+on PATH` and expected you to clone a second repo by hand. That manual step
+is why `nself ci` could not be used as a required status check.
 <!-- END PROSE:description -->
 
 ## Flags

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -10,12 +10,10 @@ package commands
 // SPORT: CLI-CMD-CI-001
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	nscicmd "github.com/nself-org/cli/internal/cmd/ci"
 	"github.com/nself-org/cli/internal/ui"
@@ -130,90 +128,4 @@ func runCI(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("nself-ci: %w", err)
 	}
 	return nil
-}
-
-// ensureCIBinary returns the path to the nself-ci binary, building it first
-// if necessary. Looks for the plugin source relative to the CLI source tree,
-// or falls back to PATH if a pre-built nself-ci is already there.
-func ensureCIBinary(verbose bool) (string, error) {
-	// Fast path: nself-ci already on PATH (installed or previously built).
-	if p, err := exec.LookPath("nself-ci"); err == nil {
-		return p, nil
-	}
-
-	// Locate the plugin source relative to this binary.
-	// The CLI binary lives at, e.g., ~/Sites/nself/cli/nself (dev) or
-	// /usr/local/bin/nself (installed). In dev the plugin source is adjacent.
-	exe, err := os.Executable()
-	if err != nil {
-		return "", fmt.Errorf("cannot determine executable path: %w", err)
-	}
-	exe, _ = filepath.EvalSymlinks(exe)
-
-	candidates := []string{
-		// Dev: cli/ → parent nself/ → plugins/free/ci
-		filepath.Join(filepath.Dir(exe), "..", "plugins", "free", "ci"),
-		filepath.Join(filepath.Dir(exe), "..", "..", "plugins", "free", "ci"),
-	}
-
-	var pluginDir string
-	for _, c := range candidates {
-		abs, _ := filepath.Abs(c)
-		if fileExists(filepath.Join(abs, "cmd", "main.go")) {
-			pluginDir = abs
-			break
-		}
-	}
-
-	if pluginDir == "" {
-		return "", fmt.Errorf("nself-ci binary not found on PATH and plugin source not found near CLI binary.\n" +
-			"Install gitleaks and build the plugin:\n" +
-			"  cd plugins/free/ci && go build -o nself-ci ./cmd/")
-	}
-
-	binary := filepath.Join(pluginDir, "nself-ci")
-
-	// Build if binary is missing or source is newer.
-	if needsBuild(binary, pluginDir) {
-		if verbose {
-			fmt.Fprintf(os.Stderr, "[nself-ci] building gate binary from %s\n", pluginDir)
-		}
-		var stderr bytes.Buffer
-		build := exec.Command("go", "build", "-o", binary, "./cmd/")
-		build.Dir = pluginDir
-		build.Stderr = &stderr
-		if err := build.Run(); err != nil {
-			return "", fmt.Errorf("go build failed: %w\n%s", err, strings.TrimSpace(stderr.String()))
-		}
-	}
-	return binary, nil
-}
-
-// needsBuild returns true if the binary is missing or any source file is newer.
-func needsBuild(binary, pluginDir string) bool {
-	info, err := os.Stat(binary)
-	if err != nil {
-		return true // binary missing
-	}
-	sources := []string{
-		filepath.Join(pluginDir, "cmd", "main.go"),
-		filepath.Join(pluginDir, "internal", "gate.go"),
-		filepath.Join(pluginDir, "internal", "status.go"),
-	}
-	for _, src := range sources {
-		si, err := os.Stat(src)
-		if err != nil {
-			continue
-		}
-		if si.ModTime().After(info.ModTime()) {
-			return true
-		}
-	}
-	return false
-}
-
-// fileExists returns true if the path exists.
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
 }

--- a/cmd/commands/ci_bootstrap.go
+++ b/cmd/commands/ci_bootstrap.go
@@ -1,0 +1,219 @@
+package commands
+
+// ci_bootstrap.go — Resolving the nself-ci gate binary.
+//
+// Purpose: `nself ci` runs its gates from a separate binary built from the free
+//   `ci` plugin. Split out of ci.go (which crossed the 300-line cap) because
+//   locating/fetching the gate is a distinct concern from running it.
+// Inputs:  the CLI's own executable path, PATH, HOME, a Go toolchain.
+// Outputs: an absolute path to a runnable nself-ci binary.
+// Constraints: the fetch is bounded and announced; it must be a one-time cost,
+//   so the cache-hit path is the invariant guarded by ci_bootstrap_test.go.
+// SPORT: CLI-CMD-CI-001
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ensureCIBinary returns the path to the nself-ci binary, building it first
+// if necessary. Looks for the plugin source relative to the CLI source tree,
+// or falls back to PATH if a pre-built nself-ci is already there.
+func ensureCIBinary(verbose bool) (string, error) {
+	// Fast path: nself-ci already on PATH (installed or previously built).
+	if p, err := exec.LookPath("nself-ci"); err == nil {
+		return p, nil
+	}
+
+	// Locate the plugin source relative to this binary.
+	// The CLI binary lives at, e.g., ~/Sites/nself/cli/nself (dev) or
+	// /usr/local/bin/nself (installed). In dev the plugin source is adjacent.
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine executable path: %w", err)
+	}
+	exe, _ = filepath.EvalSymlinks(exe)
+
+	candidates := []string{
+		// Dev: cli/ → parent nself/ → plugins/free/ci
+		filepath.Join(filepath.Dir(exe), "..", "plugins", "free", "ci"),
+		filepath.Join(filepath.Dir(exe), "..", "..", "plugins", "free", "ci"),
+	}
+
+	var pluginDir string
+	for _, c := range candidates {
+		abs, _ := filepath.Abs(c)
+		if fileExists(filepath.Join(abs, "cmd", "main.go")) {
+			pluginDir = abs
+			break
+		}
+	}
+
+	// Installed CLI: the plugin source is not adjacent, because only the single
+	// `nself` binary was distributed. Fetch and cache the gate instead of
+	// telling the user to clone a second repo and build Go by hand — that
+	// requirement is why `nself ci` could not be a required check.
+	if pluginDir == "" {
+		return ensureCIBinaryFromModule(verbose)
+	}
+
+	binary := filepath.Join(pluginDir, "nself-ci")
+
+	// Build if binary is missing or source is newer.
+	if needsBuild(binary, pluginDir) {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "[nself-ci] building gate binary from %s\n", pluginDir)
+		}
+		var stderr bytes.Buffer
+		build := exec.Command("go", "build", "-o", binary, "./cmd/")
+		build.Dir = pluginDir
+		build.Stderr = &stderr
+		if err := build.Run(); err != nil {
+			return "", fmt.Errorf("go build failed: %w\n%s", err, strings.TrimSpace(stderr.String()))
+		}
+	}
+	return binary, nil
+}
+
+// ciGateModule is the public Go module providing the nself-ci gate binary.
+const ciGateModule = "github.com/nself-org/plugins/free/ci/cmd@latest"
+
+// ciGateFetchTimeout bounds the one-off gate fetch. Generous because it may
+// include a Go toolchain download, but finite so a first run cannot hang
+// silently forever.
+const ciGateFetchTimeout = 10 * time.Minute
+
+// ciCacheBinary returns the path the fetched gate binary is cached at.
+// Kept under the nSelf config dir rather than GOBIN so it is not mixed in with
+// the user's own tools and can be cleared with the rest of nSelf's state.
+func ciCacheBinary() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".nself", "bin", "nself-ci"), nil
+}
+
+// ensureCIBinaryFromModule resolves the gate for an INSTALLED CLI, where the
+// plugin source is not on disk beside the binary.
+//
+// Order: cached build, then `go install` of the public module into that cache.
+// Only reached when the binary is absent from PATH and no adjacent source
+// exists, so it costs nothing on a dev checkout or a machine that already has
+// the gate.
+//
+// Requires a Go toolchain. That is a real constraint and the error says so
+// plainly instead of failing with a bare "not found on PATH", which is what
+// this replaces.
+func ensureCIBinaryFromModule(verbose bool) (string, error) {
+	cached, err := ciCacheBinary()
+	if err != nil {
+		return "", err
+	}
+
+	// Already fetched by a previous run.
+	if fileExists(cached) {
+		return cached, nil
+	}
+
+	if _, err := exec.LookPath("go"); err != nil {
+		return "", fmt.Errorf(
+			"nself-ci gate not installed, and no Go toolchain is available to fetch it.\n"+
+				"Either install Go and re-run, or build the gate manually:\n"+
+				"  git clone https://github.com/nself-org/plugins\n"+
+				"  cd plugins/free/ci && go build -o %s ./cmd/", cached)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cached), 0o750); err != nil {
+		return "", fmt.Errorf("creating %s: %w", filepath.Dir(cached), err)
+	}
+
+	// Announced unconditionally, not only under -v. This runs once per machine
+	// and can take minutes; a silent stall is indistinguishable from a hang, and
+	// that is exactly how it presented while this was being built.
+	fmt.Fprintf(os.Stderr, "[nself-ci] gate not installed; fetching %s (one-time, may take a few minutes)\n", ciGateModule)
+
+	// Bounded: the gate module declares a newer Go than many machines have, so
+	// `go install` may transparently download a whole toolchain first
+	//   go: ... requires go >= 1.26.4; switching to go1.26.7
+	// which is seconds on a warm cache and minutes on a cold one. Without a
+	// deadline a first run just appears to hang with no output.
+	ctx, cancel := context.WithTimeout(context.Background(), ciGateFetchTimeout)
+	defer cancel()
+
+	// GOBIN targets the cache directly, so the binary lands where we look for
+	// it next time rather than in the user's GOPATH/bin.
+	var stderr bytes.Buffer
+	install := exec.CommandContext(ctx, "go", "install", ciGateModule) //nolint:gosec // fixed module path
+	install.Env = append(os.Environ(), "GOBIN="+filepath.Dir(cached))
+	// Under -v mirror Go's own progress (module and toolchain downloads) to the
+	// terminal as it happens, while still keeping a copy for the error message.
+	if verbose {
+		install.Stderr = io.MultiWriter(&stderr, os.Stderr)
+	} else {
+		install.Stderr = &stderr
+	}
+	if err := install.Run(); err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf(
+				"fetching the nself-ci gate timed out after %s.\n"+
+					"Go may be downloading a newer toolchain; re-run to resume, or build it directly:\n"+
+					"  git clone https://github.com/nself-org/plugins\n"+
+					"  cd plugins/free/ci && go build -o %s ./cmd/", ciGateFetchTimeout, cached)
+		}
+		return "", fmt.Errorf("fetching nself-ci gate failed: %w\n%s\n"+
+			"Build it manually if this persists:\n"+
+			"  git clone https://github.com/nself-org/plugins\n"+
+			"  cd plugins/free/ci && go build -o %s ./cmd/",
+			err, strings.TrimSpace(stderr.String()), cached)
+	}
+
+	// `go install` names the binary after the package directory ("cmd"), not
+	// the module, so it has to be moved into place.
+	installed := filepath.Join(filepath.Dir(cached), "cmd")
+	if fileExists(installed) && installed != cached {
+		if err := os.Rename(installed, cached); err != nil {
+			return "", fmt.Errorf("placing gate binary at %s: %w", cached, err)
+		}
+	}
+	if !fileExists(cached) {
+		return "", fmt.Errorf("gate install reported success but %s is missing", cached)
+	}
+	return cached, nil
+}
+
+// needsBuild returns true if the binary is missing or any source file is newer.
+func needsBuild(binary, pluginDir string) bool {
+	info, err := os.Stat(binary)
+	if err != nil {
+		return true // binary missing
+	}
+	sources := []string{
+		filepath.Join(pluginDir, "cmd", "main.go"),
+		filepath.Join(pluginDir, "internal", "gate.go"),
+		filepath.Join(pluginDir, "internal", "status.go"),
+	}
+	for _, src := range sources {
+		si, err := os.Stat(src)
+		if err != nil {
+			continue
+		}
+		if si.ModTime().After(info.ModTime()) {
+			return true
+		}
+	}
+	return false
+}
+
+// fileExists returns true if the path exists.
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cmd/commands/ci_bootstrap_test.go
+++ b/cmd/commands/ci_bootstrap_test.go
@@ -1,0 +1,112 @@
+package commands
+
+// ci_bootstrap_test.go — Guards the installed-CLI gate bootstrap.
+//
+// Purpose: an installed `nself` ships as a single binary, so the nself-ci gate
+//          source is not adjacent to it. Before this, `nself ci` simply errored
+//          with "nself-ci binary not found on PATH" and told the user to clone
+//          a second repo and run `go build` by hand. That manual step is the
+//          reason `nself ci` could not be made a required status check, which
+//          is what the two-server rule depends on.
+// Inputs:  a temporary HOME.
+// Outputs: assertions on ciCacheBinary / ensureCIBinaryFromModule.
+// Constraints: no network. The fetch path itself is deliberately NOT exercised
+//          here — it shells out to `go install` and, on a cold machine, pulls a
+//          whole Go toolchain (measured at 112s). Only the cache-hit and
+//          path-resolution halves are unit-testable; the fetch is covered by
+//          the bounded-timeout error path instead.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setHome points os.UserHomeDir at a temp dir on every platform. HOME alone is
+// not enough: on Windows os.UserHomeDir reads %USERPROFILE%, so a test that
+// sets only HOME silently uses the runner's real home directory.
+func setHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	return dir
+}
+
+// TestCICacheBinary_UnderNselfDir pins where the fetched gate is cached.
+// It lives under ~/.nself/ rather than GOBIN so it is not mixed into the user's
+// own tools and is cleared along with the rest of nSelf's state.
+func TestCICacheBinary_UnderNselfDir(t *testing.T) {
+	home := setHome(t)
+
+	got, err := ciCacheBinary()
+	if err != nil {
+		t.Fatalf("ciCacheBinary: %v", err)
+	}
+
+	want := filepath.Join(home, ".nself", "bin", "nself-ci")
+	if got != want {
+		t.Errorf("cache path = %q, want %q", got, want)
+	}
+}
+
+// TestEnsureCIBinaryFromModule_CacheHit is the invariant that keeps the fetch
+// a one-time cost. If this regresses, every `nself ci` invocation re-runs
+// `go install` and the command becomes unusable as a pre-commit gate.
+func TestEnsureCIBinaryFromModule_CacheHit(t *testing.T) {
+	home := setHome(t)
+
+	cached := filepath.Join(home, ".nself", "bin", "nself-ci")
+	if err := os.MkdirAll(filepath.Dir(cached), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(cached, []byte("#!/bin/sh\nexit 0\n"), 0o750); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Must return immediately from cache. A network fetch here would hang the
+	// test rather than fail it, which is itself the signal.
+	got, err := ensureCIBinaryFromModule(false)
+	if err != nil {
+		t.Fatalf("ensureCIBinaryFromModule: %v", err)
+	}
+	if got != cached {
+		t.Errorf("returned %q, want the cached binary %q", got, cached)
+	}
+}
+
+// TestCIGateModule_IsPinnedToPublicPath guards the module path. It must stay a
+// constant: it is interpolated into an exec.Command, so anything user-derived
+// here would be a command-injection surface.
+func TestCIGateModule_IsPinnedToPublicPath(t *testing.T) {
+	t.Parallel()
+
+	const wantPrefix = "github.com/nself-org/plugins/free/ci"
+	if !strings.HasPrefix(ciGateModule, wantPrefix) {
+		t.Errorf("ciGateModule = %q, must be under %q", ciGateModule, wantPrefix)
+	}
+	// `go install` requires a main package; the gate's is ./cmd/.
+	if !strings.Contains(ciGateModule, "/cmd@") {
+		t.Errorf("ciGateModule = %q, must target the ./cmd/ main package", ciGateModule)
+	}
+}
+
+// TestCIGateFetchTimeout_IsGenerousButFinite pins the bound. A cold fetch was
+// measured at 112s because Go transparently downloads a newer toolchain
+// ("requires go >= 1.26.4; switching to go1.26.7"), so a tight timeout would
+// break first runs on slow links. Unbounded is worse: that is exactly how this
+// presented while it was being built — a silent, indefinite stall.
+func TestCIGateFetchTimeout_IsGenerousButFinite(t *testing.T) {
+	t.Parallel()
+
+	if ciGateFetchTimeout <= 0 {
+		t.Fatal("fetch must be bounded; an unbounded go install stalls with no output")
+	}
+	if ciGateFetchTimeout.Minutes() < 5 {
+		t.Errorf("timeout %s is too tight — a cold fetch includes a Go toolchain download (~112s measured, slower on poor links)", ciGateFetchTimeout)
+	}
+	if ciGateFetchTimeout.Minutes() > 30 {
+		t.Errorf("timeout %s is effectively unbounded for an interactive command", ciGateFetchTimeout)
+	}
+}


### PR DESCRIPTION
Second of the two CLI gaps tracked in `nself-cli-local-ci-gaps`. The first was the monorepo root redirect (#291).

## The problem

An installed `nself` is a single binary, so the nself-ci gate source is not on disk beside it. `nself ci` failed with:

```
nself-ci binary not found on PATH
```

and expected the user to clone a second repository and run `go build` by hand.

That manual step is why `nself ci` could not be made a required status check. The two-server rule depends on the gate running on a developer machine that only ever installed the binary, so "clone the plugins repo first" is not a viable prerequisite.

## Resolution order

| # | Source | When |
|---|---|---|
| 1 | `nself-ci` on `PATH` | already installed |
| 2 | adjacent plugin source, built on demand | developer checkout (unchanged) |
| 3 | `go install`, cached at `~/.nself/bin/nself-ci` | **new** — installed CLI |

## Two things the fetch needed

**It is slow the first time, and it was silent.** The gate module declares a newer Go than most machines have, so Go transparently downloads a matching toolchain before building:

```
go: github.com/nself-org/plugins/free/ci@v0.0.0-... requires go >= 1.26.4; switching to go1.26.7
```

Measured **112s cold, instant warm**. While building this it presented as a hang — I spent a while chasing a deadlock that was really just a toolchain download behind a 120s test timeout. So the fetch is announced unconditionally now, not only under `-v`, and `-v` mirrors Go's own progress output live.

**An unbounded `exec` is the wrong shape for that.** Capped at 10 minutes, with an error that names the manual build as the fallback.

Also: `go install` names the binary after its package directory (`cmd`), not the module, so it is moved into place afterwards.

## Verification

Built an isolated binary with no adjacent plugin source and `nself-ci` hidden from `PATH`:

- cold: fetched, cached, ran the gates — 112s
- warm: 0s
- gate correctly reported `FAIL` on a repo with no packages, so it is really running

Full suite: **4605 passed, 0 failed, 95 packages**.

## File split

The additions took `ci.go` to 331 lines, over the 300-line cap (`TestFileSizeBudgetNotExceeded` caught it). Locating the gate is a separate concern from running it, so it moved to `ci_bootstrap.go`.

## Tests

`ci_bootstrap_test.go` covers:

- **cache hit** — the invariant that keeps the fetch one-time. A regression makes every `nself ci` re-run `go install`, which would make it unusable as a pre-commit gate.
- **cache location** — under `~/.nself/` rather than GOBIN. Sets both `HOME` and `USERPROFILE`, since `os.UserHomeDir` reads the latter on Windows.
- **module path is a constant** — it is interpolated into an `exec.Command`, so anything user-derived would be an injection surface.
- **timeout is generous but finite** — pinned between 5 and 30 minutes, with the 112s measurement recorded as the reason it cannot be tight.

The fetch itself is deliberately not exercised: it needs the network and a toolchain download.