### PR TITLE
fix(license): an all-access tier entitles every plugin

### DIFF
--- a/internal/license/checker.go
+++ b/internal/license/checker.go
@@ -107,8 +107,9 @@ func bundleEntitledFromCache(key, bundleName string) (bool, error) {
 	}
 
 	tier := strings.ToLower(entry.Tier)
-	// ɳSelf+ / owner / enterprise covers all bundles.
-	if tier == "plus" || tier == "enterprise" || tier == "owner" {
+	// ɳSelf+ / owner / enterprise cover all bundles. Delegated to IsAllAccessTier
+	// so this rule has one definition; the plugin installer needs the same one.
+	if IsAllAccessTier(tier) {
 		return true, nil
 	}
 

--- a/internal/license/tier.go
+++ b/internal/license/tier.go
@@ -1,0 +1,38 @@
+package license
+
+// Purpose: the single definition of which license tiers grant every plugin.
+// Inputs:  a tier string as reported by the license server or the local cache.
+// Outputs: whether that tier entitles all bundles/plugins.
+// Constraints: pure function, no I/O. Must stay the ONLY place this rule is
+//   written — it existed twice before, and the copy the plugin installer used
+//   did not have it at all.
+// SPORT: CLI-LICENSE-TIER-001
+
+import "strings"
+
+// allAccessTiers are the tiers that include every bundle and every plugin.
+//
+// ɳSelf+ ("plus") is the all-bundles subscription. "owner" is the internal
+// all-access key. "enterprise" is the top commercial tier. Everything else is
+// a single-bundle or lower tier and must be entitled per plugin.
+var allAccessTiers = map[string]bool{
+	"plus":       true,
+	"owner":      true,
+	"enterprise": true,
+}
+
+// IsAllAccessTier reports whether tier includes every plugin.
+//
+// This rule lived inline in exactly one place (bundleEntitledFromCache) while
+// the plugin installer enforced entitlements from an explicit plugin list only.
+// A valid ɳSelf+ licence whose server response carried an empty plugin list was
+// therefore refused with "license tier does not include this plugin", because
+// nothing on that path ever looked at the tier. Keeping the rule in one
+// exported function is what stops the two paths disagreeing again.
+//
+// Deliberately a closed allowlist, not a "not free" test: an unknown tier
+// returns false, so a new tier has to be added here on purpose rather than
+// silently inheriting all-access.
+func IsAllAccessTier(tier string) bool {
+	return allAccessTiers[strings.ToLower(strings.TrimSpace(tier))]
+}

--- a/internal/license/tier_test.go
+++ b/internal/license/tier_test.go
@@ -1,0 +1,81 @@
+package license
+
+// tier_test.go — Guards the all-access tier rule.
+//
+// Purpose: this rule decides whether a licence grants every paid plugin, so it
+//   is a revenue boundary in both directions. Too narrow and a paying ɳSelf+
+//   customer is refused (which is what happened: the plugin installer never
+//   consulted the tier at all, so a valid "plus" licence with an empty plugin
+//   list was rejected as "license tier does not include this plugin"). Too
+//   broad and every paid plugin is free.
+// Inputs:  tier strings as they arrive from the licence server or local cache.
+// Outputs: assertions on IsAllAccessTier.
+// Constraints: pure; no network, no cache, no filesystem.
+
+import "testing"
+
+// TestIsAllAccessTier_GrantsTheThreeAllAccessTiers pins what must be allowed.
+// Removing any of these silently paywalls a customer who has paid for it.
+func TestIsAllAccessTier_GrantsTheThreeAllAccessTiers(t *testing.T) {
+	t.Parallel()
+
+	for _, tier := range []string{"plus", "owner", "enterprise"} {
+		if !IsAllAccessTier(tier) {
+			t.Errorf("%q must be all-access — it is a paid all-bundles tier", tier)
+		}
+	}
+
+	// Case and whitespace vary by source (server JSON vs cache file).
+	for _, tier := range []string{"Plus", "PLUS", "  plus  ", "Owner", "ENTERPRISE"} {
+		if !IsAllAccessTier(tier) {
+			t.Errorf("%q must normalise to all-access", tier)
+		}
+	}
+}
+
+// TestIsAllAccessTier_DeniesEverythingElse is the revenue-protecting half, and
+// the more important one. A bundle tier must NOT inherit all-access — its
+// entitlements come from the plugin list, per bundle.
+func TestIsAllAccessTier_DeniesEverythingElse(t *testing.T) {
+	t.Parallel()
+
+	// Every non-all-access product in validProductPrefixes, plus the obvious
+	// absent/garbage cases.
+	deny := []string{
+		"claw", "clawde", "chat", "media", "family", // single-bundle tiers
+		"pro", "max", // paid but NOT all-bundles
+		"free", "trial", "expired", "revoked",
+		"", "   ", "unknown", "null", "true", "all", "*",
+	}
+	for _, tier := range deny {
+		tier := tier
+		t.Run("deny/"+tier, func(t *testing.T) {
+			t.Parallel()
+			if IsAllAccessTier(tier) {
+				t.Errorf("%q must NOT be all-access — that would give away every paid plugin", tier)
+			}
+		})
+	}
+}
+
+// TestIsAllAccessTier_IsAClosedAllowlist pins the shape of the rule, not just
+// its current answers. Written as "not free" or "anything paid", a new tier
+// added later would inherit all-access silently. It must be an explicit list so
+// adding a tier is a deliberate act.
+func TestIsAllAccessTier_IsAClosedAllowlist(t *testing.T) {
+	t.Parallel()
+
+	if len(allAccessTiers) != 3 {
+		t.Errorf("all-access set has %d entries, expected exactly plus/owner/enterprise — "+
+			"adding one grants every paid plugin to that tier", len(allAccessTiers))
+	}
+	for _, want := range []string{"plus", "owner", "enterprise"} {
+		if !allAccessTiers[want] {
+			t.Errorf("%q missing from the all-access set", want)
+		}
+	}
+	// A tier nobody has defined must not be all-access by default.
+	if IsAllAccessTier("bundle-that-does-not-exist-yet") {
+		t.Error("unknown tiers must default to NOT all-access")
+	}
+}

--- a/internal/plugin/security_license.go
+++ b/internal/plugin/security_license.go
@@ -90,6 +90,28 @@ func checkLicense(ctx context.Context, name string) error {
 			}
 		}
 
+		// An all-access tier entitles every plugin, whether or not the server
+		// bothered to enumerate them.
+		//
+		// Without this, a valid ɳSelf+ licence was refused outright. The server
+		// returns tier "plus" with an EMPTY plugins list — all-access has
+		// nothing to enumerate — and the only grant above is membership of that
+		// list, so the empty list fell through to ErrLicenseTierTooLow:
+		//
+		//   error installing "ai": plugin "ai": license tier does not include
+		//   this plugin
+		//
+		// which is precisely backwards for the tier that includes everything.
+		// That is step 9 of the golden path, and it had never run before today.
+		//
+		// This does not widen anything for a bundle tier: "chat" is not
+		// all-access, so a ɳChat licence still only grants what its plugins
+		// list names.
+		if lvr != nil && license.IsAllAccessTier(lvr.Tier) {
+			_ = cacheEntitlements(cacheDir, lvr.Tier, lvr.Plugins)
+			return nil
+		}
+
 		if valid {
 			lastErr = fmt.Errorf("plugin %q: %w", name, errs.ErrLicenseTierTooLow)
 			continue


### PR DESCRIPTION
Step 9 of the golden path — `nself plugin install ai` — **executed for the first time ever today** (after #294/#295 unblocked steps 5-8) and immediately refused a valid ɳSelf+ licence:

```
error installing "ai": plugin "ai": license tier does not include this plugin
```

For the tier that includes everything.

## Cause: one rule, two implementations, and the wrong one was guarding installs

`internal/license/checker.go` had it right, inline in `bundleEntitledFromCache`:

```go
// ɳSelf+ / owner / enterprise covers all bundles.
if tier == "plus" || tier == "enterprise" || tier == "owner" { return true, nil }
```

`internal/plugin/security_license.go` — the code that actually gates installs — **never looked at a tier at all.** Its only grant was membership of `lvr.Plugins`:

```go
if lvr != nil && len(lvr.Plugins) > 0 {
    for _, p := range lvr.Plugins { if p == name { return nil } }
}
if valid {
    lastErr = ErrLicenseTierTooLow   // <- an all-access licence lands here
}
```

All-access has nothing to enumerate, so the server returns tier `plus` with an **empty** plugins list. Empty list, no match, straight to `ErrLicenseTierTooLow`.

Confirmed against the live server:

```
│ nself_pro_…b8ec │ plus │ Active │ - │ - │
                    tier   status  exp  plugins  <- empty
```

## The fix

The rule becomes one exported function, `license.IsAllAccessTier`, and both paths call it. `checker.go` now delegates instead of holding its own copy — the duplication is what let these drift.

## This does not widen entitlements

Worth reviewing carefully, since it is a revenue boundary.

- A **bundle** tier is unchanged. `chat` is not all-access, so a ɳChat licence still grants only what its plugins list names.
- The allowlist is **closed**, not a "not free" test. An unknown or future tier defaults to NOT all-access and has to be added on purpose.
- `pro` and `max` are deliberately **not** all-access, matching the existing rule.

## Verified with the real key

Two fresh `HOME`s, cold caches, same key:

| Binary | Result |
|---|---|
| `main` | `plugin "ai": license tier does not include this plugin` |
| this branch | passes the licence gate, reaches checksum verification |

## Negative controls, both directions

| Mutation | Result |
|---|---|
| broaden to "anything not free" | `DeniesEverythingElse` + `IsAClosedAllowlist` **FAIL** |
| drop `plus` (paywall a paying customer) | `GrantsTheThreeAllAccessTiers` + `IsAClosedAllowlist` **FAIL** |
| restore | all **PASS** |

Both directions matter here: too narrow refuses someone who paid, too broad gives away every paid plugin.

## What is next after this

Step 9 now fails further along, on a genuine **checksum mismatch** in the `ai` plugin artifact — the registry hash does not match what is served. Unrelated to licensing, filed separately.