### PR TITLE
fix(sdk): bump ts-sdk package.json to 1.3.5

### DIFF
--- a/sdk/ts-sdk/package.json
+++ b/sdk/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nself/sdk",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "TypeScript consumer SDK for nSelf \u2014 query GraphQL, manage plugins, auth, and admin from any TS/JS app.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- @nself/sdk (`sdk/ts-sdk/package.json`) was left at 1.3.4 during the v1.3.5 release, the exact two-TS-package drift the version-lockstep workflow's own comment documents.
- Causes Version Lockstep + SDK Version Coherence to fail on every push/schedule since v1.3.5, and the npm publish job to publish the wrong version.
- All 10 other lockstep-checked files already correctly report 1.3.5 — verified individually.

## Test plan
- [x] Verified all 11 lockstep files' versions match 1.3.5 except this one, pre-fix
- [ ] CI: Version Lockstep passes
- [ ] CI: SDK Version Coherence passes (TS_STATUS should flip pass)