### PR TITLE
ci: golangci-lint gate + gofmt inversion proof (T04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,32 @@ jobs:
       - name: workflow YAML lint
         run: bash scripts/ci/workflow-lint.sh
 
+  golangci-lint:
+    # P6-E2-W1-S1-T4: the PRI's Dev Env Quick Ref lint contract lists
+    # `golangci-lint run` alongside gofmt/vet, but no CI job ever enforced it.
+    # Pinned to a released tag (never @latest), matching the repo's existing
+    # tool-pinning discipline (see 2451d9bd "pin govulncheck and go-licenses
+    # instead of installing @latest").
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GOFLAGS: -mod=vendor
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9.3.0
+        with:
+          version: v2.13.2
+          args: --timeout=10m
+
   ci:
     name: Vet, Build & Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/clean-root.yml
+++ b/.github/workflows/clean-root.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Enforce explicit root-entry allowlist
         run: |
           set -euo pipefail
-          ALLOWED=".dockerignore .gitattributes .github .gitignore .gitleaks.toml .goreleaser.yml Dockerfile LICENSE Makefile README.md bin cmd go.mod go.sum internal monitoring packaging scripts sdk templates terraform test tools vendor"
+          ALLOWED=".dockerignore .gitattributes .github .gitignore .gitleaks.toml .golangci.yml .goreleaser.yml Dockerfile LICENSE Makefile README.md bin cmd go.mod go.sum internal monitoring packaging scripts sdk templates terraform test tools vendor"
           echo "$ALLOWED" | tr ' ' '\n' | sort > /tmp/root-allowed.txt
           git ls-files | awk -F/ '{print $1}' | sort -u > /tmp/root-tracked.txt
           UNEXPECTED=$(comm -23 /tmp/root-tracked.txt /tmp/root-allowed.txt)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+version: "2"
+# Minimal config: default linter set plus the ones the PRI lint contract
+# names explicitly (govet, unused, staticcheck are linters; gofmt is a v2
+# "formatter" and is configured separately below). gofmt/govet are already
+# enforced as dedicated CI steps (scripts/ci/gofmt-check.sh, go vet) but are
+# listed here too so `golangci-lint run` alone is a complete gate.
+linters:
+  default: standard
+  enable:
+    - govet
+    - unused
+    - staticcheck
+  exclusions:
+    paths:
+      - vendor
+      - testdata
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    paths:
+      - vendor
+      - testdata

--- a/internal/ztmp_gofmt_probe.go
+++ b/internal/ztmp_gofmt_probe.go
@@ -1,6 +1,0 @@
-package internal
-
-func ztmpGofmtProbe() int {
-        x :=1
-	return    x
-}

--- a/internal/ztmp_gofmt_probe.go
+++ b/internal/ztmp_gofmt_probe.go
@@ -1,0 +1,6 @@
+package internal
+
+func ztmpGofmtProbe() int {
+        x :=1
+	return    x
+}

--- a/sdk/ts-sdk/package.json
+++ b/sdk/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nself/sdk",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "TypeScript consumer SDK for nSelf \u2014 query GraphQL, manage plugins, auth, and admin from any TS/JS app.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Adds pinned golangci-lint job. Includes temporary probe commit proving the gofmt gate fails red; will be force-cleaned before merge/close.