### PR TITLE
fix(e2e): make the golden-path work dir traversable by containers

### DIFF
--- a/scripts/golden-path.sh
+++ b/scripts/golden-path.sh
@@ -358,6 +358,20 @@ else
   WORK_DIR="$(mktemp -d /tmp/nself-golden-path-XXXXXX)"
 fi
 
+# mktemp -d creates 0700. The stack bind-mounts paths from under this directory
+# into containers that run as their own uid, and nginx is not the uid that owns
+# it, so it cannot traverse in:
+#
+#   nginx: [emerg] cannot load certificate
+#   "/etc/nginx/ssl/certificates/local-nself-org/fullchain.pem":
+#   BIO_new_file() failed (... Permission denied ...)
+#
+# The certificate itself is already 0644 in a 0755 directory; only the temp
+# parent was unreachable, so nginx crash-looped and the run died at step 6.
+# 0755 on the work dir is safe here: it holds a throwaway test project, and
+# nself still writes .env at 0600 and privkey.pem at 0640 inside it.
+chmod 755 "${WORK_DIR}"
+
 run_step 2 "mkdir testproject && cd" \
   bash -c "mkdir -p ${WORK_DIR}/testproject"
 [ "${STEP_STATUS[2]}" = "fail" ] && { write_report; exit 1; }


### PR DESCRIPTION
Unblocks **E2E Golden Path**, which has never completed.

## Not the license key

The standing note said step 8 (`nself license set`) was the blocker and needed a human to fix the `NSELF_PLUGIN_LICENSE_KEY_OWNER` secret. That secret has now been corrected from the vault, and the run moved on — to **step 6**, which is a different, older problem:

```
nginx: [emerg] cannot load certificate
"/etc/nginx/ssl/certificates/local-nself-org/fullchain.pem":
BIO_new_file() failed (SSL: ... Permission denied ...)
```

nginx crash-looped, health never came up, the run died.

## Not a certificate problem either

`fullchain.pem` is already written `0644` (deliberately — it is the public chain) into a `0755` directory. Both are fine.

The unreachable part is the **temp parent**. `mktemp -d` creates `0700` owned by the runner; the stack bind-mounts paths from under it into containers running as their own uid, and nginx cannot traverse in.

The run's own diagnostics printed it, and it had been read past:

```
--- work dir ---
drwx------  3 runner runner 4096 Aug 27 15:17 .
drwxr-xr-x  8 runner runner 4096 Aug 27 15:17 testproject
```

The inner `testproject` is 0755. Only the wrapper was 0700.

## Why 0755 is safe here

The work dir holds a throwaway test project. nself still writes `.env` at 0600 and `privkey.pem` at 0640 inside it, so nothing that is actually secret becomes readable. Only the traversal bit changes.