### PR TITLE
fix(doctor): CI-VAULT-SYNC-01 could never pass on a CI runner

### DIFF
--- a/internal/doctor/check_ci_vault_sync.go
+++ b/internal/doctor/check_ci_vault_sync.go
@@ -32,6 +32,19 @@ var ciVaultInfraTokens = []string{
 	"POSTMARK_SERVER_API_TOKEN",
 }
 
+// isCIEnvironment reports whether we are running on a CI runner. It mirrors the
+// detection used by cmd/commands/browser.go so the two cannot drift.
+func isCIEnvironment() bool {
+	return os.Getenv("CI") == "true" || os.Getenv("GITHUB_ACTIONS") == "true"
+}
+
+// fileExists reports whether path exists and is a regular file. A directory at
+// the vault path is treated as absent: it cannot be parsed for keys either way.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
 // vaultEnvPath returns the canonical path to vault.env on the current machine.
 // The file lives at ~/.claude/vault.env per GCI Global Credentials Vault.
 func vaultEnvPath() string {
@@ -58,6 +71,27 @@ func CheckCIVaultSync(projectDir string) CheckResult {
 	section := "security"
 
 	vault := vaultEnvPath()
+
+	// vault.env is a developer-workstation artifact (~/.claude/vault.env). A CI
+	// runner has no such file by design: workflows receive these PATs as
+	// per-workflow GitHub Actions secrets, which are not in the ambient
+	// environment of an unrelated job. Running the check there reported CRITICAL
+	// on every single run — a gate that could never pass, which is worse than no
+	// gate because it trains people to ignore a security failure.
+	//
+	// Deliberately narrow: only skip when the vault file is genuinely absent. A
+	// self-hosted runner that does have one is still checked, so this cannot
+	// become a gate that never fails.
+	if isCIEnvironment() && !fileExists(vault) {
+		return CheckResult{
+			Section: section,
+			Name:    name,
+			Status:  "skip",
+			Message: "CI-VAULT-SYNC-01: skipped — no vault.env on this machine and CI detected. " +
+				"Vault sync is a developer-workstation concern; CI receives these PATs as " +
+				"GitHub Actions secrets. Run `nself doctor --deep` locally to verify vault coverage.",
+		}
+	}
 
 	// Collect missing critical PATs.
 	var missingPATs []string

--- a/internal/doctor/check_ci_vault_sync_test.go
+++ b/internal/doctor/check_ci_vault_sync_test.go
@@ -1,0 +1,43 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// CI-VAULT-SYNC-01 reads ~/.claude/vault.env, which cannot exist on a CI runner,
+// so it returned CRITICAL on every single run — a gate that could never pass.
+func TestCIVaultSync_SkipsOnCIWithoutVault(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("CI", "true")
+
+	got := CheckCIVaultSync(dir)
+	if got.Status != "skip" {
+		t.Fatalf("status = %q, want \"skip\" (a CI runner has no vault.env by design)", got.Status)
+	}
+}
+
+// Guards the other direction so this cannot become a gate that never fails:
+// when a vault file is present the check still runs, even on CI.
+func TestCIVaultSync_StillChecksWhenVaultPresent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	t.Setenv("GITHUB_ACTIONS", "true")
+
+	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Vault exists but contains none of the critical PATs.
+	vault := filepath.Join(dir, ".claude", "vault.env")
+	if err := os.WriteFile(vault, []byte("UNRELATED=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := CheckCIVaultSync(dir); got.Status != "fail" {
+		t.Fatalf("status = %q, want \"fail\" — a present-but-empty vault must still fail", got.Status)
+	}
+}


### PR DESCRIPTION
`CI-VAULT-SYNC-01` reads the developer vault file under the home directory — a workstation artifact. A CI runner has no such file by design; workflows get these PATs as per-workflow Actions secrets, not ambient env vars.

Result: the check returned **CRITICAL on every CI run**, which is what kept `nself-org/web` **Dogfood Check** permanently red. A security gate that can never pass is worse than no gate: it trains people to ignore a red security check.

Injecting the four PATs into CI just to satisfy it would be worse security, so the fix is to skip where the check does not apply.

**Deliberately narrow:** skips only when CI is detected *and* no vault file exists. A self-hosted runner that does have one is still checked, so this cannot become the mirror defect — a gate that never fails. Both directions are covered by tests, and with the guard reverted the skip test fails with the exact pre-fix status.