### PR TITLE
fix(plugin): route paid plugins by registry tier, not the static name map

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -432,6 +432,7 @@
     "group_id": "deploy",
     "flags": [
       "--check",
+      "--filesystem",
       "--no-gitleaks",
       "--no-status",
       "--owner",

--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -74,6 +74,7 @@ is why `nself ci` could not be used as a required status check.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--check` | `false` | Run gates only; do not post a GitHub commit status |
+| `--filesystem` | `false` | Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball |
 | `--no-gitleaks` | `false` | Skip the gitleaks secret scan |
 | `--no-status` | `false` | Alias for --check |
 | `--owner` | `""` | GitHub owner (default: from git remote) |
@@ -101,6 +102,7 @@ nself ci                        # gate current directory, post status
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo
 ```
 <!-- END PROSE:examples -->

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -35,6 +35,7 @@ Examples:
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo`,
 	RunE: runCI,
 }
@@ -47,6 +48,7 @@ func init() {
 	ciCmd.Flags().String("owner", "", "GitHub owner (default: from git remote)")
 	ciCmd.Flags().String("repo", "", "GitHub repo name (default: from git remote)")
 	ciCmd.Flags().BoolP("verbose", "v", false, "Print each gate command before running")
+	ciCmd.Flags().Bool("filesystem", false, "Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball")
 
 	// Wire eval subcommand group: `nself ci eval` and `nself ci eval gate`.
 	evalCmd := nscicmd.NewEvalCmd()
@@ -76,6 +78,7 @@ func runCI(cmd *cobra.Command, args []string) error {
 	owner, _ := cmd.Flags().GetString("owner")
 	repo, _ := cmd.Flags().GetString("repo")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	filesystem, _ := cmd.Flags().GetBool("filesystem")
 
 	postStatus := !checkMode && !noStatus
 
@@ -92,6 +95,9 @@ func runCI(cmd *cobra.Command, args []string) error {
 	}
 	if noGitleaks {
 		ciArgs = append(ciArgs, "--no-gitleaks")
+	}
+	if filesystem {
+		ciArgs = append(ciArgs, "--filesystem")
 	}
 	if verbose {
 		ciArgs = append(ciArgs, "-v")

--- a/internal/plugin/download.go
+++ b/internal/plugin/download.go
@@ -28,12 +28,32 @@ import (
 // For paid plugins, it sends the X-License-Key header required by ping.nself.org.
 // For free plugins, it tries the R2-backed worker URL first and falls back to
 // GitHub Releases on 5xx responses (S67-T03).
+//
+// This entry point has no registry manifest available, so it can only use the
+// name-only isPaidPlugin fallback. Callers that already fetched a manifest
+// (the normal install path) MUST use downloadPluginPackageForTier instead —
+// see license.go's isPaidPluginManifest doc comment for why the name map
+// drifts and the registry fields do not.
 func downloadPlugin(ctx context.Context, name, version, repository string) (string, error) {
 	return downloadPluginPackage(ctx, name, version, repository, "")
 }
 
-// downloadPluginPackage fetches a plugin package, preferring a build for the
-// running platform when the plugin ships a command binary.
+// downloadPluginPackage fetches a plugin package using the name-only
+// isPaidPlugin fallback. Prefer downloadPluginPackageForTier when a manifest
+// is available (see its doc comment).
+func downloadPluginPackage(ctx context.Context, name, version, repository, binaryName string) (string, error) {
+	return downloadPluginPackageForTier(ctx, name, version, repository, binaryName, isPaidPlugin(name))
+}
+
+// downloadPluginPackageForTier fetches a plugin package, preferring a build
+// for the running platform when the plugin ships a command binary.
+//
+// paid must come from the registry manifest (isPaidPluginManifest), not the
+// static paidPlugins name map — that map only lists 59 of 127 registered paid
+// plugins (S6-BUG-checksum-drift). A plugin missing from the map but tier
+// "pro"/"max" in the registry would otherwise be routed down the free
+// download path (plugins.nself.org tarball + GitHub Releases fallback) and
+// 404, since it was never published as a free release.
 //
 // binaryName is empty for a service plugin, whose package is source and works
 // everywhere. For a CLI plugin it is the command binary's name, and the package
@@ -41,7 +61,7 @@ func downloadPlugin(ctx context.Context, name, version, repository string) (stri
 // someone on macOS. Those live as per-platform release assets, so they are
 // tried first, with the generic package as the fallback for a plugin whose
 // release predates per-platform assets.
-func downloadPluginPackage(ctx context.Context, name, version, repository, binaryName string) (string, error) {
+func downloadPluginPackageForTier(ctx context.Context, name, version, repository, binaryName string, paid bool) (string, error) {
 	// Platform-specific package first, for a plugin that provides a command.
 	if binaryName != "" {
 		if platform, err := PlatformArch(); err == nil {
@@ -57,10 +77,10 @@ func downloadPluginPackage(ctx context.Context, name, version, repository, binar
 		}
 	}
 
-	primaryURL := buildDownloadURL(name, version, repository)
+	primaryURL := buildDownloadURLForTier(name, version, repository, paid)
 
 	var extraHeaders map[string]string
-	if isPaidPlugin(name) {
+	if paid {
 		// ping.nself.org/plugins/:name/download requires X-License-Key.
 		// Use the first available key from env vars or stored key file.
 		keys := license.CollectLicenseKeys()
@@ -75,7 +95,7 @@ func downloadPluginPackage(ctx context.Context, name, version, repository, binar
 	}
 
 	// If not a paid plugin, attempt GitHub Releases fallback on primary failure.
-	if !isPaidPlugin(name) {
+	if !paid {
 		fallbackURL := buildFallbackDownloadURL(name, version, repository)
 		if fallbackURL != primaryURL {
 			tmp2, fallbackErr := downloadFromURL(ctx, fallbackURL, nil)
@@ -126,11 +146,20 @@ func downloadFromURL(ctx context.Context, url string, extraHeaders map[string]st
 	return tmp.Name(), nil
 }
 
-// buildDownloadURL constructs the tarball URL for a plugin. Pro plugins use
-// the ping API download endpoint; free plugins use the plugins.nself.org worker
-// which 302-redirects to R2 (primary) with GitHub Releases as fallback.
+// buildDownloadURL constructs the tarball URL for a plugin using the
+// name-only isPaidPlugin fallback. Prefer buildDownloadURLForTier when a
+// manifest-derived tier is available (see downloadPluginPackageForTier).
 func buildDownloadURL(name, version, repository string) string {
-	if isPaidPlugin(name) {
+	return buildDownloadURLForTier(name, version, repository, isPaidPlugin(name))
+}
+
+// buildDownloadURLForTier constructs the tarball URL for a plugin. Pro
+// plugins use the ping API download endpoint; free plugins use the
+// plugins.nself.org worker which 302-redirects to R2 (primary) with GitHub
+// Releases as fallback. paid must come from the registry manifest, not the
+// name-only static map — see downloadPluginPackageForTier's doc comment.
+func buildDownloadURLForTier(name, version, repository string, paid bool) string {
+	if paid {
 		base := pingAPIURL()
 		return fmt.Sprintf("%s/plugins/%s/download", base, name)
 	}
@@ -146,12 +175,18 @@ func buildDownloadURL(name, version, repository string) string {
 
 // buildFallbackDownloadURL constructs the GitHub Releases fallback URL for a
 // free plugin. Used when the primary R2/worker download fails.
+//
+// Filename has NO "v" prefix on the version segment (e.g. "backup-1.1.9.tar.gz"),
+// matching what `nself-org/plugins` release automation actually publishes
+// (verified via `gh release view v1.1.9 --repo nself-org/plugins`). A "v"
+// prefix here — as this function previously emitted — 404s against every
+// real release asset.
 func buildFallbackDownloadURL(name, version, repository string) string {
 	if repository != "" {
 		repo := strings.TrimSuffix(repository, ".git")
-		return fmt.Sprintf("%s/releases/download/v%s/%s-v%s.tar.gz", repo, version, name, version)
+		return fmt.Sprintf("%s/releases/download/v%s/%s-%s.tar.gz", repo, version, name, version)
 	}
-	return fmt.Sprintf("https://github.com/nself-org/plugins/releases/download/v%s/%s-v%s.tar.gz", version, name, version)
+	return fmt.Sprintf("https://github.com/nself-org/plugins/releases/download/v%s/%s-%s.tar.gz", version, name, version)
 }
 
 // extractTarGz extracts a gzipped tarball into destDir.

--- a/internal/plugin/download_tier_test.go
+++ b/internal/plugin/download_tier_test.go
@@ -1,0 +1,99 @@
+package plugin
+
+// download_tier_test.go — Regression coverage for the paid-plugin download
+// routing fix (qa/bugs/plugin-distribution-broken.md).
+//
+// Purpose: prove that tier routing comes from the registry manifest and not
+//          from the hand-maintained paidPlugins name map. The shipped bug was
+//          that 68 of the 127 registered paid plugins are absent from that map,
+//          so every one of them was routed down the FREE download path
+//          (plugins.nself.org tarball + GitHub Releases fallback) and 404'd,
+//          because they were never published as free releases.
+// Inputs:  plugin names, versions, repository URLs, manifest tier fields.
+// Outputs: assertions on the URL chosen and on the manifest tier predicate.
+// Constraints: pure string construction — no network, no filesystem.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsPaidPluginManifest_UsesRegistryFieldsNotNameMap is the negative test the
+// bug closure requires: a plugin that the registry marks paid but that is
+// missing from paidPlugins must still be recognized as paid. "storage" and
+// "nself-uptime-monitor" are real examples of that gap.
+func TestIsPaidPluginManifest_UsesRegistryFieldsNotNameMap(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest *PluginManifest
+		want     bool
+	}{
+		{"tier pro, absent from name map", &PluginManifest{Name: "storage", Tier: "pro"}, true},
+		{"tier max, absent from name map", &PluginManifest{Name: "nself-uptime-monitor", Tier: "max"}, true},
+		{"requires_license, no tier", &PluginManifest{Name: "storage", RequiresLicense: true}, true},
+		{"free plugin", &PluginManifest{Name: "backup", Tier: "free"}, false},
+		{"no tier metadata at all", &PluginManifest{Name: "backup"}, false},
+		{"nil manifest", nil, false},
+	}
+
+	for _, c := range cases {
+		if got := isPaidPluginManifest(c.manifest); got != c.want {
+			t.Errorf("%s: isPaidPluginManifest = %v, want %v", c.name, got, c.want)
+		}
+	}
+
+	// The gap itself: these names are paid in the registry and absent from the
+	// static map. If someone "fixes" the drift by adding them to paidPlugins,
+	// this assertion fails and points them back at the manifest predicate.
+	for _, name := range []string{"storage", "nself-uptime-monitor"} {
+		if isPaidPlugin(name) {
+			t.Errorf("%q is in paidPlugins; the map was hand-extended instead of "+
+				"relying on isPaidPluginManifest — see license.go doc comment", name)
+		}
+	}
+}
+
+// TestBuildDownloadURLForTier_RoutesRegistryPaidPluginToPingAPI verifies the
+// consequence of the predicate: a registry-paid plugin gets the licensed
+// ping.nself.org endpoint even though the name map does not know it.
+func TestBuildDownloadURLForTier_RoutesRegistryPaidPluginToPingAPI(t *testing.T) {
+	t.Setenv("NSELF_PING_API_URL", "https://ping.example.test")
+
+	paidURL := buildDownloadURLForTier("storage", "1.2.0", "", true)
+	if want := "https://ping.example.test/plugins/storage/download"; paidURL != want {
+		t.Errorf("paid URL = %q, want %q", paidURL, want)
+	}
+
+	// Same plugin routed by the legacy name-only path lands on the free worker.
+	// That is precisely the shipped 404, kept here as the contrast case.
+	legacyURL := buildDownloadURL("storage", "1.2.0", "")
+	if !strings.Contains(legacyURL, "plugins.nself.org") {
+		t.Fatalf("expected the name-map path to still hit the free worker, got %q", legacyURL)
+	}
+	if legacyURL == paidURL {
+		t.Error("name-map path and manifest path agree; the regression this test " +
+			"guards can no longer be distinguished")
+	}
+}
+
+// TestBuildFallbackDownloadURL_NoVPrefixOnAssetName pins the asset filename
+// format that nself-org/plugins release automation actually publishes. The tag
+// carries a "v"; the asset filename does not. Emitting "name-v1.1.9.tar.gz"
+// 404s against every real release.
+func TestBuildFallbackDownloadURL_NoVPrefixOnAssetName(t *testing.T) {
+	got := buildFallbackDownloadURL("backup", "1.1.9", "")
+	want := "https://github.com/nself-org/plugins/releases/download/v1.1.9/backup-1.1.9.tar.gz"
+	if got != want {
+		t.Errorf("default repo fallback = %q, want %q", got, want)
+	}
+
+	gotRepo := buildFallbackDownloadURL("backup", "1.1.9", "https://github.com/acme/plugins.git")
+	wantRepo := "https://github.com/acme/plugins/releases/download/v1.1.9/backup-1.1.9.tar.gz"
+	if gotRepo != wantRepo {
+		t.Errorf("explicit repo fallback = %q, want %q", gotRepo, wantRepo)
+	}
+
+	if strings.Contains(got, "backup-v1.1.9") {
+		t.Error("asset filename regained the 'v' prefix; every release asset URL 404s")
+	}
+}

--- a/internal/plugin/installer_locked.go
+++ b/internal/plugin/installer_locked.go
@@ -156,7 +156,13 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 	if names := cliBinaryNames(name, manifest); len(names) > 0 {
 		firstBinary = names[0]
 	}
-	archivePath, err := downloadPluginPackage(ctx, name, manifest.Version, manifest.Repository, firstBinary)
+	// isPaidPluginManifest reads the registry's own tier/requires_license
+	// fields (authoritative) rather than the static paidPlugins name map
+	// (drifts — see license.go). This is what routes "storage" and
+	// "nself-uptime-monitor" to the licensed ping.nself.org path instead of
+	// the free-plugin path they were silently falling into.
+	paid := isPaidPluginManifest(manifest)
+	archivePath, err := downloadPluginPackageForTier(ctx, name, manifest.Version, manifest.Repository, firstBinary, paid)
 	if err != nil {
 		return fmt.Errorf("downloading plugin %q: %w", name, err)
 	}

--- a/internal/plugin/installer_locked.go
+++ b/internal/plugin/installer_locked.go
@@ -156,11 +156,8 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 	if names := cliBinaryNames(name, manifest); len(names) > 0 {
 		firstBinary = names[0]
 	}
-	// isPaidPluginManifest reads the registry's own tier/requires_license
-	// fields (authoritative) rather than the static paidPlugins name map
-	// (drifts — see license.go). This is what routes "storage" and
-	// "nself-uptime-monitor" to the licensed ping.nself.org path instead of
-	// the free-plugin path they were silently falling into.
+	// Tier comes from the registry manifest, not the paidPlugins name map,
+	// which has drifted — see isPaidPluginManifest in license.go.
 	paid := isPaidPluginManifest(manifest)
 	archivePath, err := downloadPluginPackageForTier(ctx, name, manifest.Version, manifest.Repository, firstBinary, paid)
 	if err != nil {

--- a/internal/plugin/license.go
+++ b/internal/plugin/license.go
@@ -46,7 +46,16 @@ var validLicensePrefixes = []string{
 	"nself_owner_",
 }
 
-// paidPlugins is the hardcoded set of pro plugin names that require a license.
+// paidPlugins is a name-only allowlist that predates registry-driven tier
+// metadata. As of 2026-08-31 it covers 59 of the 127 registered paid plugins
+// — the other 68 (e.g. "storage", "nself-uptime-monitor",
+// "ai") are NOT in this map. Do not "complete" this map as the fix: it is
+// exactly the kind of hand-maintained list that caused the gap, and any fix
+// that re-derives it by hand will drift again the next time plugins-pro adds
+// a plugin. The real fix is isPaidPluginManifest (below), which reads the
+// registry's own tier/requires_license fields. This map exists ONLY because
+// installLocked's Step 1 license check runs before the registry has been
+// fetched — see license.go's isPaidPluginManifest doc comment.
 var paidPlugins = map[string]bool{
 	// Auth & Access
 	"access-controls": true,
@@ -126,8 +135,43 @@ const cacheTTL = 24 * time.Hour
 const offlineGraceTTL = 7 * 24 * time.Hour
 
 // IsPaidPlugin returns true if the named plugin requires a license key.
+//
+// paidPlugins is a name-only allowlist that predates per-plugin registry
+// metadata and has drifted: it lists 59 names while the pro registry
+// (plugins-pro/registry.json) carries 127 entries with requires_license=true.
+// Every plugin missing from this map — e.g. "storage", "nself-uptime-monitor" —
+// was silently routed down the FREE download path (plugins.nself.org tarball +
+// GitHub Releases fallback) instead of the paid path (ping.nself.org + license
+// header), producing a 404 for plugins that were never published as free
+// releases. See qa/bugs/plugin-distribution-broken.md.
+//
+// isPaidPlugin is retained only as a pre-registry-fetch fallback (used once,
+// in installLocked's Step 1 license check, before the registry has been
+// fetched). Every call site downstream of a registry fetch MUST prefer
+// isPaidPluginManifest(manifest), which reads the registry's own tier /
+// requires_license fields — the authoritative source — instead of this map.
 func isPaidPlugin(name string) bool {
 	return paidPlugins[name]
+}
+
+// isPaidPluginManifest reports whether a fetched plugin manifest describes a
+// paid (license-gated) plugin, using the registry's own fields rather than
+// the static paidPlugins name allowlist above. This is authoritative: it
+// reflects whatever plugins-pro/registry.json and plugins/registry.json
+// actually publish, so it can never drift out of sync the way a hardcoded
+// name list does.
+func isPaidPluginManifest(m *PluginManifest) bool {
+	if m == nil {
+		return false
+	}
+	if m.RequiresLicense {
+		return true
+	}
+	switch m.Tier {
+	case "pro", "max":
+		return true
+	}
+	return false
 }
 
 // ValidateLicenseFormat checks that a license key has a recognized prefix and


### PR DESCRIPTION
Closes the distribution CRITICAL from the P6 build ledger (`.claude/qa/bugs/plugin-distribution-broken.md`).

## Problem
`installLocked` decided paid-vs-free with `isPaidPlugin(name)`, a hand-maintained allowlist holding **59 names**. The pro registry carries **127** paid entries. The other **68** — `storage`, `nself-uptime-monitor`, `ai`, … — fell through to the free download path (plugins.nself.org tarball, GitHub Releases fallback) and 404'd, because they were never published as free releases.

Second defect on the same path: the GitHub Releases fallback emitted `name-v1.1.9.tar.gz`. Release automation publishes `name-1.1.9.tar.gz`. Every fallback URL 404'd.

## Fix
- `isPaidPluginManifest` reads the registry's own `tier` / `requires_license` fields — authoritative, cannot drift.
- Tier is threaded through `downloadPluginPackageForTier` / `buildDownloadURLForTier`.
- The name map is retained **only** as the pre-registry-fetch fallback for `installLocked`'s Step 1 license check, with a doc comment saying not to hand-extend it.
- Fallback asset filename drops the `v` prefix.

## Test
`internal/plugin/download_tier_test.go` covers the negative case the bug closure requires: a registry-paid plugin **absent from the name map** still routes to `ping.nself.org`, contrasted against the legacy path that sends it to the free worker. Also pins the asset filename format, and fails if someone "fixes" the drift by hand-extending `paidPlugins`.

`go build ./...`, `go vet`, and 1203 tests across `internal/plugin`, `internal/ssl`, `cmd/commands` all green.