### PR TITLE
fix(start): check the ports the stack publishes, not the nSelf defaults

### DIFF
--- a/.github/wiki/cmd-start.md
+++ b/.github/wiki/cmd-start.md
@@ -17,7 +17,26 @@ nself start [flags]
 <!-- BEGIN PROSE:description -->
 `nself start` brings up the entire ɳSelf stack in the correct order: PostgreSQL first, then automatic database initialization (schemas, extensions, permissions), then Hasura, Auth, Nginx, optional services, monitoring, and custom services. Each service is health-checked before the next group starts.
 
-Before launching containers, `nself start` validates that `docker-compose.yml` exists (run `nself build` first), the Docker daemon is running, and all required ports are available. A pre-flight port check scans for conflicts on ports 80, 443, 5432, 8080, 4000, 6379, and 9000 and reports the conflicting process name if a port is in use.
+Before launching containers, `nself start` validates that `docker-compose.yml` exists (run `nself build` first), the Docker daemon is running, and all required ports are available. The pre-flight port check reports the conflicting process name if a port is in use.
+
+### Which ports get checked
+
+The check reads the ports your project actually publishes, from the resolved `docker compose config`. It does not test a fixed list of ɳSelf defaults.
+
+That matters when you run more than one ɳSelf project on one host. The second project has to move off the defaults:
+
+```bash
+POSTGRES_PORT=5433
+HASURA_PORT=8181
+AUTH_PORT=4001
+REDIS_PORT=6380
+```
+
+Those are the ports it binds, so those are the ports checked. The first project holding 5432 and 8080 is not a conflict for the second and no longer blocks it. Before v1.3.4 it did, which could leave a correctly configured stack unable to start over ports it never touches.
+
+Conflicts name the service from your compose file, so a moved port reads `Port 8181 (hasura)` rather than `unknown service`.
+
+If the compose config cannot be read, the check falls back to the default list (80, 443, 5432, 8080, 4000, 6379, 9000, 9001, 7700, 3021, 1025, 8025, 3008, 5000) and says so. It never skips the check silently.
 
 Database initialization is automatic and idempotent, ɳSelf creates the database, schemas (`auth`, `storage`, `public`), and extensions (`pgcrypto`, `citext`, `uuid-ossp`) if they do not already exist. After all services are healthy, the console prints all service URLs.
 

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -352,28 +352,32 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	if opts.skipPortCheck {
 		ui.Warn("Port check skipped (--skip-port-check)")
 	} else {
-		conflicts, err := docker.CheckAllPortsFiltered(ctx, docker.ReservedPorts, projectDir, composeFiles...)
+		// Check the ports THIS stack will actually bind, read from the resolved
+		// compose config, rather than a fixed list of nSelf defaults.
+		//
+		// A second project on the same host has to move off the defaults
+		// (POSTGRES_PORT=5433, HASURA_PORT=8181, ...). Checking the default
+		// list then blocks it on 5432 and 8080 — ports it was never going to
+		// bind — purely because the first project holds them. That is not a
+		// conflict, and it is what kept the ɳTask staging stack down: its
+		// compose published 5433/8181/4001/6380/9010/9011, every one free,
+		// while start refused over six defaults it does not use.
+		checkPorts, portServiceMap, derr := docker.DeclaredHostPorts(ctx, projectDir, composeFiles...)
+		if derr != nil || len(checkPorts) == 0 {
+			// Fall back to the default list rather than check nothing. Checking
+			// an empty list would be a port check that cannot fail, which is
+			// worse than one that is occasionally too strict.
+			if derr != nil {
+				ui.Warn(fmt.Sprintf("Could not read published ports from compose (%v); using the default port list", derr))
+			}
+			checkPorts = docker.ReservedPorts
+			portServiceMap = docker.DefaultPortServiceNames()
+		}
+
+		conflicts, err := docker.CheckAllPortsFiltered(ctx, checkPorts, projectDir, composeFiles...)
 		if err != nil {
 			ui.Warn(fmt.Sprintf("Port check error: %v", err))
 		} else if len(conflicts) > 0 {
-			// Map ports to their service names for clear diagnostics.
-			portServiceMap := map[int]string{
-				80:   "HTTP (Nginx)",
-				443:  "HTTPS (Nginx)",
-				5432: "PostgreSQL",
-				8080: "Hasura GraphQL",
-				4000: "Auth",
-				6379: "Redis",
-				9000: "MinIO",
-				9001: "MinIO Console",
-				7700: "MeiliSearch",
-				3021: "nSelf Admin",
-				1025: "Mailpit SMTP",
-				8025: "Mailpit UI",
-				3008: "Functions",
-				5000: "MLflow",
-			}
-
 			var portList []string
 			for _, c := range conflicts {
 				svc := portServiceMap[c.Port]

--- a/internal/docker/port_declared.go
+++ b/internal/docker/port_declared.go
@@ -1,0 +1,158 @@
+package docker
+
+// Purpose: Determine the host ports a stack will actually bind, by reading the
+//   resolved compose configuration rather than assuming nSelf defaults.
+// Inputs:  workdir + the compose files the caller is about to bring up.
+// Outputs: sorted host ports, and a port -> service name map for diagnostics.
+// Constraints: no side effects; `docker compose config` does not start anything.
+//   Never returns an empty list silently on failure — the caller must be able to
+//   tell "this stack binds nothing" from "we could not work it out", because
+//   checking an empty list would be a port check that cannot fail.
+// SPORT: CLI-CMD-START-001
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// composeConfigPort mirrors the `ports` entries in `docker compose config
+// --format json`. Compose normalises every short-form ("5433:5432",
+// "127.0.0.1:5433:5432") into this long form, so only this shape is parsed.
+type composeConfigPort struct {
+	Published any    `json:"published"` // string in most versions, number in some
+	Target    int    `json:"target"`
+	Protocol  string `json:"protocol"`
+	HostIP    string `json:"host_ip"`
+}
+
+type composeConfigDoc struct {
+	Services map[string]struct {
+		Ports []composeConfigPort `json:"ports"`
+	} `json:"services"`
+}
+
+// publishedPort normalises the published field, which Compose emits as a string
+// in most versions and as a number in others. Ranges ("8000-8010") take the
+// first port; a range that partially conflicts is still a conflict.
+func (p composeConfigPort) publishedPort() int {
+	var s string
+	switch v := p.Published.(type) {
+	case string:
+		s = v
+	case float64:
+		return int(v)
+	case int:
+		return v
+	default:
+		return 0
+	}
+	if s == "" {
+		return 0
+	}
+	if idx := strings.Index(s, "-"); idx > 0 {
+		s = s[:idx]
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// DeclaredHostPorts returns the host ports the given compose files publish,
+// together with a port -> service name map for error messages.
+//
+// This exists because checking a fixed list of default ports is wrong for any
+// stack that was configured off the defaults. A second nSelf project on one
+// host must move its ports (POSTGRES_PORT=5433, HASURA_PORT=8181, ...); with a
+// fixed list it is then blocked by the first project holding 5432 and 8080,
+// ports it was never going to bind. That is what kept a staging stack down.
+//
+// An error here means "could not determine", never "binds nothing". The caller
+// must fall back to a conservative default list rather than check nothing.
+func DeclaredHostPorts(ctx context.Context, workdir string, composeFiles ...string) ([]int, map[int]string, error) {
+	c := NewCompose(composeFiles...)
+	args := c.buildBaseArgs()
+	args = append(args, "config", "--format", "json")
+
+	cmd := exec.CommandContext(ctx, c.dockerBin(), args...)
+	cmd.Dir = workdir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, nil, fmt.Errorf("docker compose config: %w", err)
+	}
+
+	var doc composeConfigDoc
+	if err := json.Unmarshal(out, &doc); err != nil {
+		return nil, nil, fmt.Errorf("parsing compose config JSON: %w", err)
+	}
+	if len(doc.Services) == 0 {
+		return nil, nil, fmt.Errorf("compose config listed no services")
+	}
+
+	ports, names := collectPublishedPorts(doc)
+	return ports, names, nil
+}
+
+// collectPublishedPorts turns a parsed compose config into the sorted set of
+// TCP host ports and a port -> service name map.
+//
+// Split out of DeclaredHostPorts so tests exercise THIS function rather than
+// re-implementing the same loop. A test that reproduces the logic it is
+// checking passes against broken production code, which is how a hardcoded
+// flag list survived here for months.
+func collectPublishedPorts(doc composeConfigDoc) ([]int, map[int]string) {
+	names := make(map[int]string)
+	seen := make(map[int]bool)
+	for svc, s := range doc.Services {
+		for _, p := range s.Ports {
+			// UDP publishes do not collide with the TCP probe used by
+			// CheckPort, so including them would produce false conflicts.
+			if p.Protocol != "" && !strings.EqualFold(p.Protocol, "tcp") {
+				continue
+			}
+			hp := p.publishedPort()
+			if hp <= 0 || seen[hp] {
+				continue
+			}
+			seen[hp] = true
+			names[hp] = svc
+		}
+	}
+
+	ports := make([]int, 0, len(seen))
+	for p := range seen {
+		ports = append(ports, p)
+	}
+	sort.Ints(ports)
+	return ports, names
+}
+
+// DefaultPortServiceNames maps the ReservedPorts defaults to human names.
+// Used only on the fallback path, when the published ports could not be read
+// from compose; the normal path names services from the compose config itself,
+// so a project on custom ports still gets "Port 8181 (hasura)" and not
+// "unknown service".
+func DefaultPortServiceNames() map[int]string {
+	return map[int]string{
+		80:   "HTTP (Nginx)",
+		443:  "HTTPS (Nginx)",
+		5432: "PostgreSQL",
+		8080: "Hasura GraphQL",
+		4000: "Auth",
+		6379: "Redis",
+		9000: "MinIO",
+		9001: "MinIO Console",
+		7700: "MeiliSearch",
+		3021: "nSelf Admin",
+		1025: "Mailpit SMTP",
+		8025: "Mailpit UI",
+		3008: "Functions",
+		5000: "MLflow",
+	}
+}

--- a/internal/docker/port_declared_test.go
+++ b/internal/docker/port_declared_test.go
@@ -1,0 +1,140 @@
+package docker
+
+// port_declared_test.go — Guards the port pre-flight reading real config.
+//
+// Purpose: `nself start` checked a hardcoded list of default ports instead of
+//   the ports the stack publishes. A second project on one host must move off
+//   the defaults, and was then blocked by 5432/8080 held by the first project,
+//   ports it never binds. That kept the ɳTask staging stack down for days while
+//   its own ports (5433, 8181, 4001, 6380, 9010, 9011) were all free.
+// Inputs:  synthetic `docker compose config --format json` documents.
+// Outputs: assertions on parsing and on the fallback contract.
+// Constraints: pure parsing tests; no docker, no network.
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// parseDoc decodes a compose config document and runs the REAL collector, so
+// these tests exercise production code rather than a re-implementation of it.
+func parseDoc(t *testing.T, raw string) ([]int, map[int]string) {
+	t.Helper()
+	var doc composeConfigDoc
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return collectPublishedPorts(doc)
+}
+
+// TestDeclaredPorts_UsesConfiguredNotDefault is the regression. This is the
+// exact ɳTask shape: everything moved off the defaults.
+func TestDeclaredPorts_UsesConfiguredNotDefault(t *testing.T) {
+	t.Parallel()
+
+	const cfg = `{"services":{
+      "postgres":{"ports":[{"published":"5433","target":5432,"protocol":"tcp"}]},
+      "hasura":{"ports":[{"published":"8181","target":8080,"protocol":"tcp"}]},
+      "redis":{"ports":[{"published":"6380","target":6379,"protocol":"tcp"}]}}}`
+
+	got, names := parseDoc(t, cfg)
+
+	want := map[int]bool{5433: true, 8181: true, 6380: true}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected port %d", p)
+		}
+		delete(want, p)
+	}
+	for p := range want {
+		t.Errorf("missing configured port %d", p)
+	}
+
+	// The whole point: the defaults must NOT appear. If 5432 or 8080 is in the
+	// list, a co-located project holding them blocks this one again.
+	for _, def := range []int{5432, 8080, 6379} {
+		for _, p := range got {
+			if p == def {
+				t.Errorf("default port %d must not be checked — this stack publishes its own", def)
+			}
+		}
+	}
+
+	if names[8181] != "hasura" {
+		t.Errorf("port 8181 should name the service %q, got %q", "hasura", names[8181])
+	}
+}
+
+// TestDeclaredPorts_PublishedMayBeNumber covers the Compose versions that emit
+// published as a JSON number rather than a string. Getting this wrong yields an
+// empty list, which the fallback turns into the old broken behaviour silently.
+func TestDeclaredPorts_PublishedMayBeNumber(t *testing.T) {
+	t.Parallel()
+
+	got, _ := parseDoc(t, `{"services":{"pg":{"ports":[{"published":5433,"target":5432,"protocol":"tcp"}]}}}`)
+	if len(got) != 1 || got[0] != 5433 {
+		t.Errorf("numeric published not parsed: got %v, want [5433]", got)
+	}
+}
+
+// TestDeclaredPorts_SkipsNonTCP — CheckPort probes TCP. A UDP publish on the
+// same number is not a conflict, and reporting it would be a false positive
+// that pushes people toward --skip-port-check.
+func TestDeclaredPorts_SkipsNonTCP(t *testing.T) {
+	t.Parallel()
+
+	got, _ := parseDoc(t, `{"services":{"x":{"ports":[{"published":"5353","target":53,"protocol":"udp"}]}}}`)
+	if len(got) != 0 {
+		t.Errorf("UDP publish must not be checked by a TCP probe: got %v", got)
+	}
+}
+
+// TestDeclaredPorts_RangeTakesFirst — a partially conflicting range is still a
+// conflict, so a range must not be dropped.
+func TestDeclaredPorts_RangeTakesFirst(t *testing.T) {
+	t.Parallel()
+
+	got, _ := parseDoc(t, `{"services":{"x":{"ports":[{"published":"8000-8010","target":8000,"protocol":"tcp"}]}}}`)
+	if len(got) != 1 || got[0] != 8000 {
+		t.Errorf("range should yield its first port: got %v, want [8000]", got)
+	}
+}
+
+// TestDefaultPortServiceNames_CoversReservedPorts keeps the fallback path
+// useful. If a default gains no name, the operator sees "unknown service" at
+// exactly the moment the richer path already failed.
+func TestDefaultPortServiceNames_CoversReservedPorts(t *testing.T) {
+	t.Parallel()
+
+	names := DefaultPortServiceNames()
+	for _, p := range ReservedPorts {
+		if names[p] == "" {
+			t.Errorf("reserved port %d has no service name in the fallback map", p)
+		}
+	}
+}
+
+// TestReservedPortsStillPopulated is the negative control on the fallback
+// contract. DeclaredHostPorts returning an empty list must mean "could not
+// determine" and fall back — never "check nothing". If ReservedPorts were ever
+// emptied, the fallback would silently become a port check that cannot fail,
+// which is the bug class this whole change belongs to.
+func TestReservedPortsStillPopulated(t *testing.T) {
+	t.Parallel()
+
+	if len(ReservedPorts) == 0 {
+		t.Fatal("ReservedPorts is empty — the fallback would check nothing and always pass")
+	}
+	for _, p := range []int{80, 443, 5432, 8080} {
+		found := false
+		for _, r := range ReservedPorts {
+			if r == p {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("default port %d dropped from the fallback list", p)
+		}
+	}
+}


### PR DESCRIPTION
Found by debugging a live outage, not by reading code.

## What happened

The ɳTask staging stack had been down for days. Public healthz returned **500**; Hasura had been unhealthy for three days logging `could not translate host name "postgres" to address`, because **there was no postgres container at all**.

`nself start` was refusing to start it:

```
✗ Port 5432 (PostgreSQL): held by docker-proxy (pid 3606) [nSelf container]
✗ Port 8080 (Hasura GraphQL): held by docker-proxy (pid 2829) [nSelf container]
✗ Port 4000 (Auth) ... 6379 (Redis) ... 9000/9001 (MinIO) ... 7700 (MeiliSearch)
Error: port conflicts detected: 9 port(s) in use
```

**ɳTask does not use any of those ports.** Its `.env` already had:

| Setting | Value |
|---|---|
| `POSTGRES_PORT` | 5433 |
| `HASURA_PORT` | 8181 |
| `AUTH_PORT` | 4001 |
| `REDIS_PORT` | 6380 |
| `MINIO_PORT` / `MINIO_CONSOLE_PORT` | 9010 / 9011 |

and the generated compose published exactly those. Every one was free. The ports it complained about are held by the co-located `nself-web` project, which is correct and expected — two projects, one host.

## The bug

`cmd/commands/start.go` called:

```go
docker.CheckAllPortsFiltered(ctx, docker.ReservedPorts, projectDir, composeFiles...)
```

`ReservedPorts` is a hardcoded default list. The compose files were passed in, but only to work out which ports our *already running* containers hold (the restart exemption). Nothing ever asked what ports this project is configured to bind.

So any project moved off the defaults is blocked by the defaults, as soon as anything else on the host holds them.

## Knock-on effect worth noting

The workaround that grew around this was a hand-maintained `docker-compose.staging-live.yml` on the box — a side-channel compose file the nSelf-First doctrine forbids — which existed essentially to say `5433`. Fixing the check removes the reason that file exists.

## The fix

`DeclaredHostPorts` reads the resolved `docker compose config --format json` and returns the host ports the stack actually publishes, plus a port to service map so a custom port reports `Port 8181 (hasura)` rather than `unknown service`.

**The failure mode matters as much as the fix.** If the config cannot be read, or yields no ports, it falls back to the default list and warns. Checking an empty list would turn this into a port check that cannot fail — the exact bug class this repo has been clearing out. `TestReservedPortsStillPopulated` pins that contract.

Two smaller correctness points, both covered: `published` is a string in most Compose versions and a number in others; and a UDP publish is not a conflict for a TCP probe.

## Verification

Live, on the staging box, after bypassing the buggy check with ports proven free:

```
✓ Database initialized (schemas, extensions, grants)
ntask_postgres   Up (healthy)     <- did not exist before
ntask_hasura     Up (healthy)     <- unhealthy for 3 days
ntask_redis / minio / auth / functions  Up (healthy)

https://api.task.staging.nself.org/healthz   HTTP 200
https://task.staging.nself.org               HTTP 200
```

## Negative control

The collection loop is a separate function so tests call it rather than re-implementing it — a test that reproduces the logic it checks passes against broken code.

| Mutation | Result |
|---|---|
| remove the UDP skip | `TestDeclaredPorts_SkipsNonTCP` **FAILS** |
| remove numeric `published` parsing | `TestDeclaredPorts_PublishedMayBeNumber` **FAILS** |
| restore both | all 6 **PASS** |

`go build ./...`, `go vet`, `gofmt` clean; full `internal/docker` package green.