### PR TITLE
chore: follow the SSD remount from /Volumes/X9 to /Volumes/UG

### DIFF
--- a/.github/wiki/operations/Incident-Response-Runbook.md
+++ b/.github/wiki/operations/Incident-Response-Runbook.md
@@ -193,7 +193,7 @@ nself monitor --last 15m
 
 ```bash
 # What deployed in the last 2 hours?
-cd /Volumes/X9/Sites/nself/cli && git log --oneline --since="2 hours ago"
+cd /Volumes/UG/Sites/nself/cli && git log --oneline --since="2 hours ago"
 
 # Any nself update recently?
 nself version && nself update --dry-run
@@ -226,7 +226,7 @@ Navigate to the matching scenario, then follow it to resolution:
 vercel rollback --prod
 
 # CLI fix pushed to prod — roll back to prior tag
-cd /Volumes/X9/Sites/nself/cli
+cd /Volumes/UG/Sites/nself/cli
 git tag --sort=-creatordate | head -5  # find prior tag
 # then trigger deploy via nself deploy with prior version
 ```

--- a/scripts/ops/credential-rotation-check.sh
+++ b/scripts/ops/credential-rotation-check.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 # ---- defaults
-PPI_ROOT="${PPI_ROOT:-/Volumes/X9/Sites/nself}"
+PPI_ROOT="${PPI_ROOT:-/Volumes/UG/Sites/nself}"
 DRY_RUN="${DRY_RUN:-0}"
 
 # ---- arg parse


### PR DESCRIPTION
Mechanical path-only change. The workstation SSD was remounted under a new volume label, so every hardcoded `/Volumes/X9/Sites` reference pointed at a path that no longer exists.

Verified diff-by-diff that this contains nothing but that substitution — equal insertions and deletions, every changed line matching `Volumes/(X9|UG)/Sites`.

These absolute paths arguably should not be in tracked files at all: a volume rename should never be able to break a repo. Making them portable ($HOME-relative or env-driven) is follow-up work, not this PR.