### PR TITLE
fix(license): wire IsRecordRevoked into fail-open path

### DIFF
--- a/internal/license/revocation.go
+++ b/internal/license/revocation.go
@@ -4,7 +4,8 @@
 // The CLI fetches `GET /license/revocation-list` from ping.nself.org hourly
 // and stores the signed payload at `~/.config/nself/revocation-cache.json`.
 // Every license validation pass consults the local cache to decide whether
-// a presented JWT (jti / user_id / kid) has been revoked.
+// a presented JWT (jti / user_id / kid) or cached license (key_hash) has
+// been revoked.
 //
 // FAIL-OPEN policy (per PPI § Vendor Stack — license validation fail-mode):
 //   - Cache up to 7 days stale: still authoritative; refresh attempts run
@@ -49,7 +50,7 @@ const revocationHTTPTimeout = 10 * time.Second
 // RevocationEntry is one revoked identifier.  Field order matters for the
 // canonical JSON encoder; struct tags pin the wire names.
 type RevocationEntry struct {
-	Type      string `json:"type"`       // "jti" | "user_id" | "kid"
+	Type      string `json:"type"`       // "jti" | "user_id" | "kid" | "key_hash"
 	ID        string `json:"id"`         // identifier value
 	Reason    string `json:"reason"`     // human-readable
 	RevokedAt string `json:"revoked_at"` // ISO8601
@@ -66,10 +67,19 @@ type RevocationList struct {
 
 // LicenseRecord is the minimal shape needed to evaluate revocation.
 // Each field is optional: zero values are treated as "no match attempted".
+//
+// KeyHash (BUILD-LEDGER Finding #14, closed here): the fail-open cache-only
+// path (validator_validate.go) has no JTI/UserID/Kid available — the server's
+// ValidateResponse never carries one — but it always has entry.KeyHash
+// (HashKey(key), already computed and cached in CacheEntry). KeyHash is
+// therefore the join key that lets a server-published revocation list name a
+// revoked license without minting a JTI. Do not "simplify" this back to JTI:
+// JTI is simply not populated anywhere on the fail-open path.
 type LicenseRecord struct {
-	JTI    string
-	UserID string
-	Kid    string
+	JTI     string
+	UserID  string
+	Kid     string
+	KeyHash string
 }
 
 // RevocationCache is the on-disk cache wrapper around RevocationList.

--- a/internal/license/revocation_refresh_check.go
+++ b/internal/license/revocation_refresh_check.go
@@ -169,6 +169,10 @@ func matchAny(list *RevocationList, rec LicenseRecord) bool {
 			if rec.Kid != "" && e.ID == rec.Kid {
 				return true
 			}
+		case "key_hash":
+			if rec.KeyHash != "" && e.ID == rec.KeyHash {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/license/revocation_test.go
+++ b/internal/license/revocation_test.go
@@ -302,6 +302,7 @@ func TestMatchAny(t *testing.T) {
 			{Type: "jti", ID: "j1"},
 			{Type: "user_id", ID: "u1"},
 			{Type: "kid", ID: "k1"},
+			{Type: "key_hash", ID: "h1"},
 		},
 	}
 	cases := []struct {
@@ -312,6 +313,8 @@ func TestMatchAny(t *testing.T) {
 		{"jti hit", LicenseRecord{JTI: "j1"}, true},
 		{"user_id hit", LicenseRecord{UserID: "u1"}, true},
 		{"kid hit", LicenseRecord{Kid: "k1"}, true},
+		{"key_hash hit", LicenseRecord{KeyHash: "h1"}, true},
+		{"key_hash miss", LicenseRecord{KeyHash: "h-other"}, false},
 		{"empty record", LicenseRecord{}, false},
 		{"miss", LicenseRecord{JTI: "j2", UserID: "u2", Kid: "k2"}, false},
 		{"jti empty does not collide with empty entry", LicenseRecord{JTI: ""}, false},

--- a/internal/license/validator_test.go
+++ b/internal/license/validator_test.go
@@ -629,5 +629,93 @@ func TestValidator_StatusEnumStability(t *testing.T) {
 	}
 }
 
+// ============================================================================
+// BUILD-LEDGER Finding #14: FAIL-OPEN must consult the local revocation
+// cache (D3-T08's IsRecordRevoked) before granting CanProceed: true.
+// ============================================================================
+
+// seedRevocation writes a revocation cache entry directly (unsigned —
+// IsRecordRevoked's read path does not verify signatures; only the fetch
+// path does) matching the pattern used throughout revocation_test.go.
+func seedRevocation(t *testing.T, entries ...RevocationEntry) {
+	t.Helper()
+	cache := &RevocationCache{
+		List: RevocationList{
+			Kid:     "k",
+			Revoked: entries,
+		},
+		FetchedAt: time.Now().Unix(),
+	}
+	if err := WriteRevocationCache(cache); err != nil {
+		t.Fatalf("WriteRevocationCache: %v", err)
+	}
+}
+
+// THE NEGATIVE TEST the finding is explicit must exist: a license present
+// in the local revocation cache (keyed by KeyHash — the only stable
+// identifier available on the fail-open path) must be REJECTED even though
+// the remote validator is forced unreachable and the cache is well within
+// the soft TTL that would otherwise fail-open silently. A test that only
+// exercises the online path proves nothing per the bug file; this one
+// forces tryRemote down the transient-failure branch via errDoer so the
+// cache-only / fail-open code path is the one under test.
+func TestValidator_RevokedKeyHash_RemoteUnreachable_FailClosed(t *testing.T) {
+	redirectCache(t)     // CacheEntry (license.json)
+	withTempCachePath(t) // RevocationCache (revocation-cache.json) — separate file
+	ResetFailOpenWarning()
+
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	key := "nself_pro_testkey1234567890abcdef12345"
+
+	// Cache is only 1 day old — comfortably within FailOpenSoftTTL, which
+	// would silently grant access if revocation were not consulted.
+	seedCache(t, makeEntry(now, 1*24*time.Hour, 30*24*time.Hour, key))
+	seedRevocation(t, RevocationEntry{Type: "key_hash", ID: HashKey(key)})
+
+	warnFn, _, _ := captureWarn()
+	// Remote path forced to fail — this is the fail-open-eligible branch,
+	// not the online path.
+	res, err := Validate(context.Background(), key, silentOpts(now, errDoer{err: errors.New("connection refused")}, warnFn))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if res.Status != StatusFailClosed {
+		t.Errorf("status = %q, want %q (revoked license must not ride fail-open)", res.Status, StatusFailClosed)
+	}
+	if res.CanProceed {
+		t.Errorf("CanProceed = true, want false — revoked license granted access via fail-open")
+	}
+}
+
+// POSITIVE regression guard: a license absent from the revocation cache
+// (a non-matching key_hash entry is present, proving the check ran and
+// simply didn't match) must still fail-open exactly as before. This is the
+// "additive, not a behavior change" half of the acceptance criteria.
+func TestValidator_NonRevokedKeyHash_RemoteUnreachable_StillFailsOpen(t *testing.T) {
+	redirectCache(t)
+	withTempCachePath(t)
+	ResetFailOpenWarning()
+
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	key := "nself_pro_testkey1234567890abcdef12345"
+
+	seedCache(t, makeEntry(now, 1*24*time.Hour, 30*24*time.Hour, key))
+	// A revocation list that exists and is checked, but names a different
+	// license entirely.
+	seedRevocation(t, RevocationEntry{Type: "key_hash", ID: "not-this-license"})
+
+	warnFn, _, _ := captureWarn()
+	res, err := Validate(context.Background(), key, silentOpts(now, errDoer{err: errors.New("connection refused")}, warnFn))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if res.Status != StatusFailOpen {
+		t.Errorf("status = %q, want %q (non-revoked license must still fail-open)", res.Status, StatusFailOpen)
+	}
+	if !res.CanProceed {
+		t.Errorf("CanProceed = false, want true")
+	}
+}
+
 // _ = fmt.Sprintf placeholder retained in case future tests need it.
 var _ = fmt.Sprintf

--- a/internal/license/validator_validate.go
+++ b/internal/license/validator_validate.go
@@ -135,6 +135,24 @@ func Validate(ctx context.Context, key string, opts *ValidatorOptions) (*Validat
 	}
 
 	age := clk.Now().Sub(time.Unix(entry.FetchedAt, 0))
+
+	// BUILD-LEDGER Finding #14: the local revocation cache is the
+	// compensating control that makes FAIL-OPEN safe. Consult it
+	// unconditionally before either fail-open branch below can grant
+	// CanProceed: true — a revoked license must never ride the soft or
+	// hard TTL window just because the remote validator is unreachable.
+	// KeyHash (not JTI) is the join key here: CacheEntry never carries a
+	// JTI (see LicenseRecord.KeyHash doc comment in revocation.go).
+	if IsRecordRevoked(LicenseRecord{KeyHash: entry.KeyHash}) {
+		return &ValidatorResult{
+			Status:     StatusFailClosed,
+			CanProceed: false,
+			FromCache:  true,
+			Tier:       entry.Tier,
+			Reason:     "license revoked; cannot fail-open a revoked license",
+		}, nil
+	}
+
 	switch {
 	case age <= FailOpenSoftTTL:
 		return &ValidatorResult{


### PR DESCRIPTION
## Summary
- BUILD-LEDGER Finding #14: `IsRecordRevoked()` had zero production callers; `StatusFailOpen` in `validator_validate.go` never consulted the local revocation cache, so a revoked license kept working for the entire 7-day/hard-TTL fail-open window when the remote validator was unreachable.
- `CacheEntry` (the type available at fail-open time) carries no JTI/UserID/Kid, only `KeyHash`. Added a `key_hash` match type to `RevocationEntry`/`matchAny` and `LicenseRecord.KeyHash`, then call `IsRecordRevoked(LicenseRecord{KeyHash: entry.KeyHash})` unconditionally before either fail-open branch in `Validate()` can return `CanProceed: true`. A match now returns `StatusFailClosed`.
- Closes `.claude/qa/bugs/license-failopen-skips-revocation-cache.md`.

## Tests
- `TestValidator_RevokedKeyHash_RemoteUnreachable_FailClosed` — the required negative test: cache within soft TTL + remote forced unreachable + matching revoked KeyHash -> FailClosed / CanProceed:false.
- `TestValidator_NonRevokedKeyHash_RemoteUnreachable_StillFailsOpen` — regression guard: non-matching KeyHash present + remote unreachable -> still FailOpen (non-revoked UX unchanged).
- `TestMatchAny` extended with key_hash hit/miss cases.
- Inversion proof: reverting the new caller flips the negative test to FAIL (`status = "fail_open", want "fail_closed"`) — confirms the test actually exercises the fix.

## Verify
- `gofmt -l cmd internal` -> exit 0 (clean)
- `go build ./...` -> exit 0
- `go vet ./...` -> exit 0
- `go test ./internal/license/ -count=1` -> `ok` (exit 0)