### PR TITLE
ci: retry pinned Go tool installs instead of dying on a sumdb blip

### DIFF
--- a/.github/scripts/go-install-retry.sh
+++ b/.github/scripts/go-install-retry.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# go-install-retry.sh — install a pinned Go tool, retrying transient failures.
+#
+# Purpose: `go install <tool>@<version>` in CI depends on proxy.golang.org and
+#   sum.golang.org being reachable. Both are outside our control and both fail
+#   intermittently. On 2026-08-27 four separate jobs died on the same thing:
+#
+#     go: github.com/google/go-licenses@v1.6.0: version constraints conflict:
+#       ... verifying go.mod: reading https://sum.golang.org/tile/8/0/x002/691:
+#       stream error: stream ID 483; INTERNAL_ERROR; received from peer
+#
+#   Different tiles, different modules, different jobs — the tool never changed.
+#   One of those took 8 minutes to fail, so a red gate cost 8 minutes and told
+#   nobody anything true.
+#
+# Inputs:  $1 = module@version (must be pinned; see below). $2 = attempts (default 3).
+# Outputs: the tool on $GOBIN/$GOPATH/bin, or a non-zero exit after N attempts.
+# Constraints: checksum verification stays ON. This retries the download; it does
+#   NOT set GOFLAGS=-mod=mod, GONOSUMDB, GONOSUMCHECK or GOPRIVATE, because
+#   skipping verification to dodge a flaky verifier is how a supply-chain gate
+#   becomes decorative. A genuine checksum mismatch still fails on attempt 1 and
+#   on every retry.
+set -euo pipefail
+
+TOOL="${1:?usage: go-install-retry.sh <module@version> [attempts]}"
+ATTEMPTS="${2:-3}"
+
+# Refuse @latest and unpinned specs: retrying an unpinned install can silently
+# install a different version on attempt 2 than attempt 1 resolved.
+case "$TOOL" in
+  *@latest|*@master|*@main) echo "refusing to install unpinned tool: $TOOL" >&2; exit 2 ;;
+  *@*) : ;;
+  *) echo "tool must be pinned as module@version, got: $TOOL" >&2; exit 2 ;;
+esac
+
+for i in $(seq 1 "$ATTEMPTS"); do
+  if go install "$TOOL"; then
+    [ "$i" -gt 1 ] && echo "::notice::installed $TOOL on attempt $i"
+    exit 0
+  fi
+  if [ "$i" -lt "$ATTEMPTS" ]; then
+    delay=$(( i * 15 ))
+    echo "::warning::go install $TOOL failed (attempt $i/$ATTEMPTS); retrying in ${delay}s"
+    sleep "$delay"
+  fi
+done
+
+echo "::error::go install $TOOL failed after $ATTEMPTS attempts." >&2
+echo "If the error mentions sum.golang.org or proxy.golang.org, it is upstream." >&2
+echo "Checksum verification was NOT disabled — a real mismatch must not be retried away." >&2
+exit 1

--- a/.github/workflows/deep-qa-block.yml
+++ b/.github/workflows/deep-qa-block.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+          bash .github/scripts/go-install-retry.sh golang.org/x/vuln/cmd/govulncheck@v1.7.0
           bash .github/scripts/govuln-gate.sh
 
       - name: Generate report stub

--- a/.github/workflows/govuln.yml
+++ b/.github/workflows/govuln.yml
@@ -26,7 +26,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+        run: bash .github/scripts/go-install-retry.sh golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: Run govulncheck (allowlist gate)
         env:

--- a/.github/workflows/govulncheck-nightly.yml
+++ b/.github/workflows/govulncheck-nightly.yml
@@ -38,7 +38,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+        run: bash .github/scripts/go-install-retry.sh golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: Run govulncheck (JSON)
         id: scan

--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -31,7 +31,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@v1.6.0
+        run: bash .github/scripts/go-install-retry.sh github.com/google/go-licenses@v1.6.0
 
       - name: Check for disallowed licenses
         env:

--- a/.github/workflows/license-gate-unit-test.yml
+++ b/.github/workflows/license-gate-unit-test.yml
@@ -36,7 +36,7 @@ jobs:
           cache: false  # temp workspace — no go.sum to cache
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@v1.6.0
+        run: bash .github/scripts/go-install-retry.sh github.com/google/go-licenses@v1.6.0
 
       - name: Build synthetic AGPL test workspace
         id: scaffold

--- a/.github/workflows/license-gate.yml
+++ b/.github/workflows/license-gate.yml
@@ -32,7 +32,7 @@ jobs:
           cache: true
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@v1.6.0
+        run: bash .github/scripts/go-install-retry.sh github.com/google/go-licenses@v1.6.0
 
       - name: Check Go dependency licenses (AGPL/SSPL block)
         env:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+        run: bash .github/scripts/go-install-retry.sh golang.org/x/vuln/cmd/govulncheck@v1.7.0
       - name: Run govulncheck
         env:
           GOFLAGS: -mod=vendor


### PR DESCRIPTION
Four jobs failed today on the same upstream problem, none related to the change under test:

```
go: github.com/google/go-licenses@v1.6.0: version constraints conflict:
  ... verifying go.mod: reading https://sum.golang.org/tile/8/0/x002/691:
  stream error: stream ID 483; INTERNAL_ERROR; received from peer
```

Different tiles, different modules, different workflows. **License Gate went red on `main` this way after passing on the PR branch twenty minutes earlier** — and took 8 minutes to fail.

`go install <tool>@<version>` reaches proxy.golang.org and sum.golang.org on every run. Both are outside our control and both are intermittently unreliable right now. A gate that reports failure because a CDN tile hiccuped is reporting nothing about the code, and it trains people to re-run red checks without reading them — which is how a real failure gets waved through.

## Change

Seven pinned installs (`go-licenses` ×3, `govulncheck` ×4) now go through `.github/scripts/go-install-retry.sh`: 3 attempts, 15s then 30s backoff.

## What this deliberately does NOT do

**Checksum verification stays on.** No `GOFLAGS=-mod=mod`, no `GONOSUMDB`, no `GONOSUMCHECK`, no `GOPRIVATE`.

Turning off verification to dodge a flaky verifier is the obvious "fix" and it is the wrong one — it converts a supply-chain gate into decoration. A genuine checksum mismatch still fails on attempt 1 and on every retry.

**It refuses `@latest`, `@master`, `@main`.** Retrying an unpinned install can resolve a *different version* on attempt 2 than attempt 1, making the retry itself a source of drift. Repo policy already pins these (#285); this enforces it where it is used.

## Verification

Stubbed `go` binary:

| Scenario | Result |
|---|---|
| fails twice, then succeeds | installs on attempt 3, emits `::notice::` |
| fails permanently | still exits non-zero after N attempts |
| `example.com/x@latest` | refused, exit 2 |
| `example.com/x` (no version) | refused, exit 2 |

All 7 workflow files re-validated as YAML.