### PR TITLE
fix(ci): pnpm never received the npm token, so both SDKs stopped publishing

### DIFF
--- a/.github/workflows/sdk-ts-publish.yml
+++ b/.github/workflows/sdk-ts-publish.yml
@@ -103,6 +103,31 @@ jobs:
           cd sdk/ts
           pnpm build
 
+      # pnpm does not expand ${VAR} inside .npmrc, but actions/setup-node writes
+      # exactly that: //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}.
+      # pnpm therefore sends the literal string as the token, publishes
+      # unauthenticated, and npm masks the auth failure as a 404:
+      #
+      #   WARN Issue while reading ".npmrc". Failed to replace env in config:
+      #        ${NODE_AUTH_TOKEN}
+      #   npm error 404
+      #
+      # A 404 on a package that already exists (@nself/sdk was on 1.3.3) is npm
+      # declining to confirm the package exists to an unauthenticated caller.
+      # Writing the resolved token avoids the expansion entirely.
+      - name: Authenticate pnpm to npm
+        if: steps.preflight.outputs.proceed == 'true'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "NPM_TOKEN not set — publish would be unauthenticated; failing loudly instead of 404ing."
+            exit 1
+          fi
+          printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" >> "$HOME/.npmrc"
+          echo "wrote resolved auth token to ~/.npmrc"
+
       - name: Publish to npm (with provenance, skip-existing, retry up to 3x)
         if: steps.preflight.outputs.proceed == 'true'
         env:

--- a/.github/workflows/sdk-ts-sdk-publish.yml
+++ b/.github/workflows/sdk-ts-sdk-publish.yml
@@ -85,6 +85,31 @@ jobs:
         working-directory: sdk/ts-sdk
         run: pnpm build
 
+      # pnpm does not expand ${VAR} inside .npmrc, but actions/setup-node writes
+      # exactly that: //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}.
+      # pnpm therefore sends the literal string as the token, publishes
+      # unauthenticated, and npm masks the auth failure as a 404:
+      #
+      #   WARN Issue while reading ".npmrc". Failed to replace env in config:
+      #        ${NODE_AUTH_TOKEN}
+      #   npm error 404
+      #
+      # A 404 on a package that already exists (@nself/sdk was on 1.3.3) is npm
+      # declining to confirm the package exists to an unauthenticated caller.
+      # Writing the resolved token avoids the expansion entirely.
+      - name: Authenticate pnpm to npm
+        if: steps.check.outputs.proceed == 'true'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "NPM_TOKEN not set — publish would be unauthenticated; failing loudly instead of 404ing."
+            exit 1
+          fi
+          printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" >> "$HOME/.npmrc"
+          echo "wrote resolved auth token to ~/.npmrc"
+
       - name: Publish to npm
         if: steps.check.outputs.proceed == 'true'
         working-directory: sdk/ts-sdk


### PR DESCRIPTION
`@nself/sdk` and `@nself/plugin-sdk` are **both still on 1.3.3** on npm. Their publish jobs failed during the v1.3.4 release.

```
$ npm view @nself/sdk version         -> 1.3.3
$ npm view @nself/plugin-sdk version  -> 1.3.3
```

## The error names the wrong problem

The job ends with a bare:

```
npm error 404
```

A 404 publishing a package that **already exists** is npm declining to confirm existence to an *unauthenticated* caller. The real cause is two lines earlier:

```
WARN Issue while reading ".npmrc".
     Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

`actions/setup-node` writes:

```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

and relies on **npm** expanding `${VAR}` at read time. **pnpm does not do that expansion.** It sent the literal string `${NODE_AUTH_TOKEN}` as the token and published unauthenticated.

Setting `NODE_AUTH_TOKEN` on the step — which both workflows already did — cannot help. The problem is the placeholder sitting in the file, not a missing variable.

## Fix

Both workflows write the **resolved** token to `~/.npmrc` before publishing, and **fail loudly** when `NPM_TOKEN` is absent rather than proceeding unauthenticated toward a 404 that misidentifies the cause.

## Why this was easy to misread

The existing retry made it worse: three attempts, 30s apart, all unauthenticated, all 404 — so the log ends with a retry-exhausted message that reads like a flaky registry rather than an auth problem.

Verified step ordering in both files: the auth step runs before `pnpm publish`, under the same `proceed` condition.

Once merged, `workflow_dispatch` on both workflows will publish the 1.3.4 SDKs.
