### PR TITLE
docs(wiki): regenerate llms.txt for the nself ci --filesystem flag

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -432,6 +432,7 @@
     "group_id": "deploy",
     "flags": [
       "--check",
+      "--filesystem",
       "--no-gitleaks",
       "--no-status",
       "--owner",

--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -74,6 +74,7 @@ is why `nself ci` could not be used as a required status check.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--check` | `false` | Run gates only; do not post a GitHub commit status |
+| `--filesystem` | `false` | Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball |
 | `--no-gitleaks` | `false` | Skip the gitleaks secret scan |
 | `--no-status` | `false` | Alias for --check |
 | `--owner` | `""` | GitHub owner (default: from git remote) |
@@ -101,6 +102,7 @@ nself ci                        # gate current directory, post status
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo
 ```
 <!-- END PROSE:examples -->

--- a/.github/wiki/llms.txt
+++ b/.github/wiki/llms.txt
@@ -162,6 +162,7 @@ Subcommands:
 Flags:
 
 - `--check` (default false) — Run gates only; do not post a GitHub commit status
+- `--filesystem` (default false) — Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball
 - `--no-gitleaks` (default false) — Skip the gitleaks secret scan
 - `--no-status` (default false) — Alias for --check
 - `--owner` (default "") — GitHub owner (default: from git remote)

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -35,6 +35,7 @@ Examples:
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo`,
 	RunE: runCI,
 }
@@ -47,6 +48,7 @@ func init() {
 	ciCmd.Flags().String("owner", "", "GitHub owner (default: from git remote)")
 	ciCmd.Flags().String("repo", "", "GitHub repo name (default: from git remote)")
 	ciCmd.Flags().BoolP("verbose", "v", false, "Print each gate command before running")
+	ciCmd.Flags().Bool("filesystem", false, "Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball")
 
 	// Wire eval subcommand group: `nself ci eval` and `nself ci eval gate`.
 	evalCmd := nscicmd.NewEvalCmd()
@@ -76,6 +78,7 @@ func runCI(cmd *cobra.Command, args []string) error {
 	owner, _ := cmd.Flags().GetString("owner")
 	repo, _ := cmd.Flags().GetString("repo")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	filesystem, _ := cmd.Flags().GetBool("filesystem")
 
 	postStatus := !checkMode && !noStatus
 
@@ -92,6 +95,9 @@ func runCI(cmd *cobra.Command, args []string) error {
 	}
 	if noGitleaks {
 		ciArgs = append(ciArgs, "--no-gitleaks")
+	}
+	if filesystem {
+		ciArgs = append(ciArgs, "--filesystem")
 	}
 	if verbose {
 		ciArgs = append(ciArgs, "-v")


### PR DESCRIPTION
Unblocks PRs #315, #316 and #317, all of which were failing the wiki gate for a staleness they did not introduce.

## Cause
8eef46bc (`feat(ci): add --filesystem opt-in flag to nself ci`) added a flag without running `make wiki-commands`, leaving `llms.txt` stale on main.

The `wiki is generated and links resolve` workflow is **path-filtered**, so it did not run on that commit. It only fires on PRs touching matching paths — which is why the breakage surfaced on three unrelated PRs rather than on the commit that caused it.

## Fix
`make wiki-commands`. One line added to `llms.txt`. `wikigen -check` now reports all 50 command pages current, exit 0.

## Worth noting
A path-filtered gate that cannot fire on the commit that breaks it will keep doing this. Same class as the golangci-lint gate, which has been red on main since it merged yesterday — that one is being cleared separately.