### PR TITLE
fix(db): treat "database already exists" on create as success

### DIFF
--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -115,6 +115,31 @@ func createDatabase(ctx context.Context, cfg *config.Config) error {
 	}
 	createSQL := fmt.Sprintf("CREATE DATABASE %s", quotedDB)
 	if err := runSQLOnDB(ctx, cfg, "postgres", createSQL); err != nil {
+		// "already exists" here is success, not failure.
+		//
+		// The existence check above and this CREATE can see two different
+		// servers. The postgres image runs a TEMPORARY server to execute its
+		// entrypoint scripts, then shuts it down and starts the real one. The
+		// check can land on the temporary server, where the database genuinely
+		// does not exist yet, while POSTGRES_DB has already created it on the
+		// real server by the time CREATE runs:
+		//
+		//   Error: database init: create database testproject:
+		//   psql exec failed: ERROR: database "testproject" already exists
+		//
+		// That killed `nself start` at step 5 of the golden path on a clean
+		// first run. The comment above already records this window biting the
+		// check; the check was wrapped in retryTransientPG and this call was
+		// not.
+		//
+		// Retrying cannot help — the database exists and will keep existing.
+		// The function's contract is "create it if it does not already exist",
+		// so the only correct response to finding it already there is to carry
+		// on. Any other error still fails.
+		if isDatabaseAlreadyExists(err) {
+			slog.Info("database already exists (created concurrently by the postgres image)", "database", db)
+			return nil
+		}
 		return fmt.Errorf("create database %s: %w", db, err)
 	}
 
@@ -228,4 +253,23 @@ func InitializeDatabase(ctx context.Context, cfg *config.Config) error {
 
 	slog.Info("database initialization complete")
 	return nil
+}
+
+// isDatabaseAlreadyExists reports whether err is Postgres telling us the
+// database is already there.
+//
+// Matched on message text rather than SQLSTATE because the command runs via
+// `docker exec ... psql`, which surfaces the server error as stderr text and an
+// exit status; there is no structured error to read a 42P04 out of. The message
+// is stable across every supported Postgres major.
+//
+// Deliberately narrow: it must not swallow "permission denied to create
+// database" or a connection failure, which are real and must still fail.
+func isDatabaseAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already exists") &&
+		strings.Contains(msg, "database")
 }

--- a/internal/database/init_exists_test.go
+++ b/internal/database/init_exists_test.go
@@ -1,0 +1,82 @@
+package database
+
+// init_exists_test.go — Guards CREATE DATABASE being genuinely idempotent.
+//
+// Purpose: createDatabase checks for the database, then creates it. Those two
+//   steps can see two different servers: the postgres image runs a TEMPORARY
+//   server for its entrypoint scripts, then replaces it with the real one. The
+//   check lands on the temporary server (absent), POSTGRES_DB has already
+//   created it on the real server, and CREATE fails:
+//
+//     ERROR: database "testproject" already exists
+//
+//   That killed `nself start` at step 5 of the golden path on a clean run.
+// Inputs:  errors as they surface from `docker exec ... psql`.
+// Outputs: assertions on isDatabaseAlreadyExists.
+// Constraints: pure predicate tests; no docker, no postgres, no network.
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestIsDatabaseAlreadyExists_RealMessage uses the exact text from the failing
+// run rather than a paraphrase, wrapped the way the call site wraps it.
+func TestIsDatabaseAlreadyExists_RealMessage(t *testing.T) {
+	t.Parallel()
+
+	inner := errors.New(`psql exec failed: ERROR:  database "testproject" already exists: exit status 1`)
+	if !isDatabaseAlreadyExists(inner) {
+		t.Error("the real postgres message must be recognised — this is the exact string that broke the golden path")
+	}
+
+	// The call site wraps before this predicate sees it in some paths.
+	if !isDatabaseAlreadyExists(fmt.Errorf("create database testproject: %w", inner)) {
+		t.Error("must still match through a wrap")
+	}
+}
+
+// TestIsDatabaseAlreadyExists_DoesNotSwallowRealFailures is the important half.
+// A predicate that is too broad turns this fix into a database-init step that
+// cannot fail, which is worse than the bug.
+func TestIsDatabaseAlreadyExists_DoesNotSwallowRealFailures(t *testing.T) {
+	t.Parallel()
+
+	mustNotMatch := []string{
+		`ERROR:  permission denied to create database`,
+		`psql: error: connection to server failed: Connection refused`,
+		`FATAL:  password authentication failed for user "postgres"`,
+		`ERROR:  role "postgres" does not exist`,
+		`FATAL:  the database system is starting up`,
+		`ERROR:  relation "users" already exists`, // a TABLE, not a database
+		`ERROR:  schema "auth" already exists`,    // a SCHEMA, not a database
+		`Error: no such container: myproj_postgres`,
+	}
+	for _, m := range mustNotMatch {
+		m := m
+		t.Run(m[:min(len(m), 42)], func(t *testing.T) {
+			t.Parallel()
+			if isDatabaseAlreadyExists(errors.New(m)) {
+				t.Errorf("must NOT be treated as success: %q", m)
+			}
+		})
+	}
+}
+
+// TestIsDatabaseAlreadyExists_NilIsNotSuccess — nil means CREATE succeeded and
+// is handled on the happy path; the predicate must not claim it.
+func TestIsDatabaseAlreadyExists_NilIsNotSuccess(t *testing.T) {
+	t.Parallel()
+
+	if isDatabaseAlreadyExists(nil) {
+		t.Error("nil error must not be reported as already-exists")
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
Third and last blocker on **E2E Golden Path**, which has never completed. With #294 (work-dir traversal) merged, the run got past nginx and died one step earlier instead:

```
Error: database init: create database testproject:
psql exec failed: ERROR:  database "testproject" already exists
```

Step 5 of 13. Steps 1-4 pass.

## Why this looks impossible

`createDatabase` already checks whether the database exists before creating it. So a duplicate error should not be reachable.

It is, because **the check and the create can talk to two different servers.** The postgres image starts a *temporary* server to run its entrypoint scripts, shuts it down, then starts the real one. The check lands on the temporary server, where the database genuinely does not exist. By the time CREATE runs, `POSTGRES_DB` has already created it on the real server.

The code already knew about this window. The comment above the check says exactly that, and the check was wrapped in `retryTransientPG` because of it. **The CREATE was not.**

## Why not just retry

Retrying cannot help. The database exists and will keep existing, so every attempt fails identically. The function contract is "create it if it does not already exist" — finding it already there *is* the success case.

## Not swallowing real failures

This is the part worth reviewing. A predicate that is too broad converts database init into a step that cannot fail, which is worse than the bug.

`isDatabaseAlreadyExists` requires **both** `already exists` **and** `database`. Pinned as must-not-match:

| Message | Why it must still fail |
|---|---|
| `permission denied to create database` | real permissions problem |
| `connection to server failed: Connection refused` | postgres not reachable |
| `password authentication failed` | bad credentials |
| `role "postgres" does not exist` | misconfigured user |
| `the database system is starting up` | genuinely transient, belongs to retry |
| `relation "users" already exists` | a **table**, not a database |
| `schema "auth" already exists` | a **schema**, not a database |
| `no such container: myproj_postgres` | stack not up |

Matched on text rather than SQLSTATE 42P04 because the command runs through `docker exec ... psql`, which gives stderr text and an exit status, not a structured error.

## Negative control

| Mutation | Result |
|---|---|
| broaden predicate to just `already exists` | `TestIsDatabaseAlreadyExists_DoesNotSwallowRealFailures` **FAILS** |
| restore | all 3 **PASS** |

Full `internal/database` package green. The real message from the failing run is used verbatim in the test, not a paraphrase.