### PR TITLE
fix(lint): check every previously-ignored error return (608 sites)

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -432,6 +432,7 @@
     "group_id": "deploy",
     "flags": [
       "--check",
+      "--filesystem",
       "--no-gitleaks",
       "--no-status",
       "--owner",

--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -74,6 +74,7 @@ is why `nself ci` could not be used as a required status check.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--check` | `false` | Run gates only; do not post a GitHub commit status |
+| `--filesystem` | `false` | Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball |
 | `--no-gitleaks` | `false` | Skip the gitleaks secret scan |
 | `--no-status` | `false` | Alias for --check |
 | `--owner` | `""` | GitHub owner (default: from git remote) |
@@ -101,6 +102,7 @@ nself ci                        # gate current directory, post status
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo
 ```
 <!-- END PROSE:examples -->

--- a/cmd/commands/access_list.go
+++ b/cmd/commands/access_list.go
@@ -71,7 +71,7 @@ func runAccessList(cmd *cobra.Command, args []string) error {
 		fmt.Println("No nself-managed keys found. Run 'nself access grant' to add one.")
 	} else {
 		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(tw, "USER\tFINGERPRINT\tSUDO\tDOCKER\tEXPIRES\tSTATUS")
+		_, _ = fmt.Fprintln(tw, "USER\tFINGERPRINT\tSUDO\tDOCKER\tEXPIRES\tSTATUS")
 		for _, r := range rows {
 			sudo, docker, status := "no", "no", "active"
 			if r.Sudo {
@@ -87,7 +87,7 @@ func runAccessList(cmd *cobra.Command, args []string) error {
 			if expires == "" {
 				expires = "-"
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", r.User, r.Fingerprint, sudo, docker, expires, status)
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", r.User, r.Fingerprint, sudo, docker, expires, status)
 		}
 		if err := tw.Flush(); err != nil {
 			return fmt.Errorf("flush table: %w", err)

--- a/cmd/commands/admin.go
+++ b/cmd/commands/admin.go
@@ -159,7 +159,7 @@ func runAdminStart(cmd *cobra.Command, args []string) error {
 	probeReq, _ := http.NewRequestWithContext(probeCtx, http.MethodGet, adminURL, nil)
 	resp, err := httptimeout.Health.Do(probeReq)
 	if err == nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
 			fmt.Println("Admin is already running at http://localhost:" + port)
 			return nil
@@ -276,7 +276,7 @@ func runAdminHealth(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Admin health: unhealthy (%v)\n", err)
 		return fmt.Errorf("admin unreachable: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusOK {
 		fmt.Printf("Admin health: healthy (HTTP %d, %s)\n", resp.StatusCode, elapsed.Truncate(time.Millisecond))

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -35,6 +35,7 @@ Examples:
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo`,
 	RunE: runCI,
 }
@@ -47,6 +48,7 @@ func init() {
 	ciCmd.Flags().String("owner", "", "GitHub owner (default: from git remote)")
 	ciCmd.Flags().String("repo", "", "GitHub repo name (default: from git remote)")
 	ciCmd.Flags().BoolP("verbose", "v", false, "Print each gate command before running")
+	ciCmd.Flags().Bool("filesystem", false, "Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball")
 
 	// Wire eval subcommand group: `nself ci eval` and `nself ci eval gate`.
 	evalCmd := nscicmd.NewEvalCmd()
@@ -76,6 +78,7 @@ func runCI(cmd *cobra.Command, args []string) error {
 	owner, _ := cmd.Flags().GetString("owner")
 	repo, _ := cmd.Flags().GetString("repo")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	filesystem, _ := cmd.Flags().GetBool("filesystem")
 
 	postStatus := !checkMode && !noStatus
 
@@ -92,6 +95,9 @@ func runCI(cmd *cobra.Command, args []string) error {
 	}
 	if noGitleaks {
 		ciArgs = append(ciArgs, "--no-gitleaks")
+	}
+	if filesystem {
+		ciArgs = append(ciArgs, "--filesystem")
 	}
 	if verbose {
 		ciArgs = append(ciArgs, "-v")

--- a/cmd/commands/ci_forgejo.go
+++ b/cmd/commands/ci_forgejo.go
@@ -67,7 +67,7 @@ func runCIForgejo(cmd *cobra.Command, _ []string) error {
 	serverMsg := "unreachable"
 	resp, err := client.Get(baseURL + "/-/health")
 	if err == nil {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		var h forgejoHealthResponse
 		if json.NewDecoder(resp.Body).Decode(&h) == nil && h.Healthy {
 			serverOK = true
@@ -113,7 +113,7 @@ func runCIForgejo(cmd *cobra.Command, _ []string) error {
 		req, _ := http.NewRequest("GET", baseURL+"/api/v1/repos/search?limit=0", nil)
 		req.SetBasicAuth(adminUser, adminPass)
 		if r, err := client.Do(req); err == nil {
-			defer r.Body.Close()
+			defer func() { _ = r.Body.Close() }()
 			if r.StatusCode == http.StatusOK {
 				jobsInfo = "API reachable (admin authenticated)"
 			} else {

--- a/cmd/commands/clean.go
+++ b/cmd/commands/clean.go
@@ -114,32 +114,32 @@ func runClean(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Docker build cache (non-fatal if docker not available)
-	fmt.Fprintln(cmd.OutOrStdout(), "Pruning Docker build cache...")
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Pruning Docker build cache...")
 	pruneCmd := exec.CommandContext(cmd.Context(), "docker", "builder", "prune",
 		"--filter", "type=exec.cachemount",
 		"--force",
 	)
 	pruneOut, pruneErr := pruneCmd.CombinedOutput()
 	if pruneErr != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: docker builder prune failed (Docker may not be running): %v\n", pruneErr)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: docker builder prune failed (Docker may not be running): %v\n", pruneErr)
 	} else {
 		trimmed := strings.TrimSpace(string(pruneOut))
 		if trimmed != "" {
-			fmt.Fprintln(cmd.OutOrStdout(), trimmed)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), trimmed)
 		}
 	}
 
 	// Summary
 	out := cmd.OutOrStdout()
-	fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out)
 	if len(removed) == 0 {
-		fmt.Fprintln(out, "Nothing to remove — already clean.")
+		_, _ = fmt.Fprintln(out, "Nothing to remove — already clean.")
 	} else {
-		fmt.Fprintf(out, "Removed %d file(s):\n", len(removed))
+		_, _ = fmt.Fprintf(out, "Removed %d file(s):\n", len(removed))
 		for _, r := range removed {
-			fmt.Fprintf(out, "  - %s\n", r)
+			_, _ = fmt.Fprintf(out, "  - %s\n", r)
 		}
-		fmt.Fprintln(out, "\nRun 'nself build' to regenerate.")
+		_, _ = fmt.Fprintln(out, "\nRun 'nself build' to regenerate.")
 	}
 
 	// 5. --all: host-wide docker system prune, gated behind confirmation.
@@ -151,16 +151,16 @@ func runClean(cmd *cobra.Command, args []string) error {
 	skipConfirm, _ := cmd.Flags().GetBool("yes")
 	if !skipConfirm {
 		if confirmErr := confirm.ConfirmHostWidePrune(cmd.InOrStdin(), out); confirmErr != nil {
-			fmt.Fprintln(out, "\nHost-wide prune canceled.")
+			_, _ = fmt.Fprintln(out, "\nHost-wide prune canceled.")
 			return nil
 		}
 	}
 
-	fmt.Fprintln(out, "\nPruning all unused Docker resources on this host...")
+	_, _ = fmt.Fprintln(out, "\nPruning all unused Docker resources on this host...")
 	if pruneAllErr := dockerSystemPrune(cmd.Context(), out, cmd.ErrOrStderr()); pruneAllErr != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: docker system prune failed (Docker may not be running): %v\n", pruneAllErr)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: docker system prune failed (Docker may not be running): %v\n", pruneAllErr)
 	} else {
-		fmt.Fprintln(out, "Host-wide prune complete.")
+		_, _ = fmt.Fprintln(out, "Host-wide prune complete.")
 	}
 
 	return nil

--- a/cmd/commands/config_export_import.go
+++ b/cmd/commands/config_export_import.go
@@ -157,14 +157,14 @@ func runConfigImport(cmd *cobra.Command, args []string) error {
 	sort.Strings(conflicts)
 
 	if len(conflicts) > 0 && !force {
-		fmt.Fprintf(cmd.ErrOrStderr(), "The following keys in %s will be overwritten:\n", filepath.Base(envFile))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "The following keys in %s will be overwritten:\n", filepath.Base(envFile))
 		for _, k := range conflicts {
-			fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s -> %s\n", k, maskValue(k, current[k], false), maskValue(k, incoming[k], false))
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s -> %s\n", k, maskValue(k, current[k], false), maskValue(k, incoming[k], false))
 		}
-		fmt.Fprint(cmd.ErrOrStderr(), "Continue? [y/N] ")
+		_, _ = fmt.Fprint(cmd.ErrOrStderr(), "Continue? [y/N] ")
 		var response string
 		if _, scanErr := fmt.Scanln(&response); scanErr != nil || strings.ToLower(strings.TrimSpace(response)) != "y" {
-			fmt.Fprintln(cmd.ErrOrStderr(), "Import cancelled.")
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Import cancelled.")
 			return nil
 		}
 	}

--- a/cmd/commands/config_list_validate.go
+++ b/cmd/commands/config_list_validate.go
@@ -78,7 +78,7 @@ func runConfigValidate(cmd *cobra.Command, args []string) error {
 	// For validate, use the cascade loader so all defaults apply.
 	// Temporarily honour --env by setting ENV if provided.
 	if envFlag != "" {
-		os.Setenv("ENV", envFlag)
+		_ = os.Setenv("ENV", envFlag)
 	}
 
 	cfg, err := config.Load(projectDir)

--- a/cmd/commands/config_set.go
+++ b/cmd/commands/config_set.go
@@ -113,7 +113,7 @@ func setEnvFileLine(envFile, key, value string) (updated bool, err error) {
 	if openErr != nil {
 		return false, fmt.Errorf("opening %s: %w", envFile, openErr)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var lines []string
 	found := false
@@ -141,7 +141,7 @@ func setEnvFileLine(envFile, key, value string) (updated bool, err error) {
 	if scanErr := scanner.Err(); scanErr != nil {
 		return false, fmt.Errorf("scanning %s: %w", envFile, scanErr)
 	}
-	f.Close()
+	_ = f.Close()
 
 	if !found {
 		lines = append(lines, newLine)

--- a/cmd/commands/config_test.go
+++ b/cmd/commands/config_test.go
@@ -443,14 +443,14 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 	done := make(chan error, 1)
 	go func() {
 		_, copyErr := io.Copy(&buf, r)
-		r.Close()
+		_ = r.Close()
 		done <- copyErr
 	}()
 
 	old := os.Stdout
 	os.Stdout = w
 	fnErr := fn()
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 
 	if copyErr := <-done; copyErr != nil {

--- a/cmd/commands/controller.go
+++ b/cmd/commands/controller.go
@@ -65,7 +65,7 @@ func controllerEnabled() bool {
 // assertControllerEnabled prints the 503 message and returns false when the flag is off.
 func assertControllerEnabled(cmd *cobra.Command) bool {
 	if !controllerEnabled() {
-		fmt.Fprintln(cmd.ErrOrStderr(),
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
 			"503 Multi-tenant controller not enabled.\n"+
 				"Set NSELF_FLAG_MULTI_TENANT_CONTROLLER=true to enable.")
 		return false
@@ -96,7 +96,7 @@ func doControllerRequest(method, path string, body interface{}) ([]byte, int, er
 	if err != nil {
 		return nil, 0, fmt.Errorf("controller request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	return respBody, resp.StatusCode, nil

--- a/cmd/commands/controller_commands.go
+++ b/cmd/commands/controller_commands.go
@@ -43,8 +43,8 @@ var controllerStartCmd = &cobra.Command{
 		c.Stderr = cmd.ErrOrStderr()
 		if err := c.Run(); err != nil {
 			// Fallback for non-systemd environments.
-			fmt.Fprintln(cmd.OutOrStdout(), "Hint: run the controller binary directly:")
-			fmt.Fprintln(cmd.OutOrStdout(), "  NSELF_FLAG_MULTI_TENANT_CONTROLLER=true nself-tenant-controller &")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Hint: run the controller binary directly:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  NSELF_FLAG_MULTI_TENANT_CONTROLLER=true nself-tenant-controller &")
 		}
 		return nil
 	},
@@ -101,9 +101,9 @@ var controllerStatusCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-		fmt.Fprintf(w, "SLUG\tDOMAIN\tSTATUS\tCONNS\tSIZE\tHEALTHY\n")
+		_, _ = fmt.Fprintf(w, "SLUG\tDOMAIN\tSTATUS\tCONNS\tSIZE\tHEALTHY\n")
 		for _, p := range cs.Projects {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%v\n",
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%v\n",
 				p.Project.Slug,
 				p.Project.Domain,
 				p.Project.Status,
@@ -112,8 +112,8 @@ var controllerStatusCmd = &cobra.Command{
 				p.Healthy,
 			)
 		}
-		w.Flush()
-		fmt.Fprintf(cmd.OutOrStdout(), "\n%d / %d projects active (%.0f%% utilized)\n",
+		_ = w.Flush()
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\n%d / %d projects active (%.0f%% utilized)\n",
 			cs.TotalActive, cs.MaxProjects, cs.UtilizationPct)
 		return nil
 	},

--- a/cmd/commands/db_pitr_ops.go
+++ b/cmd/commands/db_pitr_ops.go
@@ -243,7 +243,7 @@ func runDBRestoreDrillList(_ *cobra.Command, _ []string) error {
 		}
 		return fmt.Errorf("open drill log: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	fmt.Printf("%-25s %-8s %-40s %-10s %-12s\n", "STARTED", "STATUS", "BACKUP FILE", "TABLES", "DURATION")
 

--- a/cmd/commands/db_remote.go
+++ b/cmd/commands/db_remote.go
@@ -271,7 +271,7 @@ func dispatchRemoteIfNeeded(cmd *cobra.Command, remoteArgs ...string) (handled b
 	}
 
 	if !cmd.Flags().Changed("json") {
-		fmt.Fprintf(cmd.OutOrStdout(), "Running 'nself %s' on %s:%s (env=%s)...\n", strings.Join(remoteArgs, " "), target.SSHTarget, target.RemotePath, target.EnvName)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Running 'nself %s' on %s:%s (env=%s)...\n", strings.Join(remoteArgs, " "), target.SSHTarget, target.RemotePath, target.EnvName)
 	}
 
 	return true, runRemoteNselfCommand(cmd.Context(), target, remoteArgs...)

--- a/cmd/commands/dispatch.go
+++ b/cmd/commands/dispatch.go
@@ -284,6 +284,6 @@ func reportProxyFailure(w io.Writer, err error) error {
 		return errs.Exit(code)
 	}
 
-	fmt.Fprintf(w, "Plugin error: %v\n", err)
+	_, _ = fmt.Fprintf(w, "Plugin error: %v\n", err)
 	return errs.Exit(1)
 }

--- a/cmd/commands/doctor_ai_client.go
+++ b/cmd/commands/doctor_ai_client.go
@@ -80,7 +80,7 @@ func aiPluginRequest(ctx context.Context, method, path string, body []byte) ([]b
 	if err != nil {
 		return nil, 0, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	// Capped read: this talks to a local daemon, but doctor must not be a way to
 	// exhaust memory if that daemon misbehaves.
 	b, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))

--- a/cmd/commands/doctor_ai_health.go
+++ b/cmd/commands/doctor_ai_health.go
@@ -25,7 +25,7 @@ func ollamaHealthy(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	return resp.StatusCode == 200
 }
 
@@ -42,7 +42,7 @@ func testLocalChat(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	return resp.StatusCode == 200
 }
 
@@ -59,7 +59,7 @@ func testLocalEmbed(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	return resp.StatusCode == 200
 }
 

--- a/cmd/commands/doctor_ai_output.go
+++ b/cmd/commands/doctor_ai_output.go
@@ -128,7 +128,7 @@ func getTotalMemoryMBFallback() (int, error) {
 			return 0, err
 		}
 		var bytes int64
-		fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &bytes)
+		_, _ = fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &bytes)
 		return int(bytes / 1024 / 1024), nil
 	default:
 		return installer.MemAvailableMB()

--- a/cmd/commands/doctor_checks_license.go
+++ b/cmd/commands/doctor_checks_license.go
@@ -130,7 +130,7 @@ func checkLicenseMigrationRate(verbose bool) doctorCheckResult {
 		}
 		return doctorCheckResult{Name: name, Status: "pass", Message: msg}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == 401 || resp.StatusCode == 403 {
 		// Endpoint exists but requires admin auth — skip (not an error for end-user).

--- a/cmd/commands/doctor_test.go
+++ b/cmd/commands/doctor_test.go
@@ -260,7 +260,7 @@ func captureDoctorStdout(t *testing.T, f func() error) (string, error) {
 	}()
 
 	ferr := f()
-	w.Close()
+	_ = w.Close()
 	out := <-done
 	return out, ferr
 }

--- a/cmd/commands/env_explain_test.go
+++ b/cmd/commands/env_explain_test.go
@@ -41,8 +41,8 @@ func TestEnvExplain_NoArgLists_Cascade(t *testing.T) {
 		".env":         "PROJECT_NAME=demo\n",
 		".env.secrets": "POSTGRES_PASSWORD=abc\n",
 	})
-	os.Unsetenv("ENV")
-	os.Unsetenv("NSELF_LEGACY_ENV_ORDER")
+	_ = os.Unsetenv("ENV")
+	_ = os.Unsetenv("NSELF_LEGACY_ENV_ORDER")
 
 	out, err := captureStdout(t, func() error {
 		return runEnvExplain(envExplainRoot(t), nil)
@@ -65,8 +65,8 @@ func TestEnvExplain_NoArgLists_Cascade(t *testing.T) {
 // warns about it.
 func TestEnvExplain_NoArgLegacyMode_ShowsWarning(t *testing.T) {
 	envExplainProject(t, map[string]string{".env": "X=1\n"})
-	os.Setenv("NSELF_LEGACY_ENV_ORDER", "1")
-	t.Cleanup(func() { os.Unsetenv("NSELF_LEGACY_ENV_ORDER") })
+	_ = os.Setenv("NSELF_LEGACY_ENV_ORDER", "1")
+	t.Cleanup(func() { _ = os.Unsetenv("NSELF_LEGACY_ENV_ORDER") })
 
 	out, err := captureStdout(t, func() error {
 		return runEnvExplain(envExplainRoot(t), nil)
@@ -89,8 +89,8 @@ func TestEnvExplain_VarArg_RedactsByDefault(t *testing.T) {
 		".env":         "API_KEY=secret-value\n",
 		".env.secrets": "API_KEY=different-secret-value\n",
 	})
-	os.Unsetenv("ENV")
-	os.Unsetenv("NSELF_LEGACY_ENV_ORDER")
+	_ = os.Unsetenv("ENV")
+	_ = os.Unsetenv("NSELF_LEGACY_ENV_ORDER")
 
 	out, err := captureStdout(t, func() error {
 		return runEnvExplain(envExplainRoot(t), []string{"API_KEY"})
@@ -112,8 +112,8 @@ func TestEnvExplain_VarArg_RevealShowsValue(t *testing.T) {
 	envExplainProject(t, map[string]string{
 		".env.local": "API_KEY=personal-secret\n",
 	})
-	os.Unsetenv("ENV")
-	os.Unsetenv("NSELF_LEGACY_ENV_ORDER")
+	_ = os.Unsetenv("ENV")
+	_ = os.Unsetenv("NSELF_LEGACY_ENV_ORDER")
 
 	root := envExplainRoot(t)
 	if err := root.Flags().Set("reveal", "true"); err != nil {
@@ -135,8 +135,8 @@ func TestEnvExplain_VarArg_RevealShowsValue(t *testing.T) {
 // cascade file gets a clear "not set" message instead of an error.
 func TestEnvExplain_VarArg_NotSetAnywhere(t *testing.T) {
 	envExplainProject(t, map[string]string{".env": "OTHER_VAR=1\n"})
-	os.Unsetenv("ENV")
-	os.Unsetenv("NSELF_LEGACY_ENV_ORDER")
+	_ = os.Unsetenv("ENV")
+	_ = os.Unsetenv("NSELF_LEGACY_ENV_ORDER")
 
 	out, err := captureStdout(t, func() error {
 		return runEnvExplain(envExplainRoot(t), []string{"MISSING_VAR"})

--- a/cmd/commands/env_target_crud.go
+++ b/cmd/commands/env_target_crud.go
@@ -88,7 +88,7 @@ func runEnvTargetList(cmd *cobra.Command, args []string) error {
 	}
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "ENV\tSERVER\tROLE\tHOST\tKEY-REF\tPRIMARY")
+	_, _ = fmt.Fprintln(tw, "ENV\tSERVER\tROLE\tHOST\tKEY-REF\tPRIMARY")
 	for _, r := range rows {
 		primary := ""
 		if r.Primary {
@@ -98,7 +98,7 @@ func runEnvTargetList(cmd *cobra.Command, args []string) error {
 		if host == "" {
 			host = "(local)"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			r.Env, r.Server, r.Role, host, r.SSHKeyRef, primary)
 	}
 	return tw.Flush()

--- a/cmd/commands/env_target_probe.go
+++ b/cmd/commands/env_target_probe.go
@@ -111,7 +111,7 @@ func runEnvTargetProbe(cmd *cobra.Command, args []string) error {
 	}
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "ENV\tSERVER\tCAPABILITY\tSSH\tDOCKER\tLATENCY\tREASON")
+	_, _ = fmt.Fprintln(tw, "ENV\tSERVER\tCAPABILITY\tSSH\tDOCKER\tLATENCY\tREASON")
 	for _, r := range rows {
 		ssh := boolMark(r.SSHReachable)
 		docker := boolMark(r.DockerOK)
@@ -119,7 +119,7 @@ func runEnvTargetProbe(cmd *cobra.Command, args []string) error {
 		if r.LatencyMS > 0 {
 			latency = fmt.Sprintf("%dms", r.LatencyMS)
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			r.Env, r.Server, r.Capability, ssh, docker, latency, r.Reason)
 	}
 	return tw.Flush()

--- a/cmd/commands/env_target_test.go
+++ b/cmd/commands/env_target_test.go
@@ -117,7 +117,7 @@ func TestEnvTargetList_JSON(t *testing.T) {
 	}
 
 	err := runEnvTargetList(cmd, nil)
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 
 	if err != nil {
@@ -337,7 +337,7 @@ func TestEnvTargetProbe_LocalEnv(t *testing.T) {
 	_ = cmd.Flags().Set("json", "true")
 
 	err := runEnvTargetProbe(cmd, []string{"local"})
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 
 	if err != nil {

--- a/cmd/commands/exec.go
+++ b/cmd/commands/exec.go
@@ -59,7 +59,7 @@ func runExec(cmd *cobra.Command, args []string) error {
 		Env:         envVars,
 	}
 
-	fmt.Fprintf(cmd.ErrOrStderr(), "Executing in %s: %v\n", service, command)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Executing in %s: %v\n", service, command)
 
 	if err := docker.Exec(cmd.Context(), service, command, opts); err != nil {
 		return fmt.Errorf("exec failed: %w", err)

--- a/cmd/commands/functions_deploy.go
+++ b/cmd/commands/functions_deploy.go
@@ -137,13 +137,13 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0640)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	_, err = io.Copy(out, in)
 	return err

--- a/cmd/commands/functions_invoke.go
+++ b/cmd/commands/functions_invoke.go
@@ -89,7 +89,7 @@ func runFunctionsInvoke(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invoking %s: %w", name, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/cmd/commands/functions_list.go
+++ b/cmd/commands/functions_list.go
@@ -122,7 +122,7 @@ func probeFunctionHealth(ctx context.Context, port int, name string) string {
 	if err != nil {
 		return "unreachable"
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode < 500 {
 		return "healthy"
 	}

--- a/cmd/commands/functions_test.go
+++ b/cmd/commands/functions_test.go
@@ -22,8 +22,8 @@ func TestFunctionsDeploy_CopiesFiles(t *testing.T) {
 
 	// Change into project dir so copyFile resolves correctly.
 	origDir, _ := os.Getwd()
-	t.Cleanup(func() { os.Chdir(origDir) })
-	os.Chdir(projectDir)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	_ = os.Chdir(projectDir)
 
 	destDir := filepath.Join(projectDir, "functions", "hello")
 	if err := os.MkdirAll(destDir, 0750); err != nil {
@@ -56,7 +56,7 @@ func TestFunctionsList_ScansDirectory(t *testing.T) {
 	}
 	// Create a non-directory entry — should be ignored.
 	f := filepath.Join(projectDir, "functions", "README.md")
-	os.WriteFile(f, []byte("docs"), 0640)
+	_ = os.WriteFile(f, []byte("docs"), 0640)
 
 	entries, err := os.ReadDir(filepath.Join(projectDir, "functions"))
 	if err != nil {

--- a/cmd/commands/health_handlers.go
+++ b/cmd/commands/health_handlers.go
@@ -55,7 +55,7 @@ func healthCheckRunE(cmd *cobra.Command, args []string) error {
 // Returns the config and the project working directory.
 func loadHealthConfig() (*config.Config, string, error) {
 	if healthEnv != "" {
-		os.Setenv("ENV", healthEnv)
+		_ = os.Setenv("ENV", healthEnv)
 	}
 	dir, err := os.Getwd()
 	if err != nil {

--- a/cmd/commands/init_templates.go
+++ b/cmd/commands/init_templates.go
@@ -161,7 +161,7 @@ func runInitMarketplaceTemplate(slug, destDir string, force, quiet bool) error {
 	if err != nil {
 		return fmt.Errorf("downloading template tarball: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("access denied for template %q — check your license key", slug)
@@ -201,7 +201,7 @@ func runInitMarketplaceTemplate(slug, destDir string, force, quiet bool) error {
 	if err != nil {
 		return fmt.Errorf("opening gzip stream: %w", err)
 	}
-	defer gr.Close()
+	defer func() { _ = gr.Close() }()
 
 	tr := tar.NewReader(gr)
 	for {
@@ -233,10 +233,10 @@ func runInitMarketplaceTemplate(slug, destDir string, force, quiet bool) error {
 				return fmt.Errorf("creating file %s: %w", target, createErr)
 			}
 			if _, copyErr := io.Copy(f, tr); copyErr != nil {
-				f.Close()
+				_ = f.Close()
 				return fmt.Errorf("writing file %s: %w", target, copyErr)
 			}
-			f.Close()
+			_ = f.Close()
 		}
 	}
 

--- a/cmd/commands/license_migrate_api.go
+++ b/cmd/commands/license_migrate_api.go
@@ -46,7 +46,7 @@ func sendMigrateRequest(ctx context.Context, licenseKey, accountID, pingURL stri
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -81,7 +81,7 @@ func fetchMigrationStatus(ctx context.Context, key string, pingURL string) (*mig
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -112,7 +112,7 @@ func fetchMigrationInfo(ctx context.Context, key string, pingURL string) (*migra
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/cmd/commands/license_validate.go
+++ b/cmd/commands/license_validate.go
@@ -48,12 +48,12 @@ var licenseValidateCmd = &cobra.Command{
 
 			masked := license.MaskKey(key)
 			if err != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "%s: validation failed: %v\n", masked, err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s: validation failed: %v\n", masked, err)
 				allValid = false
 			} else if valid {
 				fmt.Printf("%s: valid\n", masked)
 			} else {
-				fmt.Fprintf(cmd.ErrOrStderr(), "%s: invalid or expired\n", masked)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s: invalid or expired\n", masked)
 				allValid = false
 			}
 		}

--- a/cmd/commands/logs.go
+++ b/cmd/commands/logs.go
@@ -176,7 +176,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	psCmd.Dir = workdir
 	psOut, _ := psCmd.Output()
 	if len(bytes.TrimSpace(psOut)) == 0 {
-		fmt.Fprintln(cmd.ErrOrStderr(), "No containers found. Is the stack running? Try 'nself status' to check.")
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "No containers found. Is the stack running? Try 'nself status' to check.")
 		return fmt.Errorf("no containers found")
 	}
 

--- a/cmd/commands/logs_stream.go
+++ b/cmd/commands/logs_stream.go
@@ -48,10 +48,10 @@ func streamFilteredLogs(ctx context.Context, workdir string, composeArgs []strin
 		}
 		if opts.JSON {
 			jsonLine := logLineToJSON(filtered)
-			fmt.Fprintln(w, jsonLine)
+			_, _ = fmt.Fprintln(w, jsonLine)
 		} else {
 			formatted := formatLogLine(filtered, "", opts)
-			fmt.Fprintln(w, formatted)
+			_, _ = fmt.Fprintln(w, formatted)
 		}
 	}
 

--- a/cmd/commands/man.go
+++ b/cmd/commands/man.go
@@ -43,7 +43,7 @@ func runManGen(cmd *cobra.Command, _ []string) error {
 		}
 		count++
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Generated %d man page(s) in %s\n", count, manOutDir)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Generated %d man page(s) in %s\n", count, manOutDir)
 	return nil
 }
 
@@ -90,7 +90,7 @@ func writeManPage(dir string, c *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("creating %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	now := time.Now()
 	short := c.Short
@@ -103,30 +103,30 @@ func writeManPage(dir string, c *cobra.Command) error {
 	}
 
 	// Write a minimal groff/troff man page (section 1 — user commands).
-	fmt.Fprintf(f, ".TH %s 1 \"%s\" \"nself\" \"nself Manual\"\n", strings.ToUpper(name), now.Format("January 2006"))
-	fmt.Fprintf(f, ".SH NAME\n%s \\- %s\n", name, roffEscape(short))
-	fmt.Fprintf(f, ".SH SYNOPSIS\n.B %s\n", name)
+	_, _ = fmt.Fprintf(f, ".TH %s 1 \"%s\" \"nself\" \"nself Manual\"\n", strings.ToUpper(name), now.Format("January 2006"))
+	_, _ = fmt.Fprintf(f, ".SH NAME\n%s \\- %s\n", name, roffEscape(short))
+	_, _ = fmt.Fprintf(f, ".SH SYNOPSIS\n.B %s\n", name)
 
 	// Usage line (strip angle-bracket args for brevity).
 	usageLine := c.UseLine()
 	if usageLine != "" {
-		fmt.Fprintf(f, "[%s]\n", roffEscape(usageLine))
+		_, _ = fmt.Fprintf(f, "[%s]\n", roffEscape(usageLine))
 	}
 
-	fmt.Fprintf(f, ".SH DESCRIPTION\n%s\n", roffEscape(longDesc))
+	_, _ = fmt.Fprintf(f, ".SH DESCRIPTION\n%s\n", roffEscape(longDesc))
 
 	// Flags section.
 	flagUsages := c.Flags().FlagUsages()
 	if flagUsages != "" {
-		fmt.Fprintf(f, ".SH OPTIONS\n.nf\n%s\n.fi\n", roffEscape(flagUsages))
+		_, _ = fmt.Fprintf(f, ".SH OPTIONS\n.nf\n%s\n.fi\n", roffEscape(flagUsages))
 	}
 
 	// See also: parent command.
 	if p := c.Parent(); p != nil && p != RootCmd {
 		parentName := commandPath(p)
-		fmt.Fprintf(f, ".SH SEE ALSO\n.BR %s (1)\n", parentName)
+		_, _ = fmt.Fprintf(f, ".SH SEE ALSO\n.BR %s (1)\n", parentName)
 	} else if c != RootCmd {
-		fmt.Fprintf(f, ".SH SEE ALSO\n.BR nself (1)\n")
+		_, _ = fmt.Fprintf(f, ".SH SEE ALSO\n.BR nself (1)\n")
 	}
 
 	return nil

--- a/cmd/commands/mcp_tools_data.go
+++ b/cmd/commands/mcp_tools_data.go
@@ -66,7 +66,7 @@ func mcpPostJSON(ctx context.Context, url, adminSecret string, payload interface
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/cmd/commands/migrate.go
+++ b/cmd/commands/migrate.go
@@ -120,7 +120,7 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	if len(artifacts) == 0 {
 		ui.Success("No v1 artifacts detected. This project is ready for nSelf v2.")
 	} else {
-		fmt.Fprintf(cmd.ErrOrStderr(), "\n%s %s\n\n", ui.C(ui.Yellow, ui.IconWarning), ui.C(ui.Bold, "Legacy nSelf v1 artifacts detected:"))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "\n%s %s\n\n", ui.C(ui.Yellow, ui.IconWarning), ui.C(ui.Bold, "Legacy nSelf v1 artifacts detected:"))
 
 		tbl := ui.NewTable("Path", "Description", "Action")
 		for _, a := range artifacts {

--- a/cmd/commands/migrate_env_order.go
+++ b/cmd/commands/migrate_env_order.go
@@ -53,7 +53,7 @@ func printEnvOrderSummary(cmd *cobra.Command, report *migratebash.EnvOrderReport
 	}
 
 	if manual := report.ManualReviewCount(); manual > 0 {
-		fmt.Fprintf(cmd.ErrOrStderr(), "%s %s\n\n", ui.C(ui.Yellow, ui.IconWarning), ui.C(ui.Bold, fmt.Sprintf("%d variable(s) need your review:", manual)))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s %s\n\n", ui.C(ui.Yellow, ui.IconWarning), ui.C(ui.Bold, fmt.Sprintf("%d variable(s) need your review:", manual)))
 		for _, c := range report.Changes {
 			if c.Action != migratebash.ActionManualReview {
 				continue

--- a/cmd/commands/plugin_audit.go
+++ b/cmd/commands/plugin_audit.go
@@ -94,7 +94,7 @@ func runPluginAuditTables(cmd *cobra.Command, _ []string) error {
 // printAuditTable renders the audit report as a human-readable table.
 func printAuditTable(report *audit.AuditReport) {
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "TABLE\tSOURCE_ACCOUNT_ID\tHASURA_FILTER\tROW_COUNT\tWARNING")
+	_, _ = fmt.Fprintln(tw, "TABLE\tSOURCE_ACCOUNT_ID\tHASURA_FILTER\tROW_COUNT\tWARNING")
 	for _, t := range report.Tables {
 		hasCol := "yes"
 		if !t.HasSourceAccountID {
@@ -102,9 +102,9 @@ func printAuditTable(report *audit.AuditReport) {
 		}
 		filter := string(t.HasHasuraFilter)
 		warning := t.Warning
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n",
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n",
 			t.Table, hasCol, filter, t.TotalRows, warning)
 	}
-	tw.Flush()
+	_ = tw.Flush()
 	fmt.Printf("\nAudit completed at %s (%d tables)\n", report.AuditAt, len(report.Tables))
 }

--- a/cmd/commands/plugin_debug.go
+++ b/cmd/commands/plugin_debug.go
@@ -114,7 +114,7 @@ func resolveDebugPort(manual int) (int, error) {
 	for port := 2345; port <= 2399; port++ {
 		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 		if err == nil {
-			ln.Close()
+			_ = ln.Close()
 			return port, nil
 		}
 	}

--- a/cmd/commands/plugin_install_thirdparty.go
+++ b/cmd/commands/plugin_install_thirdparty.go
@@ -32,13 +32,13 @@ func confirmThirdPartyInstall(cmd *cobra.Command, sourceURL string, yes bool) er
 	}
 
 	out := cmd.ErrOrStderr()
-	fmt.Fprintf(out, "\nwarning: %s is a THIRD-PARTY plugin source (host: %s).\n", sourceURL, u.Host)
-	fmt.Fprintf(out, "  It is not part of the official nself plugin registry: its author is not\n")
-	fmt.Fprintf(out, "  vetted and its tarball is NOT signature-verified. Checksum is verified\n")
-	fmt.Fprintf(out, "  only if the plugin's own manifest declares one.\n")
+	_, _ = fmt.Fprintf(out, "\nwarning: %s is a THIRD-PARTY plugin source (host: %s).\n", sourceURL, u.Host)
+	_, _ = fmt.Fprintf(out, "  It is not part of the official nself plugin registry: its author is not\n")
+	_, _ = fmt.Fprintf(out, "  vetted and its tarball is NOT signature-verified. Checksum is verified\n")
+	_, _ = fmt.Fprintf(out, "  only if the plugin's own manifest declares one.\n")
 
 	if yes {
-		fmt.Fprintf(out, "  Proceeding without confirmation (--yes).\n")
+		_, _ = fmt.Fprintf(out, "  Proceeding without confirmation (--yes).\n")
 		return nil
 	}
 

--- a/cmd/commands/plugin_marketplace.go
+++ b/cmd/commands/plugin_marketplace.go
@@ -95,7 +95,7 @@ func fetchMarketplace(ctx context.Context, baseURL string, params url.Values) (*
 	if err != nil {
 		return nil, fmt.Errorf("fetching marketplace: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("marketplace API returned status %d", resp.StatusCode)

--- a/cmd/commands/plugin_outdated_test.go
+++ b/cmd/commands/plugin_outdated_test.go
@@ -54,7 +54,7 @@ func newOutdatedTestCmd(t *testing.T, jsonOut bool) (run func() error, stdout fu
 
 	run = func() error {
 		err := runPluginOutdated(cmd, nil)
-		w.Close()
+		_ = w.Close()
 		os.Stdout = origStdout
 		return err
 	}

--- a/cmd/commands/plugin_test.go
+++ b/cmd/commands/plugin_test.go
@@ -60,7 +60,7 @@ func TestPluginInstallSkipVerifyWithForceEmitsWarning(t *testing.T) {
 	// must have been emitted to stderr before that failure.
 	runPluginInstall(pluginInstallCmd, []string{"ai"}) //nolint:errcheck
 
-	w.Close()
+	_ = w.Close()
 	os.Stderr = origStderr
 	var buf strings.Builder
 	buf.Grow(512)

--- a/cmd/commands/project_cmd_core.go
+++ b/cmd/commands/project_cmd_core.go
@@ -43,7 +43,7 @@ var projectCreateCmd = &cobra.Command{
 			return fmt.Errorf("--domain is required")
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Creating project %q at %s...\n",
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Creating project %q at %s...\n",
 			projectCreateFlags.Slug, projectCreateFlags.Domain)
 
 		body, code, err := doControllerRequest("POST", "/projects/create", map[string]string{
@@ -68,7 +68,7 @@ var projectCreateCmd = &cobra.Command{
 			Status string `json:"status"`
 		}
 		_ = json.Unmarshal(body, &proj)
-		fmt.Fprintf(cmd.OutOrStdout(), "Project ready: https://%s (id: %s)\n", proj.Domain, proj.ID)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Project ready: https://%s (id: %s)\n", proj.Domain, proj.ID)
 		return nil
 	},
 }
@@ -105,7 +105,7 @@ var projectDeleteCmd = &cobra.Command{
 			return fmt.Errorf("delete failed (%d): %s", code, e.Error)
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Project %q deleted.\n", projectDeleteFlags.Slug)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Project %q deleted.\n", projectDeleteFlags.Slug)
 		return nil
 	},
 }

--- a/cmd/commands/project_cmd_ops.go
+++ b/cmd/commands/project_cmd_ops.go
@@ -42,11 +42,11 @@ var projectListCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-		fmt.Fprintf(w, "SLUG\tDOMAIN\tSTATUS\tCREATED\n")
+		_, _ = fmt.Fprintf(w, "SLUG\tDOMAIN\tSTATUS\tCREATED\n")
 		for _, p := range projects {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Slug, p.Domain, p.Status, p.CreatedAt)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Slug, p.Domain, p.Status, p.CreatedAt)
 		}
-		w.Flush()
+		_ = w.Flush()
 		return nil
 	},
 }
@@ -72,7 +72,7 @@ var projectStatusCmd = &cobra.Command{
 		if code != http.StatusOK {
 			return fmt.Errorf("status failed (%d): %s", code, body)
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), string(body))
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
 		return nil
 	},
 }
@@ -91,8 +91,8 @@ var projectMigrateCmd = &cobra.Command{
 		if projectMigrateFlags.Slug == "" {
 			return fmt.Errorf("--slug is required")
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Migration for project %q is handled by 'nself deploy' targeting the project schema.\n", projectMigrateFlags.Slug)
-		fmt.Fprintln(cmd.OutOrStdout(), "Use: NSELF_PROJECT_SLUG="+projectMigrateFlags.Slug+" nself deploy")
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Migration for project %q is handled by 'nself deploy' targeting the project schema.\n", projectMigrateFlags.Slug)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Use: NSELF_PROJECT_SLUG="+projectMigrateFlags.Slug+" nself deploy")
 		return nil
 	},
 }
@@ -118,7 +118,7 @@ var projectShellCmd = &cobra.Command{
 		schemaName := "project_" + projectShellFlags.Slug
 		roleName := "nself_project_" + projectShellFlags.Slug
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Opening psql as role %s (schema: %s)...\n", roleName, schemaName)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Opening psql as role %s (schema: %s)...\n", roleName, schemaName)
 		c := exec.Command("psql",
 			"-U", roleName,
 			"-d", "nself",
@@ -145,8 +145,8 @@ var projectRotateCredsCmd = &cobra.Command{
 		if projectRotateCredsFlags.Slug == "" {
 			return fmt.Errorf("--slug is required")
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "Credential rotation is dispatched to the controller daemon.")
-		fmt.Fprintln(cmd.OutOrStdout(), "This feature is available in the controller HTTP API: POST /projects/"+projectRotateCredsFlags.Slug+"/rotate-credentials")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Credential rotation is dispatched to the controller daemon.")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "This feature is available in the controller HTTP API: POST /projects/"+projectRotateCredsFlags.Slug+"/rotate-credentials")
 		return nil
 	},
 }

--- a/cmd/commands/secrets_edit_rotate.go
+++ b/cmd/commands/secrets_edit_rotate.go
@@ -48,12 +48,12 @@ var secretsEditCmd = &cobra.Command{
 			return err
 		}
 		tmpPath := tmpFile.Name()
-		defer os.Remove(tmpPath)
+		defer func() { _ = os.Remove(tmpPath) }()
 
 		if _, err := tmpFile.WriteString(strings.Join(lines, "\n") + "\n"); err != nil {
 			return err
 		}
-		tmpFile.Close()
+		_ = tmpFile.Close()
 
 		// Open editor.
 		c := exec.Command(editor, tmpPath)

--- a/cmd/commands/security_checks_certs_keys.go
+++ b/cmd/commands/security_checks_certs_keys.go
@@ -60,7 +60,7 @@ func checkKeyRotationAge() finding {
 				if strings.HasPrefix(lower, prefix) {
 					dateStr := strings.TrimSpace(line[len(prefix):])
 					t, parseErr := time.Parse("2006-01-02", dateStr)
-					f.Close()
+					_ = f.Close()
 					if parseErr != nil {
 						return finding{Name: "Key rotation age", OK: true, Detail: "last-rotated header unparseable (skipped)"}
 					}
@@ -74,7 +74,7 @@ func checkKeyRotationAge() finding {
 				}
 			}
 		}
-		f.Close()
+		_ = f.Close()
 	}
 	return finding{Name: "Key rotation age", OK: true, Detail: "no last-rotated header found (skipped)"}
 }
@@ -85,13 +85,13 @@ func checkAdminPortBinding() finding {
 	ln, err := net.Listen("tcp", "127.0.0.1:3021")
 	if err == nil {
 		// Port is free — admin is not running.
-		ln.Close()
+		_ = ln.Close()
 		return finding{Name: "Admin port (3021)", OK: true, Detail: "admin not running on port 3021"}
 	}
 	// Port is in use. Check whether it's world-accessible by trying 0.0.0.0.
 	conn, connErr := net.DialTimeout("tcp", "0.0.0.0:3021", 500*time.Millisecond)
 	if connErr == nil {
-		conn.Close()
+		_ = conn.Close()
 		return finding{Name: "Admin port (3021)", OK: false,
 			Detail: "admin port bound on 0.0.0.0 — should be 127.0.0.1 only"}
 	}
@@ -117,12 +117,12 @@ func checkCSRFGuard() finding {
 			if strings.HasPrefix(upper, "CSRF_DISABLED=TRUE") ||
 				strings.HasPrefix(upper, "CSRF_DISABLED=1") ||
 				strings.HasPrefix(upper, "CSRF_DISABLED=YES") {
-				f.Close()
+				_ = f.Close()
 				return finding{Name: "CSRF guard", OK: false,
 					Detail: fmt.Sprintf("CSRF_DISABLED is set in %s — remove to enable CSRF protection", p)}
 			}
 		}
-		f.Close()
+		_ = f.Close()
 	}
 	return finding{Name: "CSRF guard", OK: true, Detail: "no CSRF_DISABLED flag found"}
 }

--- a/cmd/commands/security_checks_system.go
+++ b/cmd/commands/security_checks_system.go
@@ -75,7 +75,7 @@ func checkSSHConfig() finding {
 	if err != nil {
 		return finding{Name: "SSH password auth", OK: true, Detail: "sshd_config not readable (skipped)"}
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -98,7 +98,7 @@ func checkRootLogin() finding {
 	if err != nil {
 		return finding{Name: "SSH root login", OK: true, Detail: "sshd_config not readable (skipped)"}
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/cmd/commands/service.go
+++ b/cmd/commands/service.go
@@ -247,7 +247,7 @@ func init() {
 	// service add flags
 	serviceAddCmd.Flags().String("template", "go", "Service template: go, node, python, static, rust, other")
 	serviceAddCmd.Flags().String("lang", "", "Alias for --template (deprecated, use --template)")
-	serviceAddCmd.Flags().MarkHidden("lang")
+	_ = serviceAddCmd.Flags().MarkHidden("lang")
 	serviceAddCmd.Flags().Bool("force", false, "Overwrite existing service directory")
 	serviceAddCmd.Flags().Bool("dry-run", false, "Print what would be done without writing files")
 

--- a/cmd/commands/service_add_upgrade.go
+++ b/cmd/commands/service_add_upgrade.go
@@ -232,7 +232,7 @@ func setEnvKeyInFile(filename, key, value string) error {
 		for scanner.Scan() {
 			lines = append(lines, scanner.Text())
 		}
-		f.Close()
+		_ = f.Close()
 		if err := scanner.Err(); err != nil {
 			return fmt.Errorf("reading %s: %w", filename, err)
 		}

--- a/cmd/commands/service_enable_disable.go
+++ b/cmd/commands/service_enable_disable.go
@@ -80,7 +80,7 @@ func runServiceDisable(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "Warning: the following services depend on %s: %s\n", canonName, strings.Join(activeDeps, ", "))
 			fmt.Fprint(os.Stderr, "Continue? [y/N] ")
 			var response string
-			fmt.Scanln(&response)
+			_, _ = fmt.Scanln(&response)
 			if strings.ToLower(strings.TrimSpace(response)) != "y" {
 				fmt.Fprintln(os.Stderr, "Aborted.")
 				return nil

--- a/cmd/commands/service_lifecycle.go
+++ b/cmd/commands/service_lifecycle.go
@@ -49,9 +49,9 @@ func runServicePs(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tSERVICE\tSTATUS\tHEALTH\tID")
+	_, _ = fmt.Fprintln(w, "NAME\tSERVICE\tSTATUS\tHEALTH\tID")
 	for _, e := range entries {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			e.Name, e.Service, e.Status, e.Health, e.ID)
 	}
 	return w.Flush()

--- a/cmd/commands/ssl.go
+++ b/cmd/commands/ssl.go
@@ -71,7 +71,7 @@ func checkDomainTLS(domain string, timeout time.Duration) (*x509.Certificate, er
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	certs := conn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
 		return nil, fmt.Errorf("no certificates returned")

--- a/cmd/commands/telemetry_test.go
+++ b/cmd/commands/telemetry_test.go
@@ -26,7 +26,7 @@ func setupTelemetryTestHome(t *testing.T) (homeDir string, cleanup func()) {
 func TestTelemetryStatusShowsCorrectState(t *testing.T) {
 	_, cleanup := setupTelemetryTestHome(t)
 	defer cleanup()
-	os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
+	_ = os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
 
 	// Default: enabled from default source
 	pref := config.GetTelemetryPreference()
@@ -42,7 +42,7 @@ func TestTelemetryStatusShowsCorrectState(t *testing.T) {
 func TestTelemetryOffPersistsPreference(t *testing.T) {
 	homeDir, cleanup := setupTelemetryTestHome(t)
 	defer cleanup()
-	os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
+	_ = os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
 
 	if err := config.SetTelemetryEnabled(false); err != nil {
 		t.Fatalf("SetTelemetryEnabled(false) failed: %v", err)

--- a/cmd/commands/template_publish_update.go
+++ b/cmd/commands/template_publish_update.go
@@ -66,7 +66,7 @@ func runTemplatePublish(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("opening tarball: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {

--- a/cmd/commands/template_registry.go
+++ b/cmd/commands/template_registry.go
@@ -51,7 +51,7 @@ func fetchTemplateList(ctx context.Context, baseURL string, params url.Values) (
 	if err != nil {
 		return nil, fmt.Errorf("fetching template registry: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("template not found")
@@ -86,7 +86,7 @@ func fetchTemplateSingle(ctx context.Context, baseURL, slug string) (*templateEn
 	if err != nil {
 		return nil, fmt.Errorf("fetching template %q: %w", slug, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("template %q not found in registry", slug)

--- a/cmd/commands/uninstall.go
+++ b/cmd/commands/uninstall.go
@@ -144,7 +144,7 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 
 	steps.Next() // Stopping containers
 	if err := runDockerComposeDown(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), cwd, purge); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "  %s docker compose down: %v (continuing)\n",
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  %s docker compose down: %v (continuing)\n",
 			ui.C(ui.Yellow, ui.IconWarning), err)
 	}
 
@@ -200,7 +200,7 @@ func runDockerComposeDown(ctx context.Context, stdout, stderr io.Writer, project
 // This allows tests to inject a closed reader (EOF) via root.SetIn() rather
 // than blocking forever on the real os.Stdin.
 func confirmPrompt(cmd *cobra.Command, prompt string) bool {
-	fmt.Fprint(cmd.OutOrStdout(), prompt)
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), prompt)
 	scanner := bufio.NewScanner(cmd.InOrStdin())
 	if !scanner.Scan() {
 		return false

--- a/cmd/commands/update_binary_ops.go
+++ b/cmd/commands/update_binary_ops.go
@@ -32,13 +32,13 @@ func copyAndReplace(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("creating temp file in %s: %w", dir, err)
 	}
-	defer os.Remove(tmpDst.Name())
+	defer func() { _ = os.Remove(tmpDst.Name()) }()
 
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("opening source binary: %w", err)
 	}
-	defer srcFile.Close()
+	defer func() { _ = srcFile.Close() }()
 
 	if _, err := io.Copy(tmpDst, srcFile); err != nil {
 		return fmt.Errorf("copying binary data: %w", err)
@@ -63,7 +63,7 @@ func fetchExpectedChecksum(checksumURL, filename string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("checksum file returned HTTP %d", resp.StatusCode)
@@ -100,7 +100,7 @@ func downloadFile(url string, dst io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("server returned HTTP %d", resp.StatusCode)
@@ -133,7 +133,7 @@ func extractBinary(r io.Reader, binaryName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("creating gzip reader: %w", err)
 	}
-	defer gr.Close()
+	defer func() { _ = gr.Close() }()
 
 	tr := tar.NewReader(gr)
 	for {
@@ -157,12 +157,12 @@ func extractBinary(r io.Reader, binaryName string) (string, error) {
 			return "", fmt.Errorf("creating temp file for binary: %w", err)
 		}
 		if _, err := io.Copy(tmpFile, tr); err != nil {
-			tmpFile.Close()
-			os.Remove(tmpFile.Name())
+			_ = tmpFile.Close()
+			_ = os.Remove(tmpFile.Name())
 			return "", fmt.Errorf("extracting binary data: %w", err)
 		}
 		if err := tmpFile.Close(); err != nil {
-			os.Remove(tmpFile.Name())
+			_ = os.Remove(tmpFile.Name())
 			return "", fmt.Errorf("closing extracted binary: %w", err)
 		}
 		return tmpFile.Name(), nil

--- a/cmd/commands/update_release_api.go
+++ b/cmd/commands/update_release_api.go
@@ -40,7 +40,7 @@ func fetchReleaseFromURL(apiURL string) (tag string, htmlURL string, err error) 
 	if err != nil {
 		return "", "", fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
@@ -95,7 +95,7 @@ func fetchMigrationGuideURL(currentVersion string) string {
 	if err != nil {
 		return ""
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return ""
 	}

--- a/cmd/commands/update_selfupdate.go
+++ b/cmd/commands/update_selfupdate.go
@@ -64,8 +64,8 @@ func selfUpdateFromURLInner(binaryURL, expectedSum string) error {
 	if err != nil {
 		return fmt.Errorf("creating temp file: %w", err)
 	}
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	defer func() { _ = tmpFile.Close() }()
 
 	if err := downloadFile(binaryURL, tmpFile); err != nil {
 		return fmt.Errorf("downloading %s: %w", binaryURL, err)
@@ -91,7 +91,7 @@ func selfUpdateFromURLInner(binaryURL, expectedSum string) error {
 		if err != nil {
 			return fmt.Errorf("extracting binary from archive: %w", err)
 		}
-		defer os.Remove(extracted)
+		defer func() { _ = os.Remove(extracted) }()
 		tmpBinary = extracted
 	} else {
 		// Raw binary: copy to a new temp file so we can chmod it independently.
@@ -99,9 +99,9 @@ func selfUpdateFromURLInner(binaryURL, expectedSum string) error {
 		if err != nil {
 			return fmt.Errorf("creating raw binary temp file: %w", err)
 		}
-		defer os.Remove(rawTmp.Name())
+		defer func() { _ = os.Remove(rawTmp.Name()) }()
 		if _, err := io.Copy(rawTmp, tmpFile); err != nil {
-			rawTmp.Close()
+			_ = rawTmp.Close()
 			return fmt.Errorf("copying binary data: %w", err)
 		}
 		if err := rawTmp.Close(); err != nil {
@@ -165,8 +165,8 @@ func selfUpdate(tag string) error {
 	if err != nil {
 		return fmt.Errorf("creating temp file: %w", err)
 	}
-	defer os.Remove(tmpArchive.Name())
-	defer tmpArchive.Close()
+	defer func() { _ = os.Remove(tmpArchive.Name()) }()
+	defer func() { _ = tmpArchive.Close() }()
 
 	if err := downloadFile(archiveURL, tmpArchive); err != nil {
 		return fmt.Errorf("downloading %s: %w", archiveURL, err)
@@ -188,7 +188,7 @@ func selfUpdate(tag string) error {
 	if err != nil {
 		return fmt.Errorf("extracting binary from archive: %w", err)
 	}
-	defer os.Remove(tmpBinary)
+	defer func() { _ = os.Remove(tmpBinary) }()
 
 	// Determine the path of the running executable.
 	exePath, err := os.Executable()

--- a/cmd/commands/upgrade_test.go
+++ b/cmd/commands/upgrade_test.go
@@ -29,8 +29,8 @@ func makeTarGzArchive(t *testing.T, binaryName string, content []byte) []byte {
 	if err != nil {
 		t.Fatalf("creating temp archive: %v", err)
 	}
-	defer os.Remove(tmp.Name())
-	defer tmp.Close()
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	defer func() { _ = tmp.Close() }()
 
 	gw := gzip.NewWriter(tmp)
 	tw := tar.NewWriter(gw)
@@ -427,7 +427,7 @@ func TestSelfUpdateFromURLWithSHA(t *testing.T) {
 			return
 		}
 		if strings.HasSuffix(r.URL.Path, ".tar.gz") {
-			w.Write(archive)
+			_, _ = w.Write(archive)
 			return
 		}
 		http.NotFound(w, r)

--- a/cmd/commands/verify_sbom.go
+++ b/cmd/commands/verify_sbom.go
@@ -61,7 +61,7 @@ func runVerifySBOM(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating temp dir: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	sbomPath := filepath.Join(tmpDir, sbomFile)
 	bundlePath := filepath.Join(tmpDir, bundleFile)
@@ -101,7 +101,7 @@ func sbomDownloadFile(ctx context.Context, url, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, url)
 	}
@@ -109,7 +109,7 @@ func sbomDownloadFile(ctx context.Context, url, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, err = io.Copy(f, resp.Body)
 	return err
 }

--- a/cmd/commands/version_bench_test.go
+++ b/cmd/commands/version_bench_test.go
@@ -130,6 +130,6 @@ func emitBenchmarkResult(name string, b *testing.B) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, _ = f.Write(append(data, '\n'))
 }

--- a/cmd/nself-backup-archive/main.go
+++ b/cmd/nself-backup-archive/main.go
@@ -72,6 +72,6 @@ func logFailure(walPath string, err error) {
 	if ferr != nil {
 		return
 	}
-	defer f.Close()
-	fmt.Fprintf(f, "%s FAIL %s: %v\n", time.Now().Format(time.RFC3339), walPath, err)
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "%s FAIL %s: %v\n", time.Now().Format(time.RFC3339), walPath, err)
 }

--- a/internal/access/audit.go
+++ b/internal/access/audit.go
@@ -64,7 +64,7 @@ func writeAudit(r auditRecord) error {
 	if err != nil {
 		return fmt.Errorf("open audit log: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	line := fmt.Sprintf("ts=%s action=%s host=%s user=%s fingerprint=%s sudo=%t docker=%t",
 		time.Now().UTC().Format(time.RFC3339),

--- a/internal/admin/connect.go
+++ b/internal/admin/connect.go
@@ -137,7 +137,7 @@ func BootstrapSession(localPort int, token string) error {
 	if err != nil {
 		return fmt.Errorf("bootstrap session: POST %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("bootstrap session: server returned %d", resp.StatusCode)

--- a/internal/audit/event_log.go
+++ b/internal/audit/event_log.go
@@ -65,7 +65,7 @@ func Write(event string, fields map[string]string) error {
 	if err != nil {
 		return fmt.Errorf("audit: opening log %s: %w", logPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := f.Write(line); err != nil {
 		return fmt.Errorf("audit: writing to log %s: %w", logPath, err)

--- a/internal/audit/event_log_test.go
+++ b/internal/audit/event_log_test.go
@@ -47,7 +47,7 @@ func TestWrite_CreatesFileWith0600(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open audit.log: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	sc := bufio.NewScanner(f)
 	if !sc.Scan() {
@@ -93,7 +93,7 @@ func TestWrite_AppendsMultipleEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	lineCount := 0
 	sc := bufio.NewScanner(f)

--- a/internal/audit/table_audit.go
+++ b/internal/audit/table_audit.go
@@ -91,7 +91,7 @@ func RunTableAuditWithConfig(ctx context.Context, cfg AuditConfig) (*AuditReport
 	if err != nil {
 		return nil, fmt.Errorf("open DB: %w", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	auditCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -157,7 +157,7 @@ func listNPTables(ctx context.Context, db *sql.DB) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list np_* tables: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var names []string
 	for rows.Next() {

--- a/internal/audit/table_audit_hasura.go
+++ b/internal/audit/table_audit_hasura.go
@@ -45,7 +45,7 @@ func auditTable(ctx context.Context, db *sql.DB, table string) (TableAuditResult
 	if err != nil {
 		return result, fmt.Errorf("aggregate %s by source_account_id: %w", table, err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	result.Accounts = make(map[string]int64)
 	for rows.Next() {

--- a/internal/auth/auth_coverage_test.go
+++ b/internal/auth/auth_coverage_test.go
@@ -230,7 +230,7 @@ func TestWriteRotationLog_OpenFileFail(t *testing.T) {
 	if err := os.Chmod(logDir, 0555); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}
-	t.Cleanup(func() { os.Chmod(logDir, 0755) })
+	t.Cleanup(func() { _ = os.Chmod(logDir, 0755) })
 
 	logPath := filepath.Join(logDir, "jwt-rotation.log")
 	t.Setenv("NSELF_JWT_ROTATION_LOG", logPath)
@@ -351,7 +351,7 @@ func TestWriteAuthFile_WriteFileFail(t *testing.T) {
 	if err := os.Chmod(nselfDir, 0555); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}
-	t.Cleanup(func() { os.Chmod(nselfDir, 0755) })
+	t.Cleanup(func() { _ = os.Chmod(nselfDir, 0755) })
 
 	err := WriteAuthFile(&AuthFile{AccessToken: "tok", SessionToken: "sess", Email: "x@x.com", Tier: "free"})
 	if err == nil {

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -104,7 +104,7 @@ func DeviceAuthorize(ctx context.Context) (*DeviceCodeResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("contacting auth server: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return nil, parseAPIError(resp)
@@ -134,7 +134,7 @@ func PollToken(ctx context.Context, deviceCode string) (*TokenResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("polling token: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// authorization_pending → user hasn't clicked "Authorize" yet
 	if resp.StatusCode == http.StatusAccepted {
@@ -166,7 +166,7 @@ func RefreshToken(ctx context.Context, accessToken string) (*TokenResponse, erro
 	if err != nil {
 		return nil, fmt.Errorf("refreshing token: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, parseAPIError(resp)
@@ -197,7 +197,7 @@ func RevokeSession(ctx context.Context, accessToken string, all bool) error {
 	if err != nil {
 		return fmt.Errorf("revoking session: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return parseAPIError(resp)
@@ -220,7 +220,7 @@ func GetSession(ctx context.Context, accessToken string) (*AccountInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting session: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, ErrNotLoggedIn
@@ -252,7 +252,7 @@ func GetLicenses(ctx context.Context, accessToken string) ([]LicenseInfo, error)
 	if err != nil {
 		return nil, fmt.Errorf("getting licenses: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, parseAPIError(resp)

--- a/internal/auth/client_devices.go
+++ b/internal/auth/client_devices.go
@@ -39,7 +39,7 @@ func GetDevices(ctx context.Context, accessToken string) ([]DeviceEntry, error) 
 	if err != nil {
 		return nil, fmt.Errorf("getting devices: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, parseAPIError(resp)
 	}
@@ -66,7 +66,7 @@ func RevokeDevice(ctx context.Context, accessToken, deviceID string) error {
 	if err != nil {
 		return fmt.Errorf("revoking device: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		return parseAPIError(resp)
 	}
@@ -90,7 +90,7 @@ func TransferLicense(ctx context.Context, accessToken, licenseID, toEmail string
 	if err != nil {
 		return fmt.Errorf("transferring license: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return parseAPIError(resp)
 	}

--- a/internal/auth/client_team.go
+++ b/internal/auth/client_team.go
@@ -36,7 +36,7 @@ func GetTeamMembers(ctx context.Context, accessToken string) ([]TeamMember, erro
 	if err != nil {
 		return nil, fmt.Errorf("getting team: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, parseAPIError(resp)
@@ -66,7 +66,7 @@ func InviteTeamMember(ctx context.Context, accessToken, email string) error {
 	if err != nil {
 		return fmt.Errorf("inviting team member: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return parseAPIError(resp)
 	}
@@ -86,7 +86,7 @@ func RemoveTeamMember(ctx context.Context, accessToken, email string) error {
 	if err != nil {
 		return fmt.Errorf("removing team member: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		return parseAPIError(resp)
 	}
@@ -108,7 +108,7 @@ func SetTeamMemberRole(ctx context.Context, accessToken, email, role string) err
 	if err != nil {
 		return fmt.Errorf("setting team member role: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return parseAPIError(resp)
 	}
@@ -130,7 +130,7 @@ func ActivateLicense(ctx context.Context, accessToken, licenseID string) error {
 	if err != nil {
 		return fmt.Errorf("activating license: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return parseAPIError(resp)
 	}

--- a/internal/auth/jwt_rotation.go
+++ b/internal/auth/jwt_rotation.go
@@ -57,8 +57,8 @@ func RotationLogPath() string {
 		// Directory exists; check write permission via O_WRONLY probe.
 		probe := filepath.Join(primaryDir, ".nself-write-probe")
 		if f, err := os.OpenFile(probe, os.O_CREATE|os.O_WRONLY, 0o600); err == nil {
-			f.Close()
-			os.Remove(probe)
+			_ = f.Close()
+			_ = os.Remove(probe)
 			return DefaultRotationLogPath
 		}
 	}
@@ -220,7 +220,7 @@ func writeRotationLog(entry string) error {
 	if err != nil {
 		return fmt.Errorf("open rotation log: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Acquire an exclusive advisory lock before writing so concurrent calls
 	// cannot produce torn (interleaved) log lines. lockExclusive is a per-OS

--- a/internal/backup/archive.go
+++ b/internal/backup/archive.go
@@ -54,7 +54,7 @@ func ArchiveWAL(ctx context.Context, opts ArchiveWALOptions) error {
 			return fmt.Errorf("%w: age encrypt failed: %s", errs.ErrWALArchiveFailed, string(output))
 		}
 		uploadPath = encPath
-		defer os.Remove(encPath)
+		defer func() { _ = os.Remove(encPath) }()
 		walBase = walBase + ".age"
 	}
 

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -16,7 +16,7 @@ func TestValidateBackupPath_Valid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp dir: %v", err)
 	}
-	defer os.RemoveAll(backupDir)
+	defer func() { _ = os.RemoveAll(backupDir) }()
 
 	got, err := ValidateBackupPath(backupDir, "data.dump")
 	if err != nil {
@@ -41,7 +41,7 @@ func TestValidateBackupPath_PathTraversal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp dir: %v", err)
 	}
-	defer os.RemoveAll(backupDir)
+	defer func() { _ = os.RemoveAll(backupDir) }()
 
 	_, err = ValidateBackupPath(backupDir, "../../etc/passwd")
 	if err == nil {
@@ -61,13 +61,13 @@ func TestValidateBackupPath_Symlink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create backup temp dir: %v", err)
 	}
-	defer os.RemoveAll(backupDir)
+	defer func() { _ = os.RemoveAll(backupDir) }()
 
 	evilDir, err := os.MkdirTemp("", "evil-*")
 	if err != nil {
 		t.Fatalf("create evil temp dir: %v", err)
 	}
-	defer os.RemoveAll(evilDir)
+	defer func() { _ = os.RemoveAll(evilDir) }()
 
 	// Create a symlink named "safe-link" inside backupDir that points outside.
 	linkPath := filepath.Join(backupDir, "safe-link")
@@ -110,7 +110,7 @@ func TestListBackups_MultipleFiles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("create file %s: %v", name, err)
 		}
-		f.Close()
+		_ = f.Close()
 	}
 
 	// Also create a subdirectory — it must NOT appear in the result.
@@ -255,7 +255,7 @@ func TestValidateBackupPath_ValidSubdir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp dir: %v", err)
 	}
-	defer os.RemoveAll(backupDir)
+	defer func() { _ = os.RemoveAll(backupDir) }()
 
 	subdir := filepath.Join(backupDir, "2024", "monthly")
 	if err := os.MkdirAll(subdir, 0o755); err != nil {

--- a/internal/backup/create_targets.go
+++ b/internal/backup/create_targets.go
@@ -71,7 +71,7 @@ func createFullBackup(ctx context.Context, cfg *config.Config, backupDir, ts, ta
 		_ = cmd.Wait()
 		return fmt.Errorf("create backup file %s: %w", outputPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := io.Copy(f, stdout); err != nil {
 		_ = cmd.Process.Kill()

--- a/internal/backup/embedded.go
+++ b/internal/backup/embedded.go
@@ -184,7 +184,7 @@ func backupEmbeddedSQL(ctx context.Context, cfg *config.Config, backupDir, ts st
 	header := fmt.Sprintf("-- nself embedded-pg SQL dump\n-- timestamp: %s\n-- tables: %d\n\n",
 		ts, len(tables))
 	if _, err := fmt.Fprint(f, header); err != nil {
-		f.Close()
+		_ = f.Close()
 		_ = os.Remove(tmpPath)
 		return nil, fmt.Errorf("write backup header: %w", err)
 	}
@@ -203,7 +203,7 @@ func backupEmbeddedSQL(ctx context.Context, cfg *config.Config, backupDir, ts st
 
 		// Write the COPY-FROM form for restore compatibility.
 		if _, err := fmt.Fprintf(f, "-- table: %s\n%s\n", table, copyIn); err != nil {
-			f.Close()
+			_ = f.Close()
 			_ = os.Remove(tmpPath)
 			return nil, fmt.Errorf("write table header for %s: %w", table, err)
 		}

--- a/internal/backup/hasura_metadata.go
+++ b/internal/backup/hasura_metadata.go
@@ -95,7 +95,7 @@ func exportMetadata(ctx context.Context, hasuraURL, adminSecret string) ([]byte,
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/backup/list_test.go
+++ b/internal/backup/list_test.go
@@ -53,7 +53,7 @@ func TestValidateBackupPath_AbsoluteUserPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp dir: %v", err)
 	}
-	defer os.RemoveAll(backupDir)
+	defer func() { _ = os.RemoveAll(backupDir) }()
 
 	absPath := filepath.Join(backupDir, "subdir", "file.dump")
 	got, err := ValidateBackupPath(backupDir, absPath)
@@ -75,7 +75,7 @@ func TestValidateBackupPath_DotDotMiddle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp dir: %v", err)
 	}
-	defer os.RemoveAll(backupDir)
+	defer func() { _ = os.RemoveAll(backupDir) }()
 
 	// Create the "valid" subdirectory so the traversal starts realistically.
 	os.MkdirAll(filepath.Join(backupDir, "valid"), 0755) //nolint:errcheck
@@ -93,7 +93,7 @@ func TestValidateBackupPath_NestedValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp dir: %v", err)
 	}
-	defer os.RemoveAll(backupDir)
+	defer func() { _ = os.RemoveAll(backupDir) }()
 
 	os.MkdirAll(filepath.Join(backupDir, "2026", "04"), 0755) //nolint:errcheck
 
@@ -113,7 +113,7 @@ func TestValidateBackupPath_EmptyUserPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create temp dir: %v", err)
 	}
-	defer os.RemoveAll(backupDir)
+	defer func() { _ = os.RemoveAll(backupDir) }()
 
 	// Empty path resolves to backupDir — this is the base, which is allowed.
 	_, err = ValidateBackupPath(backupDir, "")

--- a/internal/backup/prune_format.go
+++ b/internal/backup/prune_format.go
@@ -34,7 +34,7 @@ func FormatPruneJSON(result *PruneResult, keepDaily int) error {
 	if err != nil {
 		return fmt.Errorf("marshal prune report: %w", err)
 	}
-	fmt.Fprintln(os.Stdout, string(data))
+	_, _ = fmt.Fprintln(os.Stdout, string(data))
 	return nil
 }
 

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -50,7 +50,7 @@ func Restore(ctx context.Context, cfg *config.Config, opts RestoreOptions) error
 			return fmt.Errorf("decrypt backup: %w", err)
 		}
 		workFile = decrypted
-		defer os.Remove(decrypted) // Clean up decrypted temp file.
+		defer func() { _ = os.Remove(decrypted) }()
 	}
 
 	// Determine what to restore.
@@ -158,7 +158,7 @@ func restorePgDump(ctx context.Context, container, user, db, backupFile string) 
 	if err != nil {
 		return fmt.Errorf("open backup file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	args := []string{
 		"exec", "-i", container,

--- a/internal/backup/stream.go
+++ b/internal/backup/stream.go
@@ -151,7 +151,7 @@ func runStreamPipeline(ctx context.Context, cfg *config.Config, pgURL, destinati
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		defer pgW.Close()
+		defer func() { _ = pgW.Close() }()
 		if err := runPgDump(ctx, cfg, pgURL, pgW); err != nil {
 			cancel()
 			errc <- fmt.Errorf("pg_dump: %w", err)
@@ -163,7 +163,7 @@ func runStreamPipeline(ctx context.Context, cfg *config.Config, pgURL, destinati
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			defer encW.Close()
+			defer func() { _ = encW.Close() }()
 			if err := ageEncryptStream(ctx, pgR, encW, recipients); err != nil {
 				cancel()
 				pgR.CloseWithError(err)
@@ -176,7 +176,7 @@ func runStreamPipeline(ctx context.Context, cfg *config.Config, pgURL, destinati
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		defer uploadReader.Close()
+		defer func() { _ = uploadReader.Close() }()
 		if err := rcloneRcat(ctx, uploadReader, destination, key); err != nil {
 			cancel()
 			errc <- fmt.Errorf("rclone upload: %w", err)

--- a/internal/backup/stream_restore.go
+++ b/internal/backup/stream_restore.go
@@ -50,7 +50,7 @@ func fetchGitHubKeys(ctx context.Context, username string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GitHub API request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API returned %d for user %s", resp.StatusCode, username)

--- a/internal/backup/stream_restore_remote.go
+++ b/internal/backup/stream_restore_remote.go
@@ -62,7 +62,7 @@ func RestoreFromRemote(ctx context.Context, cfg *config.Config, from, keyPath st
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		defer dlW.Close()
+		defer func() { _ = dlW.Close() }()
 		cmd := exec.CommandContext(ctx, "rclone", "cat", from)
 		cmd.Stdout = dlW
 		stderr, err := cmd.StderrPipe()
@@ -99,7 +99,7 @@ func RestoreFromRemote(ctx context.Context, cfg *config.Config, from, keyPath st
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			defer decW.Close()
+			defer func() { _ = decW.Close() }()
 			cmd := exec.CommandContext(ctx, "age", "--decrypt", "-i", keyPath)
 			cmd.Stdin = downloadReader
 			cmd.Stdout = decW
@@ -145,7 +145,7 @@ func RestoreFromRemote(ctx context.Context, cfg *config.Config, from, keyPath st
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		defer restoreReader.Close()
+		defer func() { _ = restoreReader.Close() }()
 		args := []string{
 			"exec", "-i", container,
 			"pg_restore",

--- a/internal/build/build_extra_test.go
+++ b/internal/build/build_extra_test.go
@@ -336,14 +336,14 @@ func setHomeForTest(t *testing.T, home string) {
 	}
 	t.Cleanup(func() {
 		if homeSet {
-			os.Setenv("HOME", origHome)
+			_ = os.Setenv("HOME", origHome)
 		} else {
-			os.Unsetenv("HOME")
+			_ = os.Unsetenv("HOME")
 		}
 		if profileSet {
-			os.Setenv("USERPROFILE", origProfile)
+			_ = os.Setenv("USERPROFILE", origProfile)
 		} else {
-			os.Unsetenv("USERPROFILE")
+			_ = os.Unsetenv("USERPROFILE")
 		}
 	})
 }

--- a/internal/build/orchestrator.go
+++ b/internal/build/orchestrator.go
@@ -112,8 +112,8 @@ func acquireBuildLock(workdir string) (*os.File, error) {
 
 // releaseBuildLock closes and removes the lock file returned by acquireBuildLock.
 func releaseBuildLock(f *os.File, workdir string) {
-	f.Close()
-	os.Remove(filepath.Join(workdir, buildLockFile))
+	_ = f.Close()
+	_ = os.Remove(filepath.Join(workdir, buildLockFile))
 }
 
 // Build orchestrates the full nself build pipeline.
@@ -573,7 +573,7 @@ func persistGeneratedSecrets(workdir string, cfg *config.Config) error {
 				onDisk[line[:idx]] = true
 			}
 		}
-		f.Close()
+		_ = f.Close()
 	}
 
 	// Determine which secrets need persisting.
@@ -610,7 +610,7 @@ func persistGeneratedSecrets(workdir string, cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", secretsPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	for _, s := range toWrite {
 		if _, err := fmt.Fprintf(f, "%s=%s\n", s.envKey, config.QuoteEnvValue(s.value)); err != nil {

--- a/internal/build/plugins_manifest.go
+++ b/internal/build/plugins_manifest.go
@@ -61,7 +61,7 @@ func ReadComposeManifest(workdir string) ([]string, error) {
 		}
 		return nil, fmt.Errorf("opening compose manifest: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var paths []string
 	scanner := bufio.NewScanner(f)

--- a/internal/bundle/installer.go
+++ b/internal/bundle/installer.go
@@ -134,7 +134,7 @@ func Install(ctx context.Context, bundleSlug string, opts InstallOpts) (*Install
 	printPlan(out, b, result.Channel, planned, pins, result.Skipped, opts)
 
 	if opts.DryRun {
-		fmt.Fprintln(out, "(dry-run) no changes made.")
+		_, _ = fmt.Fprintln(out, "(dry-run) no changes made.")
 		return result, nil
 	}
 
@@ -209,7 +209,7 @@ func Install(ctx context.Context, bundleSlug string, opts InstallOpts) (*Install
 			cmp := plugin.CompareVersions(existingVer, targetVer)
 			if cmp == 0 {
 				// Same version: skip silently.
-				fmt.Fprintf(out, "  ✓ %s@%s (already installed, same version)\n", name, targetVer)
+				_, _ = fmt.Fprintf(out, "  ✓ %s@%s (already installed, same version)\n", name, targetVer)
 				continue
 			}
 			if cmp > 0 {
@@ -220,27 +220,27 @@ func Install(ctx context.Context, bundleSlug string, opts InstallOpts) (*Install
 					return result, fmt.Errorf("--strict: plugin %q is at %s (higher than bundle pin %s); use without --strict to skip", name, existingVer, targetVer)
 				}
 				// Default: skip with warning, no silent downgrade.
-				fmt.Fprintf(out, "  ⚠ %s: installed at %s (higher than bundle pin %s) — skipping to avoid downgrade\n", name, existingVer, targetVer)
+				_, _ = fmt.Fprintf(out, "  ⚠ %s: installed at %s (higher than bundle pin %s) — skipping to avoid downgrade\n", name, existingVer, targetVer)
 				continue
 			}
 			// cmp < 0: existing is lower → upgrade, fall through to install.
-			fmt.Fprintf(out, "  ↑ upgrading %s: %s → %s\n", name, existingVer, targetVer)
+			_, _ = fmt.Fprintf(out, "  ↑ upgrading %s: %s → %s\n", name, existingVer, targetVer)
 		} else {
-			fmt.Fprintf(out, "  → installing %s@%s...\n", name, targetVer)
+			_, _ = fmt.Fprintf(out, "  → installing %s@%s...\n", name, targetVer)
 		}
 
 		if err := installFn(ctx, cfg, name, pluginDir); err != nil {
-			fmt.Fprintf(out, "  ✗ %s install failed: %v\n", name, err)
+			_, _ = fmt.Fprintf(out, "  ✗ %s install failed: %v\n", name, err)
 			result.RolledBack = rollbackInstalled(ctx, cfg, removeFn, pluginDir, result.Installed, out)
 			return result, fmt.Errorf("bundle %q install failed at plugin %q: %w", b.Slug, name, err)
 		}
 		result.Installed = append(result.Installed, name)
-		fmt.Fprintf(out, "  ✓ %s@%s installed\n", name, targetVer)
+		_, _ = fmt.Fprintf(out, "  ✓ %s@%s installed\n", name, targetVer)
 	}
 
-	fmt.Fprintf(out, "\nBundle %q (%s) installed: %d plugins.\n", b.Name, b.Slug, len(result.Installed))
+	_, _ = fmt.Fprintf(out, "\nBundle %q (%s) installed: %d plugins.\n", b.Name, b.Slug, len(result.Installed))
 	if len(result.Skipped) > 0 {
-		fmt.Fprintf(out, "Skipped (missing from registry): %s\n", strings.Join(result.Skipped, ", "))
+		_, _ = fmt.Fprintf(out, "Skipped (missing from registry): %s\n", strings.Join(result.Skipped, ", "))
 	}
 
 	// Trigger a single nself build to regenerate docker-compose.yml and nginx
@@ -250,8 +250,8 @@ func Install(ctx context.Context, bundleSlug string, opts InstallOpts) (*Install
 		if err := triggerBuild(ctx, out); err != nil {
 			// Build failure is non-fatal: plugins are on disk; user can run
 			// nself build manually. Surface as a warning, not a hard error.
-			fmt.Fprintf(out, "\nWARNING: nself build failed after bundle install: %v\n", err)
-			fmt.Fprintln(out, "Run 'nself build' manually to apply the new plugins.")
+			_, _ = fmt.Fprintf(out, "\nWARNING: nself build failed after bundle install: %v\n", err)
+			_, _ = fmt.Fprintln(out, "Run 'nself build' manually to apply the new plugins.")
 		}
 	}
 

--- a/internal/bundle/installer_helpers.go
+++ b/internal/bundle/installer_helpers.go
@@ -54,9 +54,9 @@ func rollbackInstalled(
 	rolled := make([]string, 0, len(installed))
 	for i := len(installed) - 1; i >= 0; i-- {
 		name := installed[i]
-		fmt.Fprintf(out, "  ↩ rolling back %s...\n", name)
+		_, _ = fmt.Fprintf(out, "  ↩ rolling back %s...\n", name)
 		if err := remove(ctx, cfg, name, pluginDir); err != nil {
-			fmt.Fprintf(out, "  ! rollback of %s failed: %v (manual cleanup may be required)\n", name, err)
+			_, _ = fmt.Fprintf(out, "  ! rollback of %s failed: %v (manual cleanup may be required)\n", name, err)
 			continue
 		}
 		rolled = append(rolled, name)
@@ -70,20 +70,20 @@ func printPlan(out io.Writer, b Bundle, ch Channel, planned []string, pins Versi
 	if opts.DryRun {
 		header = "Install plan (dry-run)"
 	}
-	fmt.Fprintf(out, "%s for bundle %s (%s) — channel %s\n", header, b.Name, b.Slug, ch)
+	_, _ = fmt.Fprintf(out, "%s for bundle %s (%s) — channel %s\n", header, b.Name, b.Slug, ch)
 	if len(planned) == 0 {
-		fmt.Fprintln(out, "  (no plugins to install)")
+		_, _ = fmt.Fprintln(out, "  (no plugins to install)")
 	}
 	for _, name := range planned {
-		fmt.Fprintf(out, "  • %s@%s\n", name, pins[name])
+		_, _ = fmt.Fprintf(out, "  • %s@%s\n", name, pins[name])
 	}
 	if len(skipped) > 0 {
-		fmt.Fprintf(out, "  skipped (not in registry, non-strict): %s\n", strings.Join(skipped, ", "))
+		_, _ = fmt.Fprintf(out, "  skipped (not in registry, non-strict): %s\n", strings.Join(skipped, ", "))
 	}
 	if opts.Force {
-		fmt.Fprintln(out, "  license: will validate (--force only skips same-version check)")
+		_, _ = fmt.Fprintln(out, "  license: will validate (--force only skips same-version check)")
 	} else {
-		fmt.Fprintln(out, "  license: will validate each plugin before any FS change")
+		_, _ = fmt.Fprintln(out, "  license: will validate each plugin before any FS change")
 	}
 }
 
@@ -184,7 +184,7 @@ func buildInstalledVersionMap(pluginDir string) map[string]string {
 // docker-compose.yml and nginx configs are regenerated with the new plugins.
 // This is a subprocess call matching the pattern in internal/promote/promote.go.
 func triggerBuild(ctx context.Context, out io.Writer) error {
-	fmt.Fprintln(out, "\nRunning 'nself build' to apply installed plugins...")
+	_, _ = fmt.Fprintln(out, "\nRunning 'nself build' to apply installed plugins...")
 	nself, err := exec.LookPath("nself")
 	if err != nil {
 		// nself binary not found — likely running in tests or a non-standard PATH.

--- a/internal/bundle/installer_multi.go
+++ b/internal/bundle/installer_multi.go
@@ -89,19 +89,19 @@ func InstallMultiple(ctx context.Context, bundleSlugs []string, opts InstallOpts
 
 	// Log conflicts to out.
 	if len(conflicts) > 0 {
-		fmt.Fprintf(out, "Cross-bundle version conflicts resolved (%d):\n", len(conflicts))
+		_, _ = fmt.Fprintf(out, "Cross-bundle version conflicts resolved (%d):\n", len(conflicts))
 		for _, c := range conflicts {
 			if c.Resolved == "" {
 				// Skip scenario: installed version is higher than all bundles want.
-				fmt.Fprintf(out, "  ⚠ %s: installed version is higher than all bundle pins %v — skipping to avoid downgrade\n",
+				_, _ = fmt.Fprintf(out, "  ⚠ %s: installed version is higher than all bundle pins %v — skipping to avoid downgrade\n",
 					c.PluginName, c.Versions)
 			} else {
-				fmt.Fprintf(out, "  → %s: versions %v across bundles %v → resolved to %s (MAX)\n",
+				_, _ = fmt.Fprintf(out, "  → %s: versions %v across bundles %v → resolved to %s (MAX)\n",
 					c.PluginName, c.Versions, c.BundleNames, c.Resolved)
 				if opts.Strict {
 					for i, v := range c.Versions {
 						if v != c.Resolved && plugin.CompareVersions(c.Resolved, v) > 0 {
-							fmt.Fprintf(out, "    WARNING: --strict: bundle %q was tested against %s (lower than resolved %s)\n",
+							_, _ = fmt.Fprintf(out, "    WARNING: --strict: bundle %q was tested against %s (lower than resolved %s)\n",
 								c.BundleNames[i], v, c.Resolved)
 						}
 					}

--- a/internal/bundle/installer_test.go
+++ b/internal/bundle/installer_test.go
@@ -42,7 +42,7 @@ func TestInstall_MetaBundleNotInstallable(t *testing.T) {
 
 func TestInstall_DryRunWithMockedRegistry(t *testing.T) {
 	dir := setupOfflineRegistry(t, mockNsentryRegistry())
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	var buf bytes.Buffer
 	res, err := Install(context.Background(), "nsentry", InstallOpts{
@@ -69,7 +69,7 @@ func TestInstall_DryRunWithMockedRegistry(t *testing.T) {
 
 func TestInstall_AtomicRollbackOnFailure(t *testing.T) {
 	dir := setupOfflineRegistry(t, mockNsentryRegistry())
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	pluginDir := t.TempDir()
 	var buf bytes.Buffer
@@ -126,7 +126,7 @@ func TestInstall_AtomicRollbackOnFailure(t *testing.T) {
 // is always enforced.
 func TestInstall_ForceStillValidatesLicense(t *testing.T) {
 	dir := setupOfflineRegistry(t, mockNsentryRegistry())
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	pluginDir := t.TempDir()
 	var buf bytes.Buffer
@@ -170,7 +170,7 @@ func TestInstall_ForceStillValidatesLicense(t *testing.T) {
 
 func TestInstall_LicenseFailWithoutForce(t *testing.T) {
 	dir := setupOfflineRegistry(t, mockNsentryRegistry())
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	pluginDir := t.TempDir()
 	var buf bytes.Buffer
@@ -196,7 +196,7 @@ func TestInstall_LicenseFailWithoutForce(t *testing.T) {
 func TestInstall_StrictModeMissingPlugin(t *testing.T) {
 	// Mock registry has only one plugin; bundle expects 13. Strict mode → error.
 	dir := setupOfflineRegistry(t, mockPartialNsentryRegistry())
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	var buf bytes.Buffer
 	_, err := Install(context.Background(), "nsentry", InstallOpts{

--- a/internal/bundle/remover.go
+++ b/internal/bundle/remover.go
@@ -93,12 +93,12 @@ func Remove(ctx context.Context, bundleSlug string, opts RemoveOpts) (*RemoveRes
 	printRemovePlan(out, b, result, opts)
 
 	if opts.DryRun {
-		fmt.Fprintln(out, "(dry-run) no changes made.")
+		_, _ = fmt.Fprintln(out, "(dry-run) no changes made.")
 		return result, nil
 	}
 
 	if len(result.Planned) == 0 {
-		fmt.Fprintln(out, "Nothing to remove.")
+		_, _ = fmt.Fprintln(out, "Nothing to remove.")
 		return result, nil
 	}
 
@@ -123,19 +123,19 @@ func Remove(ctx context.Context, bundleSlug string, opts RemoveOpts) (*RemoveRes
 	// are typically dependencies (ai before claw, realtime before chat).
 	for i := len(result.Planned) - 1; i >= 0; i-- {
 		name := result.Planned[i]
-		fmt.Fprintf(out, "  → removing %s...\n", name)
+		_, _ = fmt.Fprintf(out, "  → removing %s...\n", name)
 		// force=true: operator opted into full bundle teardown; skip the
 		// reverse-dependency check that would otherwise block.
 		if err := removeFn(ctx, cfg, name, pluginDir, opts.KeepData, true); err != nil {
-			fmt.Fprintf(out, "  ✗ %s remove failed: %v\n", name, err)
+			_, _ = fmt.Fprintf(out, "  ✗ %s remove failed: %v\n", name, err)
 			result.Failed = append(result.Failed, name)
 			continue
 		}
 		result.Removed = append(result.Removed, name)
-		fmt.Fprintf(out, "  ✓ %s removed\n", name)
+		_, _ = fmt.Fprintf(out, "  ✓ %s removed\n", name)
 	}
 
-	fmt.Fprintf(out, "\nBundle %q (%s) remove summary: %d removed, %d failed, %d already absent.\n",
+	_, _ = fmt.Fprintf(out, "\nBundle %q (%s) remove summary: %d removed, %d failed, %d already absent.\n",
 		b.Name, b.Slug, len(result.Removed), len(result.Failed), len(result.NotInstalled))
 
 	// Trigger a single nself build to regenerate docker-compose.yml and nginx
@@ -143,8 +143,8 @@ func Remove(ctx context.Context, bundleSlug string, opts RemoveOpts) (*RemoveRes
 	// actually removed — mirrors the install path in installer.go.
 	if len(result.Removed) > 0 {
 		if err := triggerBuild(ctx, out); err != nil {
-			fmt.Fprintf(out, "\nWARNING: nself build failed after bundle remove: %v\n", err)
-			fmt.Fprintln(out, "Run 'nself build' manually to apply the changes.")
+			_, _ = fmt.Fprintf(out, "\nWARNING: nself build failed after bundle remove: %v\n", err)
+			_, _ = fmt.Fprintln(out, "Run 'nself build' manually to apply the changes.")
 		}
 	}
 
@@ -160,19 +160,19 @@ func printRemovePlan(out io.Writer, b Bundle, r *RemoveResult, opts RemoveOpts) 
 	if opts.DryRun {
 		header = "Remove plan (dry-run)"
 	}
-	fmt.Fprintf(out, "%s for bundle %s (%s)\n", header, b.Name, b.Slug)
+	_, _ = fmt.Fprintf(out, "%s for bundle %s (%s)\n", header, b.Name, b.Slug)
 	if opts.KeepData {
-		fmt.Fprintln(out, "  data: preserve (--keep-data)")
+		_, _ = fmt.Fprintln(out, "  data: preserve (--keep-data)")
 	} else {
-		fmt.Fprintln(out, "  data: drop plugin schema/tables")
+		_, _ = fmt.Fprintln(out, "  data: drop plugin schema/tables")
 	}
 	if len(r.Planned) == 0 {
-		fmt.Fprintln(out, "  (no installed plugins from this bundle)")
+		_, _ = fmt.Fprintln(out, "  (no installed plugins from this bundle)")
 	}
 	for _, name := range r.Planned {
-		fmt.Fprintf(out, "  • %s\n", name)
+		_, _ = fmt.Fprintf(out, "  • %s\n", name)
 	}
 	if len(r.NotInstalled) > 0 {
-		fmt.Fprintf(out, "  not-installed: %s\n", strings.Join(r.NotInstalled, ", "))
+		_, _ = fmt.Fprintf(out, "  not-installed: %s\n", strings.Join(r.NotInstalled, ", "))
 	}
 }

--- a/internal/cmd/ci/eval_gate_test.go
+++ b/internal/cmd/ci/eval_gate_test.go
@@ -18,7 +18,7 @@ func evalGateServer(t *testing.T, statusCode int, body interface{}) *httptest.Se
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
 		if body != nil {
-			json.NewEncoder(w).Encode(body)
+			_ = json.NewEncoder(w).Encode(body)
 		}
 	}))
 	t.Cleanup(srv.Close)

--- a/internal/cmd/ci/serve.go
+++ b/internal/cmd/ci/serve.go
@@ -153,11 +153,11 @@ func handleHealthz(w http.ResponseWriter, _ *http.Request) {
 // handleInfo returns a plaintext info page at /.
 func handleInfo(w http.ResponseWriter, _ *http.Request, cfg ServeConfig) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprintf(w, "nself-ci-serve\n")
-	fmt.Fprintf(w, "  port        : 3845\n")
-	fmt.Fprintf(w, "  concurrency : %d\n", cfg.Concurrency)
-	fmt.Fprintf(w, "  job_timeout : %ds\n", cfg.JobTimeout)
-	fmt.Fprintf(w, "  workdir     : %s\n", cfg.WorkDir)
-	fmt.Fprintf(w, "  /healthz    : health probe\n")
-	fmt.Fprintf(w, "  POST /      : GitHub webhook (push, pull_request)\n")
+	_, _ = fmt.Fprintf(w, "nself-ci-serve\n")
+	_, _ = fmt.Fprintf(w, "  port        : 3845\n")
+	_, _ = fmt.Fprintf(w, "  concurrency : %d\n", cfg.Concurrency)
+	_, _ = fmt.Fprintf(w, "  job_timeout : %ds\n", cfg.JobTimeout)
+	_, _ = fmt.Fprintf(w, "  workdir     : %s\n", cfg.WorkDir)
+	_, _ = fmt.Fprintf(w, "  /healthz    : health probe\n")
+	_, _ = fmt.Fprintf(w, "  POST /      : GitHub webhook (push, pull_request)\n")
 }

--- a/internal/cmd/ci/serve_job.go
+++ b/internal/cmd/ci/serve_job.go
@@ -50,7 +50,7 @@ func runJob(job ciJob, binaryPath string, cfg ServeConfig) {
 		})
 		return
 	}
-	defer os.RemoveAll(workdir) // always clean up
+	defer func() { _ = os.RemoveAll(workdir) }()
 
 	// Run gate inside Docker container with resource limits.
 	passed, summary, runErr := runGateInDocker(binaryPath, workdir, cfg)

--- a/internal/cmd/ci/serve_test.go
+++ b/internal/cmd/ci/serve_test.go
@@ -325,7 +325,7 @@ func TestIntegration_HttpServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("healthz GET: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("/healthz: got %d, want 200", resp.StatusCode)
 	}
@@ -341,7 +341,7 @@ func TestIntegration_HttpServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("webhook POST: %v", err)
 	}
-	resp2.Body.Close()
+	_ = resp2.Body.Close()
 	if resp2.StatusCode != http.StatusAccepted {
 		t.Errorf("signed webhook: got %d, want 202", resp2.StatusCode)
 	}
@@ -354,7 +354,7 @@ func TestIntegration_HttpServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bad-sig POST: %v", err)
 	}
-	resp3.Body.Close()
+	_ = resp3.Body.Close()
 	if resp3.StatusCode != http.StatusForbidden {
 		t.Errorf("bad-sig: got %d, want 403", resp3.StatusCode)
 	}

--- a/internal/cmdlog/logger.go
+++ b/internal/cmdlog/logger.go
@@ -89,7 +89,7 @@ func (l *Logger) write(entry Entry) error {
 	if err != nil {
 		return fmt.Errorf("cmdlog: open %s: %w", l.path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	_, err = f.Write(line)
 	return err

--- a/internal/cmdlog/logger_test.go
+++ b/internal/cmdlog/logger_test.go
@@ -120,7 +120,7 @@ func TestRotation(t *testing.T) {
 	// Instead, test the rotation mechanics directly:
 	l.mu.Lock()
 	// Create a fake .1 file and verify shift works
-	os.WriteFile(logPath+".1", []byte("old"), 0644)
+	_ = os.WriteFile(logPath+".1", []byte("old"), 0644)
 	l.mu.Unlock()
 
 	// Verify .1 exists

--- a/internal/config/cascade_test.go
+++ b/internal/config/cascade_test.go
@@ -114,9 +114,9 @@ const cascadeTestVar = "NSELF_TEST_CASCADE_VAR"
 // .env.secrets beats .env.dev beats bare .env. Table-driven: each case adds
 // one more, higher-precedence file and checks the winner shifts.
 func TestLoad_CanonicalPrecedenceChain(t *testing.T) {
-	os.Unsetenv("ENV")
-	os.Unsetenv(LegacyEnvOrderVar)
-	t.Cleanup(func() { os.Unsetenv(cascadeTestVar) })
+	_ = os.Unsetenv("ENV")
+	_ = os.Unsetenv(LegacyEnvOrderVar)
+	t.Cleanup(func() { _ = os.Unsetenv(cascadeTestVar) })
 
 	dir := t.TempDir()
 
@@ -161,9 +161,9 @@ func TestLoad_CanonicalPrecedenceChain(t *testing.T) {
 // (pre-CLI-R18 projects) is no longer part of the cascade at all under the
 // canonical order: it must not win even though it used to be loaded last.
 func TestLoad_CanonicalOrder_EnvAiIsIgnored(t *testing.T) {
-	os.Unsetenv("ENV")
-	os.Unsetenv(LegacyEnvOrderVar)
-	t.Cleanup(func() { os.Unsetenv(cascadeTestVar) })
+	_ = os.Unsetenv("ENV")
+	_ = os.Unsetenv(LegacyEnvOrderVar)
+	t.Cleanup(func() { _ = os.Unsetenv(cascadeTestVar) })
 
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, ".env"), cascadeTestVar+"=from-env\n")
@@ -183,11 +183,11 @@ func TestLoad_CanonicalOrder_EnvAiIsIgnored(t *testing.T) {
 // set, the historical order is restored: bare .env and then .env.ai win last,
 // overriding .env.secrets and .env.local exactly as before CLI-R18.
 func TestLoad_LegacyOrder_EnvAiWinsLast(t *testing.T) {
-	os.Unsetenv("ENV")
-	os.Setenv(LegacyEnvOrderVar, "1")
+	_ = os.Unsetenv("ENV")
+	_ = os.Setenv(LegacyEnvOrderVar, "1")
 	t.Cleanup(func() {
-		os.Unsetenv(LegacyEnvOrderVar)
-		os.Unsetenv(cascadeTestVar)
+		_ = os.Unsetenv(LegacyEnvOrderVar)
+		_ = os.Unsetenv(cascadeTestVar)
 	})
 
 	dir := t.TempDir()
@@ -208,9 +208,9 @@ func TestLoad_LegacyOrder_EnvAiWinsLast(t *testing.T) {
 // NSELF_LEGACY_ENV_ORDER emits a slog.Warn naming the variable and a removal
 // version on every single Load() call, not just the first.
 func TestLoad_LegacyOrder_WarnsOnEveryUse(t *testing.T) {
-	os.Unsetenv("ENV")
-	os.Setenv(LegacyEnvOrderVar, "1")
-	t.Cleanup(func() { os.Unsetenv(LegacyEnvOrderVar) })
+	_ = os.Unsetenv("ENV")
+	_ = os.Setenv(LegacyEnvOrderVar, "1")
+	t.Cleanup(func() { _ = os.Unsetenv(LegacyEnvOrderVar) })
 
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, ".env"), "X=1\n")

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -10,7 +10,7 @@ import (
 // TestGetEnvOr_ReturnsDefault verifies that getEnvOr returns the fallback value
 // when the env var is unset.
 func TestGetEnvOr_ReturnsDefault(t *testing.T) {
-	os.Unsetenv("NSELF_TEST_GETENVOOR_UNSET")
+	_ = os.Unsetenv("NSELF_TEST_GETENVOOR_UNSET")
 	got := getEnvOr("NSELF_TEST_GETENVOOR_UNSET", "default-val")
 	if got != "default-val" {
 		t.Errorf("getEnvOr() = %q, want %q", got, "default-val")
@@ -20,8 +20,8 @@ func TestGetEnvOr_ReturnsDefault(t *testing.T) {
 // TestGetEnvOr_ReturnsEnvValue verifies that getEnvOr returns the actual env
 // value when the variable is set to a non-empty string.
 func TestGetEnvOr_ReturnsEnvValue(t *testing.T) {
-	os.Setenv("NSELF_TEST_GETENVOOR_SET", "actual-val")
-	t.Cleanup(func() { os.Unsetenv("NSELF_TEST_GETENVOOR_SET") })
+	_ = os.Setenv("NSELF_TEST_GETENVOOR_SET", "actual-val")
+	t.Cleanup(func() { _ = os.Unsetenv("NSELF_TEST_GETENVOOR_SET") })
 
 	got := getEnvOr("NSELF_TEST_GETENVOOR_SET", "default-val")
 	if got != "actual-val" {
@@ -32,8 +32,8 @@ func TestGetEnvOr_ReturnsEnvValue(t *testing.T) {
 // TestGetEnvOr_EmptyStringUsesDefault verifies that an explicitly empty env var
 // triggers the fallback (empty string is treated as unset).
 func TestGetEnvOr_EmptyStringUsesDefault(t *testing.T) {
-	os.Setenv("NSELF_TEST_GETENVOOR_EMPTY", "")
-	t.Cleanup(func() { os.Unsetenv("NSELF_TEST_GETENVOOR_EMPTY") })
+	_ = os.Setenv("NSELF_TEST_GETENVOOR_EMPTY", "")
+	t.Cleanup(func() { _ = os.Unsetenv("NSELF_TEST_GETENVOOR_EMPTY") })
 
 	got := getEnvOr("NSELF_TEST_GETENVOOR_EMPTY", "fallback")
 	if got != "fallback" {
@@ -46,7 +46,7 @@ func TestGetEnvOr_EmptyStringUsesDefault(t *testing.T) {
 // TestGetEnvInt_ReturnsDefault verifies that getEnvInt returns the fallback
 // when the env var is unset.
 func TestGetEnvInt_ReturnsDefault(t *testing.T) {
-	os.Unsetenv("NSELF_TEST_GETENVINT_UNSET")
+	_ = os.Unsetenv("NSELF_TEST_GETENVINT_UNSET")
 	got := getEnvInt("NSELF_TEST_GETENVINT_UNSET", 42)
 	if got != 42 {
 		t.Errorf("getEnvInt() = %d, want %d", got, 42)
@@ -56,8 +56,8 @@ func TestGetEnvInt_ReturnsDefault(t *testing.T) {
 // TestGetEnvInt_ReturnsIntValue verifies that getEnvInt correctly parses a
 // valid integer string.
 func TestGetEnvInt_ReturnsIntValue(t *testing.T) {
-	os.Setenv("NSELF_TEST_GETENVINT_SET", "8080")
-	t.Cleanup(func() { os.Unsetenv("NSELF_TEST_GETENVINT_SET") })
+	_ = os.Setenv("NSELF_TEST_GETENVINT_SET", "8080")
+	t.Cleanup(func() { _ = os.Unsetenv("NSELF_TEST_GETENVINT_SET") })
 
 	got := getEnvInt("NSELF_TEST_GETENVINT_SET", 0)
 	if got != 8080 {
@@ -68,8 +68,8 @@ func TestGetEnvInt_ReturnsIntValue(t *testing.T) {
 // TestGetEnvInt_InvalidValueReturnsDefault verifies that a non-numeric env var
 // causes getEnvInt to return the fallback instead of panicking or returning 0.
 func TestGetEnvInt_InvalidValueReturnsDefault(t *testing.T) {
-	os.Setenv("NSELF_TEST_GETENVINT_INVALID", "not-a-number")
-	t.Cleanup(func() { os.Unsetenv("NSELF_TEST_GETENVINT_INVALID") })
+	_ = os.Setenv("NSELF_TEST_GETENVINT_INVALID", "not-a-number")
+	t.Cleanup(func() { _ = os.Unsetenv("NSELF_TEST_GETENVINT_INVALID") })
 
 	got := getEnvInt("NSELF_TEST_GETENVINT_INVALID", 99)
 	if got != 99 {
@@ -80,8 +80,8 @@ func TestGetEnvInt_InvalidValueReturnsDefault(t *testing.T) {
 // TestGetEnvInt_EmptyStringReturnsDefault verifies that an empty string env var
 // causes getEnvInt to return the fallback.
 func TestGetEnvInt_EmptyStringReturnsDefault(t *testing.T) {
-	os.Setenv("NSELF_TEST_GETENVINT_EMPTY", "")
-	t.Cleanup(func() { os.Unsetenv("NSELF_TEST_GETENVINT_EMPTY") })
+	_ = os.Setenv("NSELF_TEST_GETENVINT_EMPTY", "")
+	t.Cleanup(func() { _ = os.Unsetenv("NSELF_TEST_GETENVINT_EMPTY") })
 
 	got := getEnvInt("NSELF_TEST_GETENVINT_EMPTY", 7)
 	if got != 7 {
@@ -94,7 +94,7 @@ func TestGetEnvInt_EmptyStringReturnsDefault(t *testing.T) {
 // TestGetEnvBool_ReturnsDefault verifies that getEnvBool returns the fallback
 // when the env var is unset.
 func TestGetEnvBool_ReturnsDefault(t *testing.T) {
-	os.Unsetenv("NSELF_TEST_GETENVBOOL_UNSET")
+	_ = os.Unsetenv("NSELF_TEST_GETENVBOOL_UNSET")
 	got := getEnvBool("NSELF_TEST_GETENVBOOL_UNSET", true)
 	if !got {
 		t.Errorf("getEnvBool() = false, want true (fallback)")
@@ -106,26 +106,26 @@ func TestGetEnvBool_ReturnsDefault(t *testing.T) {
 func TestGetEnvBool_TrueValues(t *testing.T) {
 	trueVals := []string{"true", "1", "yes", "on", "enabled", "TRUE", "YES"}
 	for _, v := range trueVals {
-		os.Setenv("NSELF_TEST_GETENVBOOL_TRUE", v)
+		_ = os.Setenv("NSELF_TEST_GETENVBOOL_TRUE", v)
 		got := getEnvBool("NSELF_TEST_GETENVBOOL_TRUE", false)
 		if !got {
 			t.Errorf("getEnvBool(%q) = false, want true", v)
 		}
 	}
-	os.Unsetenv("NSELF_TEST_GETENVBOOL_TRUE")
+	_ = os.Unsetenv("NSELF_TEST_GETENVBOOL_TRUE")
 }
 
 // TestGetEnvBool_FalseValues verifies that non-truthy strings are parsed as false.
 func TestGetEnvBool_FalseValues(t *testing.T) {
 	falseVals := []string{"false", "0", "no", "off", "disabled", "nope"}
 	for _, v := range falseVals {
-		os.Setenv("NSELF_TEST_GETENVBOOL_FALSE", v)
+		_ = os.Setenv("NSELF_TEST_GETENVBOOL_FALSE", v)
 		got := getEnvBool("NSELF_TEST_GETENVBOOL_FALSE", true)
 		if got {
 			t.Errorf("getEnvBool(%q) = true, want false", v)
 		}
 	}
-	os.Unsetenv("NSELF_TEST_GETENVBOOL_FALSE")
+	_ = os.Unsetenv("NSELF_TEST_GETENVBOOL_FALSE")
 }
 
 // ── ApplyDefaults ────────────────────────────────────────────────────────────

--- a/internal/config/minio_alias_test.go
+++ b/internal/config/minio_alias_test.go
@@ -33,14 +33,14 @@ func clearMinioEnv(t *testing.T) {
 		"S3_ACCESS_KEY", "S3_SECRET_KEY",
 	} {
 		orig, had := os.LookupEnv(k)
-		os.Unsetenv(k)
+		_ = os.Unsetenv(k)
 		if had {
 			t.Cleanup(func(k, orig string) func() {
-				return func() { os.Setenv(k, orig) }
+				return func() { _ = os.Setenv(k, orig) }
 			}(k, orig))
 		} else {
 			t.Cleanup(func(k string) func() {
-				return func() { os.Unsetenv(k) }
+				return func() { _ = os.Unsetenv(k) }
 			}(k))
 		}
 	}

--- a/internal/confirm/confirm.go
+++ b/internal/confirm/confirm.go
@@ -16,9 +16,9 @@ var ErrDestructionCanceled = errors.New("destruction canceled by user")
 // Returns nil if the typed string matches projectName exactly.
 // Returns ErrDestructionCanceled if the input does not match or if r is exhausted (EOF).
 func ConfirmDestruction(projectName string, r io.Reader, w io.Writer) error {
-	fmt.Fprintf(w, "\u26a0  This will permanently destroy project %q.\n", projectName)
-	fmt.Fprintf(w, "   All containers, volumes, and data will be deleted.\n")
-	fmt.Fprintf(w, "   Type the project name to confirm: ")
+	_, _ = fmt.Fprintf(w, "\u26a0  This will permanently destroy project %q.\n", projectName)
+	_, _ = fmt.Fprintf(w, "   All containers, volumes, and data will be deleted.\n")
+	_, _ = fmt.Fprintf(w, "   Type the project name to confirm: ")
 
 	scanner := bufio.NewScanner(r)
 	if !scanner.Scan() {
@@ -42,11 +42,11 @@ func ConfirmDestruction(projectName string, r io.Reader, w io.Writer) error {
 // "yes" (case-insensitive). Returns ErrDestructionCanceled on any other input,
 // including EOF.
 func ConfirmHostWidePrune(r io.Reader, w io.Writer) error {
-	fmt.Fprintln(w, "⚠  This will run a host-wide 'docker system prune'.")
-	fmt.Fprintln(w, "   It removes stopped containers, unused networks, unused images, and")
-	fmt.Fprintln(w, "   build cache for EVERY Docker project on this machine, not just the")
-	fmt.Fprintln(w, "   current one. Named volumes are not affected.")
-	fmt.Fprintf(w, "   Type \"yes\" to continue: ")
+	_, _ = fmt.Fprintln(w, "⚠  This will run a host-wide 'docker system prune'.")
+	_, _ = fmt.Fprintln(w, "   It removes stopped containers, unused networks, unused images, and")
+	_, _ = fmt.Fprintln(w, "   build cache for EVERY Docker project on this machine, not just the")
+	_, _ = fmt.Fprintln(w, "   current one. Named volumes are not affected.")
+	_, _ = fmt.Fprintf(w, "   Type \"yes\" to continue: ")
 
 	scanner := bufio.NewScanner(r)
 	if !scanner.Scan() {

--- a/internal/controlplane/sim/harness.go
+++ b/internal/controlplane/sim/harness.go
@@ -118,7 +118,7 @@ func Start(t *testing.T, cfg FleetConfig) *Fleet {
 	// 1. Generate ephemeral ED25519 key-pair.
 	pubKeyPEM, keyPath := generateKeyPair(t)
 	f.PrivateKeyPath = keyPath
-	f.cleanup = append(f.cleanup, func() { os.Remove(keyPath) })
+	f.cleanup = append(f.cleanup, func() { _ = os.Remove(keyPath) })
 
 	// 2. Create isolated bridge network.
 	networkName := fmt.Sprintf("nself-sim-%d", time.Now().UnixNano())

--- a/internal/controlplane/sim/harness_helpers.go
+++ b/internal/controlplane/sim/harness_helpers.go
@@ -107,7 +107,7 @@ func generateKeyPair(t *testing.T) (authorizedKey string, keyPath string) {
 	if err != nil {
 		t.Fatalf("sim: create key file: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if err := f.Chmod(0600); err != nil {
 		t.Fatalf("sim: chmod key file: %v", err)
@@ -202,7 +202,7 @@ func waitForPort(t *testing.T, addr string, timeout time.Duration) {
 	for time.Now().Before(deadline) {
 		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
 		if err == nil {
-			conn.Close()
+			_ = conn.Close()
 			return
 		}
 		time.Sleep(500 * time.Millisecond)
@@ -220,7 +220,7 @@ func extractPort(line string) int {
 		return 2222
 	}
 	var p int
-	fmt.Sscanf(parts[len(parts)-1], "%d", &p)
+	_, _ = fmt.Sscanf(parts[len(parts)-1], "%d", &p)
 	return p
 }
 

--- a/internal/cost/alerter.go
+++ b/internal/cost/alerter.go
@@ -130,7 +130,7 @@ func (a *Alerter) queryDailyCosts(ctx context.Context) (map[string]float64, erro
 		}
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	totals := map[string]float64{}
 	for rows.Next() {
@@ -178,7 +178,7 @@ func (a *Alerter) postSlack(ctx context.Context, message string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("Slack webhook returned HTTP %d", resp.StatusCode)

--- a/internal/cost/alerter_test.go
+++ b/internal/cost/alerter_test.go
@@ -10,28 +10,28 @@ import (
 )
 
 func TestEnabled_Default(t *testing.T) {
-	os.Unsetenv("COST_ALERT_ENABLED")
+	_ = os.Unsetenv("COST_ALERT_ENABLED")
 	if Enabled() {
 		t.Error("expected Enabled() to return false by default")
 	}
 }
 
 func TestEnabled_True(t *testing.T) {
-	os.Setenv("COST_ALERT_ENABLED", "true")
-	defer os.Unsetenv("COST_ALERT_ENABLED")
+	_ = os.Setenv("COST_ALERT_ENABLED", "true")
+	defer func() { _ = os.Unsetenv("COST_ALERT_ENABLED") }()
 	if !Enabled() {
 		t.Error("expected Enabled() to return true when env is 'true'")
 	}
 }
 
 func TestLoadBudgetFromEnv(t *testing.T) {
-	os.Setenv("COST_BUDGET_AI_DAILY_USD", "5.00")
-	os.Setenv("COST_BUDGET_MEDIA_DAILY_USD", "2.50")
-	os.Setenv("COST_BUDGET_TOTAL_DAILY_USD", "20.00")
+	_ = os.Setenv("COST_BUDGET_AI_DAILY_USD", "5.00")
+	_ = os.Setenv("COST_BUDGET_MEDIA_DAILY_USD", "2.50")
+	_ = os.Setenv("COST_BUDGET_TOTAL_DAILY_USD", "20.00")
 	defer func() {
-		os.Unsetenv("COST_BUDGET_AI_DAILY_USD")
-		os.Unsetenv("COST_BUDGET_MEDIA_DAILY_USD")
-		os.Unsetenv("COST_BUDGET_TOTAL_DAILY_USD")
+		_ = os.Unsetenv("COST_BUDGET_AI_DAILY_USD")
+		_ = os.Unsetenv("COST_BUDGET_MEDIA_DAILY_USD")
+		_ = os.Unsetenv("COST_BUDGET_TOTAL_DAILY_USD")
 	}()
 
 	b := LoadBudgetFromEnv()
@@ -61,7 +61,7 @@ func TestFormatAlert(t *testing.T) {
 }
 
 func TestPostSlack_NoURL(t *testing.T) {
-	os.Unsetenv("SLACK_WEBHOOK_URL")
+	_ = os.Unsetenv("SLACK_WEBHOOK_URL")
 	a := New(nil, Budget{})
 	// Should not error when URL is unset
 	if err := a.postSlack(context.Background(), "test message"); err != nil {
@@ -77,8 +77,8 @@ func TestPostSlack_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	os.Setenv("SLACK_WEBHOOK_URL", ts.URL)
-	defer os.Unsetenv("SLACK_WEBHOOK_URL")
+	_ = os.Setenv("SLACK_WEBHOOK_URL", ts.URL)
+	defer func() { _ = os.Unsetenv("SLACK_WEBHOOK_URL") }()
 
 	a := &Alerter{HTTPClient: ts.Client()}
 	if err := a.postSlack(context.Background(), "budget exceeded"); err != nil {
@@ -90,7 +90,7 @@ func TestPostSlack_Success(t *testing.T) {
 }
 
 func TestCheckAndAlert_Disabled(t *testing.T) {
-	os.Unsetenv("COST_ALERT_ENABLED")
+	_ = os.Unsetenv("COST_ALERT_ENABLED")
 	a := &Alerter{}
 	// Should return nil without touching DB
 	if err := a.CheckAndAlert(context.Background()); err != nil {

--- a/internal/database/backup.go
+++ b/internal/database/backup.go
@@ -83,7 +83,7 @@ func Backup(ctx context.Context, cfg *config.Config, outputPath string) error {
 		_ = cmd.Wait()
 		return fmt.Errorf("create backup file %s: %w", outputPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Stream pg_dump output to the file.
 	if _, err := io.Copy(f, stdout); err != nil {

--- a/internal/database/checksum.go
+++ b/internal/database/checksum.go
@@ -226,7 +226,7 @@ func ResetChecksum(ctx context.Context, cfg *config.Config, migrationID string) 
 			if err != nil {
 				return fmt.Errorf("open database for checksum update: %w", err)
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 			_, err = conn.ExecContext(ctx,
 				"UPDATE nself_ops.migrations SET checksum = $1 WHERE id = $2",
 				cs, migrationID)

--- a/internal/database/drill.go
+++ b/internal/database/drill.go
@@ -191,7 +191,7 @@ func appendDrillLog(projectDir string, r DrillResult) error {
 	if err != nil {
 		return fmt.Errorf("drill log: open: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := f.Write(append(data, '\n')); err != nil {
 		return fmt.Errorf("drill log: write: %w", err)
 	}

--- a/internal/database/hasura.go
+++ b/internal/database/hasura.go
@@ -48,7 +48,7 @@ func postMetadata(ctx context.Context, cfg *config.Config, payload metadataReque
 	if err != nil {
 		return nil, fmt.Errorf("hasura metadata request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -19,7 +19,7 @@ func withCwd(t *testing.T, dir string) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatalf("chdir %s: %v", dir, err)
 	}
-	t.Cleanup(func() { os.Chdir(orig) })
+	t.Cleanup(func() { _ = os.Chdir(orig) })
 }
 
 // mkdirAll creates a directory (and parents) inside base, failing the test on error.

--- a/internal/database/restore.go
+++ b/internal/database/restore.go
@@ -36,7 +36,7 @@ func Restore(ctx context.Context, cfg *config.Config, inputPath string) error {
 	if err != nil {
 		return fmt.Errorf("open backup file %s: %w", inputPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	container := cfg.ProjectName + "_postgres"
 

--- a/internal/database/restore_drill.go
+++ b/internal/database/restore_drill.go
@@ -194,7 +194,7 @@ func RecordDrillResult(projectDir string, result RestoreDrillResult) error {
 	if err != nil {
 		return fmt.Errorf("open drill log %s: %w", logPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := f.Write(append(data, '\n')); err != nil {
 		return fmt.Errorf("write drill log entry: %w", err)

--- a/internal/database/restore_drill_exec.go
+++ b/internal/database/restore_drill_exec.go
@@ -26,7 +26,7 @@ func restoreToDB(ctx context.Context, cfg *config.Config, backupFile string, tar
 	if err != nil {
 		return fmt.Errorf("open backup file %s: %w", backupFile, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	container := containerName(cfg)
 	user := cfg.Postgres.User

--- a/internal/database/rls.go
+++ b/internal/database/rls.go
@@ -46,13 +46,13 @@ func AuditRLS(ctx context.Context, cfg *config.Config) ([]RLSTableInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("audit rls: %w", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	rows, err := db.QueryContext(ctx, auditRLSQuery)
 	if err != nil {
 		return nil, fmt.Errorf("audit rls query: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var results []RLSTableInfo
 	for rows.Next() {
@@ -114,7 +114,7 @@ func hasUserIDColumn(ctx context.Context, cfg *config.Config, schema, table stri
 	if err != nil {
 		return false, fmt.Errorf("check user_id column: %w", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	var exists bool
 	if err := db.QueryRowContext(ctx, q, schema, table).Scan(&exists); err != nil {

--- a/internal/database/rls_db.go
+++ b/internal/database/rls_db.go
@@ -22,7 +22,7 @@ func Open(ctx context.Context, cfg *config.Config) (*sql.DB, error) {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
 	if err := db.PingContext(ctx); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("connect to database: %w (is the postgres container running?)", err)
 	}
 	return db, nil

--- a/internal/deploy/secrets.go
+++ b/internal/deploy/secrets.go
@@ -146,6 +146,6 @@ func checkReadable(path string) error {
 	if err != nil {
 		return err
 	}
-	f.Close()
+	_ = f.Close()
 	return nil
 }

--- a/internal/deprecation/checker.go
+++ b/internal/deprecation/checker.go
@@ -85,7 +85,7 @@ func CheckPluginCompat(installed []InstalledPlugin, reg *PluginRegistry) []Warni
 // PrintWarnings writes all warnings to w, one per line.
 func PrintWarnings(w io.Writer, warnings []Warning) {
 	for _, warn := range warnings {
-		fmt.Fprintln(w, warn.String())
+		_, _ = fmt.Fprintln(w, warn.String())
 	}
 }
 

--- a/internal/deprecation/deprecation.go
+++ b/internal/deprecation/deprecation.go
@@ -115,10 +115,10 @@ func (r *Registry) IsDeprecated(name string) bool {
 // Format: [DEPRECATED] 'nself <item>' (since v<X.Y.Z>) → use 'nself <replacement>'. Docs: <url>
 func (r *Registry) Warn(w io.Writer, item Item) {
 	if item.Phase >= 2 {
-		fmt.Fprintf(w, "[DEPRECATED] '%s' (since %s) → use '%s'. Will be removed in a future release. Docs: %s\n",
+		_, _ = fmt.Fprintf(w, "[DEPRECATED] '%s' (since %s) → use '%s'. Will be removed in a future release. Docs: %s\n",
 			item.Name, item.Since, item.Replacement, item.DocsURL)
 	} else {
-		fmt.Fprintf(w, "[DEPRECATED] '%s' (since %s) → use '%s'. Docs: %s\n",
+		_, _ = fmt.Fprintf(w, "[DEPRECATED] '%s' (since %s) → use '%s'. Docs: %s\n",
 			item.Name, item.Since, item.Replacement, item.DocsURL)
 	}
 }
@@ -126,6 +126,6 @@ func (r *Registry) Warn(w io.Writer, item Item) {
 // Warn is a package-level convenience that creates a one-shot warning
 // without needing a Registry. Used for inline deprecations.
 func Warn(w io.Writer, name, since, replacement, docsURL string) {
-	fmt.Fprintf(w, "[DEPRECATED] '%s' (since %s) → use '%s'. Docs: %s\n",
+	_, _ = fmt.Fprintf(w, "[DEPRECATED] '%s' (since %s) → use '%s'. Docs: %s\n",
 		name, since, replacement, docsURL)
 }

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -759,7 +759,7 @@ func TestCheckPort_FreePort(t *testing.T) {
 		t.Fatalf("could not open listener: %v", err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close() // Release before CheckPort probe.
+	_ = ln.Close()
 
 	// The port MAY be grabbed by another process in the tiny window, but in
 	// test environments this is acceptable. We simply verify CheckPort returns
@@ -780,7 +780,7 @@ func TestCheckPort_InUsePort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not bind listener: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	port := ln.Addr().(*net.TCPAddr).Port
 	inUse, err := CheckPort(port)
@@ -797,7 +797,7 @@ func TestCheckAllPorts_WithActiveListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not bind listener: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	port := ln.Addr().(*net.TCPAddr).Port
 	conflicts, err := CheckAllPorts([]int{port})
@@ -816,7 +816,7 @@ func TestCheckAllPorts_NoConflicts(t *testing.T) {
 		t.Fatalf("could not bind: %v", err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
+	_ = ln.Close()
 
 	conflicts, err := CheckAllPorts([]int{port})
 	if err != nil {
@@ -912,7 +912,7 @@ func TestExecutorInterface_MockSatisfiesInterface(t *testing.T) {
 	if err != nil || rc == nil {
 		t.Fatalf("unexpected ComposeLogs result: %v", err)
 	}
-	rc.Close()
+	_ = rc.Close()
 
 	info, err := e.Inspect(ctx, "container1")
 	if err != nil || info != nil {
@@ -1062,7 +1062,7 @@ func TestCheckAllPortsFiltered_OwnPortNotConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not bind listener: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	port := ln.Addr().(*net.TCPAddr).Port
 
@@ -1093,7 +1093,7 @@ func TestCheckAllPortsFiltered_UnownedPortIsConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not bind listener: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	port := ln.Addr().(*net.TCPAddr).Port
 

--- a/internal/docker/port.go
+++ b/internal/docker/port.go
@@ -35,7 +35,7 @@ func CheckPort(port int) (bool, error) {
 		// Connection refused or timed out — port is available.
 		return false, nil
 	}
-	conn.Close()
+	_ = conn.Close()
 	// Connection succeeded — something is listening.
 	return true, nil
 }

--- a/internal/doctor/check_ci_token.go
+++ b/internal/doctor/check_ci_token.go
@@ -181,7 +181,7 @@ func RecordCITokenRotation(projectDir string) error {
 	if err != nil {
 		return fmt.Errorf("opening rotation log: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	line := fmt.Sprintf("rotated %s\n", time.Now().UTC().Format(time.RFC3339))
 	if _, err := f.WriteString(line); err != nil {

--- a/internal/doctor/deep_db.go
+++ b/internal/doctor/deep_db.go
@@ -97,7 +97,7 @@ func HasuraChecks(ctx context.Context, verbose bool) []CheckResult {
 		results = append(results, CheckResult{Section: "hasura", Name: "Hasura healthz", Status: "pass", Message: "200 OK"})
 	}
 	if resp != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 
 	// Metadata consistency — check via metadata API

--- a/internal/doctor/deep_nginx.go
+++ b/internal/doctor/deep_nginx.go
@@ -115,7 +115,7 @@ func PingChecks(ctx context.Context, verbose bool) []CheckResult {
 		results = append(results, CheckResult{Section: "ping", Name: "ping.nself.org", Status: "warn",
 			Message: fmt.Sprintf("unreachable: %v", err)})
 	} else {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if resp.StatusCode == 200 {
 			results = append(results, CheckResult{Section: "ping", Name: "ping.nself.org", Status: "pass", Message: "reachable"})
 		} else {

--- a/internal/doctor/deep_plugins.go
+++ b/internal/doctor/deep_plugins.go
@@ -38,7 +38,7 @@ func probePluginHTTP(client *http.Client, pluginName string, port int) CheckResu
 				FixCmd:  fmt.Sprintf("nself start --plugin %s", pluginName),
 			}
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
 			return CheckResult{
 				Section: "plugins",

--- a/internal/doctor/deep_test.go
+++ b/internal/doctor/deep_test.go
@@ -132,7 +132,7 @@ func TestProbePluginHTTP_ConnectionRefused(t *testing.T) {
 			return
 		}
 		conn, _, _ := hj.Hijack()
-		conn.Close()
+		_ = conn.Close()
 	}))
 	defer srv.Close()
 

--- a/internal/doctor/dogfood_headers.go
+++ b/internal/doctor/dogfood_headers.go
@@ -79,7 +79,7 @@ func checkHSTSHeader(ctx context.Context) CheckResult {
 		return CheckResult{Section: "security", Name: checkName, Status: "warn",
 			Message: fmt.Sprintf("unreachable: %v", err)}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	hsts := resp.Header.Get("Strict-Transport-Security")
 	if hsts == "" {
@@ -130,7 +130,7 @@ func checkHttpOnlyCookies(ctx context.Context) CheckResult {
 		return CheckResult{Section: "security", Name: checkName, Status: "warn",
 			Message: fmt.Sprintf("unreachable: %v", err)}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	cookies := resp.Cookies()
 	if len(cookies) == 0 {

--- a/internal/doctor/hardening_check_helpers.go
+++ b/internal/doctor/hardening_check_helpers.go
@@ -65,7 +65,7 @@ func readEnvFileKey(path, key string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	prefix := key + "="
 	scanner := bufio.NewScanner(f)

--- a/internal/doctor/hasura_remote_schema_orphans.go
+++ b/internal/doctor/hasura_remote_schema_orphans.go
@@ -143,7 +143,7 @@ func exportRemoteSchemas(ctx context.Context, hasuraURL, adminSecret string) ([]
 	if err != nil {
 		return nil, fmt.Errorf("metadata API unreachable: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))

--- a/internal/doctor/hasura_remote_schema_orphans_test.go
+++ b/internal/doctor/hasura_remote_schema_orphans_test.go
@@ -21,9 +21,9 @@ func metadataResponse(schemas []map[string]interface{}) []byte {
 }
 
 func TestCheckOrphanRemoteSchemas_NoHasuraURL(t *testing.T) {
-	os.Unsetenv("NSELF_HASURA_GRAPHQL_URL")
-	os.Unsetenv("HASURA_GRAPHQL_URL")
-	os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET")
+	_ = os.Unsetenv("NSELF_HASURA_GRAPHQL_URL")
+	_ = os.Unsetenv("HASURA_GRAPHQL_URL")
+	_ = os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET")
 
 	result := CheckOrphanRemoteSchemas(context.Background())
 	if result.Status != "skip" {
@@ -32,9 +32,9 @@ func TestCheckOrphanRemoteSchemas_NoHasuraURL(t *testing.T) {
 }
 
 func TestCheckOrphanRemoteSchemas_NoAdminSecret(t *testing.T) {
-	os.Setenv("HASURA_GRAPHQL_URL", "http://localhost:8080")
-	defer os.Unsetenv("HASURA_GRAPHQL_URL")
-	os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET")
+	_ = os.Setenv("HASURA_GRAPHQL_URL", "http://localhost:8080")
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_URL") }()
+	_ = os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET")
 
 	result := CheckOrphanRemoteSchemas(context.Background())
 	if result.Status != "skip" {
@@ -43,10 +43,10 @@ func TestCheckOrphanRemoteSchemas_NoAdminSecret(t *testing.T) {
 }
 
 func TestCheckOrphanRemoteSchemas_HasuraUnreachable(t *testing.T) {
-	os.Setenv("HASURA_GRAPHQL_URL", "http://127.0.0.1:19999") // nothing listening
-	defer os.Unsetenv("HASURA_GRAPHQL_URL")
-	os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
-	defer os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET")
+	_ = os.Setenv("HASURA_GRAPHQL_URL", "http://127.0.0.1:19999") // nothing listening
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_URL") }()
+	_ = os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET") }()
 
 	result := CheckOrphanRemoteSchemas(context.Background())
 	if result.Status != "warn" {
@@ -57,14 +57,14 @@ func TestCheckOrphanRemoteSchemas_HasuraUnreachable(t *testing.T) {
 func TestCheckOrphanRemoteSchemas_NoRemoteSchemas(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(metadataResponse(nil))
+		_, _ = w.Write(metadataResponse(nil))
 	}))
 	defer srv.Close()
 
-	os.Setenv("HASURA_GRAPHQL_URL", srv.URL)
-	defer os.Unsetenv("HASURA_GRAPHQL_URL")
-	os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
-	defer os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET")
+	_ = os.Setenv("HASURA_GRAPHQL_URL", srv.URL)
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_URL") }()
+	_ = os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET") }()
 
 	result := CheckOrphanRemoteSchemas(context.Background())
 	if result.Status != "pass" {
@@ -85,18 +85,18 @@ func TestCheckOrphanRemoteSchemas_AllLoaded(t *testing.T) {
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(metadataResponse(schemas))
+		_, _ = w.Write(metadataResponse(schemas))
 	}))
 	defer srv.Close()
 
-	os.Setenv("HASURA_GRAPHQL_URL", srv.URL)
-	defer os.Unsetenv("HASURA_GRAPHQL_URL")
-	os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
-	defer os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET")
+	_ = os.Setenv("HASURA_GRAPHQL_URL", srv.URL)
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_URL") }()
+	_ = os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET") }()
 
 	// Simulate both plugins loaded via NSELF_PLUGINS_LOADED.
-	os.Setenv("NSELF_PLUGINS_LOADED", "ai,stripe")
-	defer os.Unsetenv("NSELF_PLUGINS_LOADED")
+	_ = os.Setenv("NSELF_PLUGINS_LOADED", "ai,stripe")
+	defer func() { _ = os.Unsetenv("NSELF_PLUGINS_LOADED") }()
 
 	result := CheckOrphanRemoteSchemas(context.Background())
 	if result.Status != "pass" {
@@ -118,18 +118,18 @@ func TestCheckOrphanRemoteSchemas_OrphanDetected(t *testing.T) {
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(metadataResponse(schemas))
+		_, _ = w.Write(metadataResponse(schemas))
 	}))
 	defer srv.Close()
 
-	os.Setenv("HASURA_GRAPHQL_URL", srv.URL)
-	defer os.Unsetenv("HASURA_GRAPHQL_URL")
-	os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
-	defer os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET")
+	_ = os.Setenv("HASURA_GRAPHQL_URL", srv.URL)
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_URL") }()
+	_ = os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET") }()
 
 	// Only ai is loaded; stripe was uninstalled.
-	os.Setenv("NSELF_PLUGINS_LOADED", "ai")
-	defer os.Unsetenv("NSELF_PLUGINS_LOADED")
+	_ = os.Setenv("NSELF_PLUGINS_LOADED", "ai")
+	defer func() { _ = os.Unsetenv("NSELF_PLUGINS_LOADED") }()
 
 	result := CheckOrphanRemoteSchemas(context.Background())
 	if result.Status != "warn" {
@@ -153,18 +153,18 @@ func TestCheckOrphanRemoteSchemas_URLBasedMatch(t *testing.T) {
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(metadataResponse(schemas))
+		_, _ = w.Write(metadataResponse(schemas))
 	}))
 	defer srv.Close()
 
-	os.Setenv("HASURA_GRAPHQL_URL", srv.URL)
-	defer os.Unsetenv("HASURA_GRAPHQL_URL")
-	os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
-	defer os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET")
+	_ = os.Setenv("HASURA_GRAPHQL_URL", srv.URL)
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_URL") }()
+	_ = os.Setenv("HASURA_GRAPHQL_ADMIN_SECRET", "test-secret")
+	defer func() { _ = os.Unsetenv("HASURA_GRAPHQL_ADMIN_SECRET") }()
 
 	// Plugin URL env var present → plugin is loaded.
-	os.Setenv("PLUGIN_GEOCODING_INTERNAL_URL", pluginURL)
-	defer os.Unsetenv("PLUGIN_GEOCODING_INTERNAL_URL")
+	_ = os.Setenv("PLUGIN_GEOCODING_INTERNAL_URL", pluginURL)
+	defer func() { _ = os.Unsetenv("PLUGIN_GEOCODING_INTERNAL_URL") }()
 
 	result := CheckOrphanRemoteSchemas(context.Background())
 	if result.Status != "pass" {
@@ -173,11 +173,11 @@ func TestCheckOrphanRemoteSchemas_URLBasedMatch(t *testing.T) {
 }
 
 func TestResolveLoadedPlugins_MultipleSourcess(t *testing.T) {
-	os.Unsetenv("NSELF_PLUGINS_LOADED")
-	os.Setenv("NSELF_AI_LOADED", "1")
-	defer os.Unsetenv("NSELF_AI_LOADED")
-	os.Setenv("PLUGIN_STRIPE_INTERNAL_URL", "http://plugin-stripe:4001")
-	defer os.Unsetenv("PLUGIN_STRIPE_INTERNAL_URL")
+	_ = os.Unsetenv("NSELF_PLUGINS_LOADED")
+	_ = os.Setenv("NSELF_AI_LOADED", "1")
+	defer func() { _ = os.Unsetenv("NSELF_AI_LOADED") }()
+	_ = os.Setenv("PLUGIN_STRIPE_INTERNAL_URL", "http://plugin-stripe:4001")
+	defer func() { _ = os.Unsetenv("PLUGIN_STRIPE_INTERNAL_URL") }()
 
 	loaded := resolveLoadedPlugins()
 	if !loaded["ai"] {

--- a/internal/doctor/jwt.go
+++ b/internal/doctor/jwt.go
@@ -166,7 +166,7 @@ func envFileHasKey(path, key string) bool {
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	sc := bufio.NewScanner(f)
 	// Env values can be long (base64 JWT blobs, long JSON); bump the

--- a/internal/doctor/nself_audit_scan.go
+++ b/internal/doctor/nself_audit_scan.go
@@ -115,7 +115,7 @@ func CheckNSelfAuditScan(ctx context.Context, projectDir string) []CheckResult {
 		// fresh project will hit this; it's not an error.
 		return []CheckResult{nselfAuditSkipped(fmt.Sprintf("nself-audit plugin not reachable on :%s (run `nself plugin install nself-audit`)", port))}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))

--- a/internal/doctor/ops_drill_test.go
+++ b/internal/doctor/ops_drill_test.go
@@ -36,7 +36,7 @@ func writeEntry(t *testing.T, projectDir string, completedAt time.Time, success 
 	if err != nil {
 		t.Fatalf("open log: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := f.Write(append(data, '\n')); err != nil {
 		t.Fatalf("write log: %v", err)
 	}

--- a/internal/doctor/paypal_csv_parity_test.go
+++ b/internal/doctor/paypal_csv_parity_test.go
@@ -13,13 +13,13 @@ func TestCheckPayPalCSVParity_Mismatch(t *testing.T) {
 	originalIDs := os.Getenv("PAYPAL_CLIENT_IDS")
 	originalSecrets := os.Getenv("PAYPAL_CLIENT_SECRETS")
 	defer func() {
-		os.Setenv("PAYPAL_CLIENT_IDS", originalIDs)
-		os.Setenv("PAYPAL_CLIENT_SECRETS", originalSecrets)
+		_ = os.Setenv("PAYPAL_CLIENT_IDS", originalIDs)
+		_ = os.Setenv("PAYPAL_CLIENT_SECRETS", originalSecrets)
 	}()
 
 	// Test: 3 IDs, 2 secrets.
-	os.Setenv("PAYPAL_CLIENT_IDS", "id1,id2,id3")
-	os.Setenv("PAYPAL_CLIENT_SECRETS", "sec1,sec2")
+	_ = os.Setenv("PAYPAL_CLIENT_IDS", "id1,id2,id3")
+	_ = os.Setenv("PAYPAL_CLIENT_SECRETS", "sec1,sec2")
 
 	result := CheckPayPalCSVParity(context.Background())
 
@@ -40,13 +40,13 @@ func TestCheckPayPalCSVParity_Match(t *testing.T) {
 	originalIDs := os.Getenv("PAYPAL_CLIENT_IDS")
 	originalSecrets := os.Getenv("PAYPAL_CLIENT_SECRETS")
 	defer func() {
-		os.Setenv("PAYPAL_CLIENT_IDS", originalIDs)
-		os.Setenv("PAYPAL_CLIENT_SECRETS", originalSecrets)
+		_ = os.Setenv("PAYPAL_CLIENT_IDS", originalIDs)
+		_ = os.Setenv("PAYPAL_CLIENT_SECRETS", originalSecrets)
 	}()
 
 	// Test: 2 IDs, 2 secrets.
-	os.Setenv("PAYPAL_CLIENT_IDS", "id1,id2")
-	os.Setenv("PAYPAL_CLIENT_SECRETS", "sec1,sec2")
+	_ = os.Setenv("PAYPAL_CLIENT_IDS", "id1,id2")
+	_ = os.Setenv("PAYPAL_CLIENT_SECRETS", "sec1,sec2")
 
 	result := CheckPayPalCSVParity(context.Background())
 
@@ -64,13 +64,13 @@ func TestCheckPayPalCSVParity_NotConfigured(t *testing.T) {
 	originalIDs := os.Getenv("PAYPAL_CLIENT_IDS")
 	originalSecrets := os.Getenv("PAYPAL_CLIENT_SECRETS")
 	defer func() {
-		os.Setenv("PAYPAL_CLIENT_IDS", originalIDs)
-		os.Setenv("PAYPAL_CLIENT_SECRETS", originalSecrets)
+		_ = os.Setenv("PAYPAL_CLIENT_IDS", originalIDs)
+		_ = os.Setenv("PAYPAL_CLIENT_SECRETS", originalSecrets)
 	}()
 
 	// Test: both empty.
-	os.Setenv("PAYPAL_CLIENT_IDS", "")
-	os.Setenv("PAYPAL_CLIENT_SECRETS", "")
+	_ = os.Setenv("PAYPAL_CLIENT_IDS", "")
+	_ = os.Setenv("PAYPAL_CLIENT_SECRETS", "")
 
 	result := CheckPayPalCSVParity(context.Background())
 

--- a/internal/doctor/rls_check.go
+++ b/internal/doctor/rls_check.go
@@ -73,7 +73,7 @@ func CheckRLSEnforcement(ctx context.Context, strict bool) []CheckResult {
 			Message: fmt.Sprintf("cannot open DB for RLS check: %v", err),
 		}}
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	// Set a short timeout — this is a diagnostic check.
 	checkCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
@@ -190,7 +190,7 @@ func queryNPTables(ctx context.Context, db *sql.DB) ([]rlsTableInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("pg_class query: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var tables []rlsTableInfo
 	for rows.Next() {

--- a/internal/doctor/rls_hasura_filters.go
+++ b/internal/doctor/rls_hasura_filters.go
@@ -65,7 +65,7 @@ func checkHasuraRowFilters(ctx context.Context, tables []rlsTableInfo, warnStatu
 			Message: fmt.Sprintf("Hasura metadata API unreachable: %v (skipping filter audit)", err),
 		}}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return []CheckResult{{

--- a/internal/doctor/sdk_version.go
+++ b/internal/doctor/sdk_version.go
@@ -227,7 +227,7 @@ func getJSON(ctx context.Context, client *http.Client, url string) ([]byte, erro
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, nil // not yet published — caller treats empty string as warn

--- a/internal/doctor/sdk_version_test.go
+++ b/internal/doctor/sdk_version_test.go
@@ -71,7 +71,7 @@ func TestVersionDriftStatus(t *testing.T) {
 func TestCheckOneSDK_Pass(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"version": "1.0.13"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "1.0.13"})
 	}))
 	defer ts.Close()
 
@@ -116,7 +116,7 @@ func TestCheckOneSDK_Warn(t *testing.T) {
 func TestCheckOneSDK_Drift(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"version": "1.0.10"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "1.0.10"})
 	}))
 	defer ts.Close()
 
@@ -142,7 +142,7 @@ func TestCheckOneSDK_Drift(t *testing.T) {
 func TestCheckOneSDK_MajorMismatch(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"version": "2.0.0"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "2.0.0"})
 	}))
 	defer ts.Close()
 

--- a/internal/embedded/pg_socket_bridge.go
+++ b/internal/embedded/pg_socket_bridge.go
@@ -77,7 +77,7 @@ func (b *PGSocketBridge) Listen(ctx context.Context, sockPath string, runtime *E
 		return fmt.Errorf("embedded/bridge: listen on %s: %w", sockPath, err)
 	}
 	if err := os.Chmod(sockPath, 0o660); err != nil {
-		ln.Close()
+		_ = ln.Close()
 		return fmt.Errorf("embedded/bridge: chmod socket: %w", err)
 	}
 
@@ -128,7 +128,7 @@ func (b *PGSocketBridge) acceptLoop(ctx context.Context) {
 // Postgres simple-query (Q) messages. Extended-query protocol (P/B/E) flow is
 // passed through unmodified; pglite itself will reject unsupported commands.
 func (b *PGSocketBridge) handleConn(ctx context.Context, client net.Conn) {
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	b.mu.Lock()
 	rt := b.runtime
@@ -141,7 +141,7 @@ func (b *PGSocketBridge) handleConn(ctx context.Context, client net.Conn) {
 		// Cannot reach pglite — close the client connection.
 		return
 	}
-	defer backend.Close()
+	defer func() { _ = backend.Close() }()
 
 	// Bidirectional copy with interception on the client→backend direction.
 	var wg sync.WaitGroup

--- a/internal/embedded/pg_socket_bridge_test.go
+++ b/internal/embedded/pg_socket_bridge_test.go
@@ -79,7 +79,7 @@ func TestPGSocketBridge_UnsupportedCommandIntercepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("backend listen: %v", err)
 	}
-	defer backendLn.Close()
+	defer func() { _ = backendLn.Close() }()
 
 	backendReceived := make(chan []byte, 1)
 	go func() {
@@ -87,7 +87,7 @@ func TestPGSocketBridge_UnsupportedCommandIntercepted(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		buf, _ := io.ReadAll(conn)
 		backendReceived <- buf
 	}()
@@ -103,20 +103,20 @@ func TestPGSocketBridge_UnsupportedCommandIntercepted(t *testing.T) {
 	if err := bridge.Listen(t.Context(), bridgeSock, rt); err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
-	defer bridge.Close()
+	defer func() { _ = bridge.Close() }()
 
 	// Connect as a Postgres client.
 	client, err := net.Dial("unix", bridgeSock)
 	if err != nil {
 		t.Fatalf("client dial: %v", err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// Send a simple-query (Q) message with COPY.
 	sendSimpleQuery(t, client, "COPY foo FROM STDIN")
 
 	// Expect an ErrorResponse back.
-	client.SetDeadline(time.Now().Add(2 * time.Second))
+	_ = client.SetDeadline(time.Now().Add(2 * time.Second))
 	resp := make([]byte, 512)
 	n, err := client.Read(resp)
 	if err != nil {
@@ -170,7 +170,7 @@ func TestPGSocketBridge_SocketFile(t *testing.T) {
 	if err := bridge.Listen(t.Context(), bridgeSock, rt); err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
-	defer bridge.Close()
+	defer func() { _ = bridge.Close() }()
 
 	if _, err := os.Stat(bridgeSock); err != nil {
 		t.Errorf("socket file not created: %v", err)

--- a/internal/embedded/pglite_fetch.go
+++ b/internal/embedded/pglite_fetch.go
@@ -163,7 +163,7 @@ func downloadAndVerify(ctx context.Context, url, dst, want string) error {
 	if err != nil {
 		return fmt.Errorf("embedded/pglite: download %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("embedded/pglite: server returned %d for %s", resp.StatusCode, url)
@@ -179,7 +179,7 @@ func downloadAndVerify(ctx context.Context, url, dst, want string) error {
 
 	h := sha256.New()
 	if _, err := io.Copy(io.MultiWriter(tmp, h), resp.Body); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("embedded/pglite: write download: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
@@ -203,7 +203,7 @@ func sha256HexFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {

--- a/internal/embedded/wasmtime_runtime_boot.go
+++ b/internal/embedded/wasmtime_runtime_boot.go
@@ -90,9 +90,9 @@ func (r *EmbeddedPGRuntime) boot(ctx context.Context) error {
 
 	// Configure WASI: preopened filesystem, environment.
 	wasiCfg := wasmtime.NewWasiConfig()
-	wasiCfg.SetStdoutFile(filepath.Join(r.runtimeDir, "pglite-stdout.log"))
-	wasiCfg.SetStderrFile(filepath.Join(r.runtimeDir, "pglite-stderr.log"))
-	wasiCfg.PreopenDir(filepath.Join(r.runtimeDir, wasmPreopenDir), "/data")
+	_ = wasiCfg.SetStdoutFile(filepath.Join(r.runtimeDir, "pglite-stdout.log"))
+	_ = wasiCfg.SetStderrFile(filepath.Join(r.runtimeDir, "pglite-stderr.log"))
+	_ = wasiCfg.PreopenDir(filepath.Join(r.runtimeDir, wasmPreopenDir), "/data")
 
 	store.SetWasi(wasiCfg)
 
@@ -183,10 +183,10 @@ func (r *EmbeddedPGRuntime) loadOrCompileModule() (*wasmtime.Module, error) {
 		tmp, err := os.CreateTemp(filepath.Dir(cachePath), ".pglite-compiled-*")
 		if err == nil {
 			if _, werr := tmp.Write(serialized); werr == nil {
-				tmp.Close()
+				_ = tmp.Close()
 				_ = os.Rename(tmp.Name(), cachePath)
 			} else {
-				tmp.Close()
+				_ = tmp.Close()
 				_ = os.Remove(tmp.Name())
 			}
 		}
@@ -217,7 +217,7 @@ func (r *EmbeddedPGRuntime) waitForSocket(ctx context.Context, exitCh <-chan err
 		conn, err := (&net.Dialer{}).DialContext(dialCtx, "unix", r.sockPath)
 		cancel()
 		if err == nil {
-			conn.Close()
+			_ = conn.Close()
 			return nil // ready
 		}
 
@@ -271,6 +271,6 @@ func (r *EmbeddedPGRuntime) Healthy() bool {
 	if err != nil {
 		return false
 	}
-	conn.Close()
+	_ = conn.Close()
 	return true
 }

--- a/internal/env/legacy_bios.go
+++ b/internal/env/legacy_bios.go
@@ -113,7 +113,7 @@ func applyLegacyBIOSFallback(
 			// Never abort the whole CLI on a single env promotion failure —
 			// that would brick the operator's command. Log to stderr and
 			// continue.
-			fmt.Fprintf(stderr, "warning: failed to promote %s -> %s: %v\n", legacy, canonical, err)
+			_, _ = fmt.Fprintf(stderr, "warning: failed to promote %s -> %s: %v\n", legacy, canonical, err)
 			continue
 		}
 		promoted = append(promoted, LegacyBIOSPromotion{
@@ -147,7 +147,7 @@ func emitLegacyBIOSWarning(w io.Writer, promoted []LegacyBIOSPromotion) {
 		fmt.Fprintf(&b, "              %s  ->  %s\n", p.Legacy, p.Canonical)
 	}
 	b.WriteString("\n")
-	fmt.Fprint(w, b.String())
+	_, _ = fmt.Fprint(w, b.String())
 }
 
 // resetLegacyWarningOnce is a test-only helper that resets the

--- a/internal/eval/client.go
+++ b/internal/eval/client.go
@@ -84,7 +84,7 @@ func (c *Client) do(ctx context.Context, method, path string, body any, dst any)
 	if err != nil {
 		return fmt.Errorf("eval client request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/eval/client_test.go
+++ b/internal/eval/client_test.go
@@ -16,7 +16,7 @@ func TestRunSuite(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusAccepted)
-		json.NewEncoder(w).Encode(RunQueued{RunID: "run-abc123", Status: "queued"})
+		_ = json.NewEncoder(w).Encode(RunQueued{RunID: "run-abc123", Status: "queued"})
 	}))
 	defer srv.Close()
 
@@ -39,7 +39,7 @@ func TestGetRun(t *testing.T) {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
-		json.NewEncoder(w).Encode(EvalRunResult{
+		_ = json.NewEncoder(w).Encode(EvalRunResult{
 			SchemaVer:  expectedSchemaVer,
 			ID:         "run-xyz",
 			SuiteSlug:  "recall-quality-v1",
@@ -66,7 +66,7 @@ func TestGetRun(t *testing.T) {
 
 func TestGetRunSchemaVersionMismatch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(EvalRunResult{
+		_ = json.NewEncoder(w).Encode(EvalRunResult{
 			SchemaVer: 99,
 			ID:        "run-abc",
 			Status:    "passed",
@@ -89,7 +89,7 @@ func TestWaitForRunPollsUntilTerminal(t *testing.T) {
 		if calls >= 3 {
 			status = "passed"
 		}
-		json.NewEncoder(w).Encode(EvalRunResult{
+		_ = json.NewEncoder(w).Encode(EvalRunResult{
 			SchemaVer: expectedSchemaVer,
 			ID:        "run-poll",
 			Status:    status,
@@ -123,7 +123,7 @@ func TestWaitForRunPollsUntilTerminal(t *testing.T) {
 
 func TestWaitForRunPreconditionFailed(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(EvalRunResult{
+		_ = json.NewEncoder(w).Encode(EvalRunResult{
 			SchemaVer:          expectedSchemaVer,
 			ID:                 "run-pre",
 			Status:             "failed",
@@ -144,7 +144,7 @@ func TestWaitForRunPreconditionFailed(t *testing.T) {
 
 func TestValidateYAMLValid(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(ValidationResult{Valid: true})
+		_ = json.NewEncoder(w).Encode(ValidationResult{Valid: true})
 	}))
 	defer srv.Close()
 
@@ -160,7 +160,7 @@ func TestValidateYAMLValid(t *testing.T) {
 
 func TestValidateYAMLInvalid(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(ValidationResult{
+		_ = json.NewEncoder(w).Encode(ValidationResult{
 			Valid:  false,
 			Errors: []ValidationError{{Field: "suite", Message: "suite is required"}},
 		})
@@ -186,7 +186,7 @@ func TestGetGateStatus(t *testing.T) {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
-		json.NewEncoder(w).Encode(GateStatus{
+		_ = json.NewEncoder(w).Encode(GateStatus{
 			Tier:    "semi-auto",
 			Cleared: true,
 		})

--- a/internal/eval/output.go
+++ b/internal/eval/output.go
@@ -44,7 +44,7 @@ func WriteResult(w io.Writer, result EvalRunResult, format, repoRoot string) err
 	// Always write the JSON artifact.
 	if err := writeArtifact(result, repoRoot); err != nil {
 		// Non-fatal: print warning and continue.
-		fmt.Fprintf(w, "warning: could not write eval artifact: %v\n", err)
+		_, _ = fmt.Fprintf(w, "warning: could not write eval artifact: %v\n", err)
 	}
 
 	switch format {
@@ -85,28 +85,28 @@ func writeJSON(w io.Writer, result EvalRunResult) error {
 // writeTable writes a per-task tabular report to w.
 func writeTable(w io.Writer, result EvalRunResult) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	defer tw.Flush()
+	defer func() { _ = tw.Flush() }()
 
 	status := "PASSED"
 	if !result.Passed {
 		status = "FAILED"
 	}
 
-	fmt.Fprintf(tw, "Suite:\t%s\n", result.SuiteSlug)
-	fmt.Fprintf(tw, "Run ID:\t%s\n", result.ID)
-	fmt.Fprintf(tw, "Status:\t%s\n", status)
-	fmt.Fprintf(tw, "Pass Rate:\t%.1f%%\n", result.PassRate*100)
-	fmt.Fprintf(tw, "Suite Score:\t%.4f\n", result.SuiteScore)
-	fmt.Fprintln(tw)
+	_, _ = fmt.Fprintf(tw, "Suite:\t%s\n", result.SuiteSlug)
+	_, _ = fmt.Fprintf(tw, "Run ID:\t%s\n", result.ID)
+	_, _ = fmt.Fprintf(tw, "Status:\t%s\n", status)
+	_, _ = fmt.Fprintf(tw, "Pass Rate:\t%.1f%%\n", result.PassRate*100)
+	_, _ = fmt.Fprintf(tw, "Suite Score:\t%.4f\n", result.SuiteScore)
+	_, _ = fmt.Fprintln(tw)
 
 	if len(result.Tasks) == 0 {
-		fmt.Fprintln(tw, "(no task results)")
+		_, _ = fmt.Fprintln(tw, "(no task results)")
 		return nil
 	}
 
 	// Header.
-	fmt.Fprintf(tw, "TASK\tMODE\tSCORE\tPASS\tRATIONALE\n")
-	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+	_, _ = fmt.Fprintf(tw, "TASK\tMODE\tSCORE\tPASS\tRATIONALE\n")
+	_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
 		strings.Repeat("-", 24), strings.Repeat("-", 8),
 		strings.Repeat("-", 6), strings.Repeat("-", 4),
 		strings.Repeat("-", 30))
@@ -120,7 +120,7 @@ func writeTable(w io.Writer, result EvalRunResult) error {
 		if len(rationale) > 50 {
 			rationale = rationale[:47] + "..."
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%.4f\t%s\t%s\n",
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%.4f\t%s\t%s\n",
 			truncate(t.TaskID, 24), t.ScoringMode, t.Score, passStr, rationale)
 	}
 	return nil
@@ -152,23 +152,23 @@ func WriteGateStatus(w io.Writer, gs GateStatus, verbose bool) {
 		icon = "✗"
 		label = "BLOCKED"
 	}
-	fmt.Fprintf(w, "%s  tier=%s  %s\n", icon, gs.Tier, label)
+	_, _ = fmt.Fprintf(w, "%s  tier=%s  %s\n", icon, gs.Tier, label)
 	if !gs.Cleared && len(gs.BlockingSuites) > 0 {
-		fmt.Fprintln(w, "Blocking suites:")
+		_, _ = fmt.Fprintln(w, "Blocking suites:")
 		for _, slug := range gs.BlockingSuites {
-			fmt.Fprintf(w, "  - %s\n", slug)
+			_, _ = fmt.Fprintf(w, "  - %s\n", slug)
 		}
 	}
 	if !gs.Enforced {
-		fmt.Fprintln(w, "  (note: tier enforcement is disabled — gate result is advisory)")
+		_, _ = fmt.Fprintln(w, "  (note: tier enforcement is disabled — gate result is advisory)")
 	}
 }
 
 // WriteValidationErrors prints validation errors to w.
 func WriteValidationErrors(w io.Writer, errs []ValidationError) {
-	fmt.Fprintf(w, "Validation failed (%d error(s)):\n", len(errs))
+	_, _ = fmt.Fprintf(w, "Validation failed (%d error(s)):\n", len(errs))
 	for _, e := range errs {
-		fmt.Fprintf(w, "  [%s] %s\n", e.Field, e.Message)
+		_, _ = fmt.Fprintf(w, "  [%s] %s\n", e.Field, e.Message)
 	}
 }
 

--- a/internal/generate/schema.go
+++ b/internal/generate/schema.go
@@ -178,7 +178,7 @@ func FetchSchema(ctx context.Context, hasuraURL, adminSecret string) (*introspec
 	if err != nil {
 		return nil, fmt.Errorf("introspection request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/health/checker_watch.go
+++ b/internal/health/checker_watch.go
@@ -87,7 +87,7 @@ func CheckEndpoint(ctx context.Context, url string) (*HealthResult, error) {
 			Details:  err.Error(),
 		}, nil
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	status := "unhealthy"
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {

--- a/internal/health/hasura_healthz.go
+++ b/internal/health/hasura_healthz.go
@@ -109,7 +109,7 @@ func HasuraHealthzHandler(cfg HasuraHealthzConfig) http.HandlerFunc {
 				resultCh <- probeResult{reachable: false}
 				return
 			}
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			resultCh <- probeResult{reachable: resp.StatusCode == http.StatusOK}
 		}()
 

--- a/internal/health/history.go
+++ b/internal/health/history.go
@@ -97,7 +97,7 @@ func SaveHistory(report *HealthReport, historyDir string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Write JSON line followed by newline.
 	data = append(data, '\n')
@@ -118,7 +118,7 @@ func GetHistory(historyDir string, limit int) ([]HealthReport, error) {
 		}
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Read all lines first, then take the tail.  Health history files
 	// are expected to stay small (hundreds of entries at most).

--- a/internal/health/probes.go
+++ b/internal/health/probes.go
@@ -135,7 +135,7 @@ func ProbeNginxHTTP(ctx context.Context, host string, port int) *HealthResult {
 			Details:  err.Error(),
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Any HTTP response (200, 301, 302, 403...) means Nginx is up.
 	return &HealthResult{
@@ -194,7 +194,7 @@ func probeHTTP(ctx context.Context, service, url string, decide func(int, []byte
 			Details:  err.Error(),
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
 	status, detail := decide(resp.StatusCode, body)

--- a/internal/installer/ollama_matrix.go
+++ b/internal/installer/ollama_matrix.go
@@ -77,7 +77,7 @@ func MemAvailableMB() (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("read meminfo: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/internal/installer/ollama_systemd.go
+++ b/internal/installer/ollama_systemd.go
@@ -54,7 +54,7 @@ func downloadAndRunInstaller(ctx context.Context, log func(string, string, map[s
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(filepath.Dir(tmpPath))
+	defer func() { _ = os.RemoveAll(filepath.Dir(tmpPath)) }()
 
 	log("info", "install.sh checksum verified", map[string]any{"sha256": ExpectedOllamaInstallChecksum()})
 
@@ -121,7 +121,7 @@ func probeUntilReady(ctx context.Context, url string, total time.Duration) error
 		req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
 		resp, err := httptimeout.Installer.Do(req)
 		if err == nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if resp.StatusCode == 200 {
 				return nil
 			}
@@ -137,7 +137,7 @@ func probeOllamaVersion(ctx context.Context) string {
 	if err != nil {
 		return ""
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	var body struct {
 		Version string `json:"version"`
 	}
@@ -159,7 +159,7 @@ func pullOllamaModel(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("pull %s HTTP %d: %s", name, resp.StatusCode, string(body))

--- a/internal/installer/ollama_test.go
+++ b/internal/installer/ollama_test.go
@@ -43,7 +43,7 @@ func TestInstallerHTTPTimeout(t *testing.T) {
 	elapsed := time.Since(start)
 
 	if err == nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		t.Fatalf("expected timeout error, got nil after %v", elapsed)
 	}
 	// Timeout should fire near 100ms, well below the server's 400ms sleep.

--- a/internal/installer/verify.go
+++ b/internal/installer/verify.go
@@ -47,7 +47,7 @@ func DownloadAndVerify(ctx context.Context, url, expectedSHA string) (string, er
 	if err != nil {
 		return "", errf(ErrOllamaInstallFailed, fmt.Sprintf("download %s", url), err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", errf(ErrOllamaInstallFailed,
@@ -62,14 +62,14 @@ func DownloadAndVerify(ctx context.Context, url, expectedSHA string) (string, er
 		return "", errf(ErrOllamaInstallFailed, "create temp dir", err)
 	}
 	if err = os.Chmod(dir, 0o700); err != nil {
-		os.RemoveAll(dir)
+		_ = os.RemoveAll(dir)
 		return "", errf(ErrOllamaInstallFailed, "chmod temp dir", err)
 	}
 
 	tmpPath := dir + "/install.sh"
 	tmp, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
 	if err != nil {
-		os.RemoveAll(dir)
+		_ = os.RemoveAll(dir)
 		return "", errf(ErrOllamaInstallFailed, "create temp file", err)
 	}
 
@@ -77,18 +77,18 @@ func DownloadAndVerify(ctx context.Context, url, expectedSHA string) (string, er
 	w := io.MultiWriter(tmp, h)
 
 	if _, err = io.Copy(w, io.LimitReader(resp.Body, 2*1024*1024)); err != nil {
-		tmp.Close()
-		os.RemoveAll(dir)
+		_ = tmp.Close()
+		_ = os.RemoveAll(dir)
 		return "", errf(ErrOllamaInstallFailed, "write temp file", err)
 	}
 	if err = tmp.Close(); err != nil {
-		os.RemoveAll(dir)
+		_ = os.RemoveAll(dir)
 		return "", errf(ErrOllamaInstallFailed, "close temp file", err)
 	}
 
 	got := hex.EncodeToString(h.Sum(nil))
 	if got != expectedSHA {
-		os.RemoveAll(dir)
+		_ = os.RemoveAll(dir)
 		return "", errf(ErrOllamaInstallFailed,
 			fmt.Sprintf("checksum mismatch: got %s want %s", got, expectedSHA), nil)
 	}

--- a/internal/installer/verify_test.go
+++ b/internal/installer/verify_test.go
@@ -35,7 +35,7 @@ func TestDownloadAndVerify_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DownloadAndVerify returned unexpected error: %v", err)
 	}
-	defer os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	if tmpPath == "" {
 		t.Fatal("DownloadAndVerify returned empty path on success")
@@ -65,14 +65,14 @@ func TestDownloadAndVerify_Mismatch(t *testing.T) {
 
 	tmpPath, err := DownloadAndVerify(context.Background(), srv.URL, wrongSHA)
 	if err == nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		t.Fatal("DownloadAndVerify: expected checksum mismatch error, got nil")
 	}
 
 	// Temp file must not remain on disk after a mismatch.
 	if tmpPath != "" {
 		if _, statErr := os.Stat(tmpPath); statErr == nil {
-			os.Remove(tmpPath)
+			_ = os.Remove(tmpPath)
 			t.Errorf("DownloadAndVerify left temp file %q behind on mismatch", tmpPath)
 		}
 	}
@@ -133,7 +133,7 @@ func TestDownloadAndVerify_TempDirPerms(t *testing.T) {
 		t.Fatalf("DownloadAndVerify returned unexpected error: %v", err)
 	}
 	dir := filepath.Dir(tmpPath)
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	// Directory must be 0700 (owner-only).
 	dirInfo, err := os.Stat(dir)
@@ -172,14 +172,14 @@ func TestDownloadAndVerify_ContextCancel(t *testing.T) {
 	tmpPath, err := DownloadAndVerify(ctx, srv.URL, sha256Hex([]byte("any")))
 	if err == nil {
 		if tmpPath != "" {
-			os.RemoveAll(filepath.Dir(tmpPath))
+			_ = os.RemoveAll(filepath.Dir(tmpPath))
 		}
 		t.Fatal("DownloadAndVerify: expected error for cancelled context, got nil")
 	}
 	// No temp file should remain.
 	if tmpPath != "" {
 		if _, statErr := os.Stat(tmpPath); statErr == nil {
-			os.RemoveAll(filepath.Dir(tmpPath))
+			_ = os.RemoveAll(filepath.Dir(tmpPath))
 			t.Errorf("DownloadAndVerify left temp file %q behind on context cancel", tmpPath)
 		}
 	}
@@ -207,7 +207,7 @@ func TestDownloadAndVerify_LimitReaderCap(t *testing.T) {
 	tmpPath, err := DownloadAndVerify(context.Background(), srv.URL, correctSHA)
 	if err == nil {
 		if tmpPath != "" {
-			os.RemoveAll(filepath.Dir(tmpPath))
+			_ = os.RemoveAll(filepath.Dir(tmpPath))
 		}
 		t.Fatal("DownloadAndVerify: expected checksum mismatch for body > 2 MiB cap, got nil")
 	}
@@ -222,7 +222,7 @@ func TestDownloadAndVerify_LimitReaderCap(t *testing.T) {
 	// No temp artefacts should remain.
 	if tmpPath != "" {
 		if _, statErr := os.Stat(tmpPath); statErr == nil {
-			os.RemoveAll(filepath.Dir(tmpPath))
+			_ = os.RemoveAll(filepath.Dir(tmpPath))
 			t.Errorf("DownloadAndVerify left temp file %q behind after mismatch", tmpPath)
 		}
 	}

--- a/internal/license/checker.go
+++ b/internal/license/checker.go
@@ -62,7 +62,7 @@ func BundleEntitled(ctx context.Context, key, bundleName string) (bool, error) {
 		}
 		return false, fmt.Errorf("license validation network error (bundle=%q): %w", bundleName, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/internal/license/checker_test.go
+++ b/internal/license/checker_test.go
@@ -26,7 +26,7 @@ func newRefusingServer(t *testing.T) *httptest.Server {
 			return
 		}
 		conn, _, _ := hj.Hijack()
-		conn.Close()
+		_ = conn.Close()
 	}))
 	t.Cleanup(srv.Close)
 	return srv

--- a/internal/license/coverage_g7t03_test.go
+++ b/internal/license/coverage_g7t03_test.go
@@ -620,7 +620,7 @@ func TestIsTerminal_NotTerminal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTemp: %v", err)
 	}
-	defer tmpFile.Close()
+	defer func() { _ = tmpFile.Close() }()
 	if isTerminal(tmpFile) {
 		t.Error("isTerminal(regular file) should be false")
 	}
@@ -632,7 +632,7 @@ func TestIsTerminal_ClosedFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTemp: %v", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 	// Stat on a closed file fails on most platforms.
 	_ = isTerminal(tmpFile) // do not panic
 }
@@ -678,12 +678,12 @@ func TestTailStream_DefaultStdout(t *testing.T) {
 	os.Stdout = w
 	defer func() {
 		os.Stdout = origStdout
-		w.Close()
-		r.Close()
+		_ = w.Close()
+		_ = r.Close()
 	}()
 
 	// Drain pipe in background to avoid blocking write.
-	go io.Copy(io.Discard, r)
+	go func() { _, _ = io.Copy(io.Discard, r) }()
 
 	err := TailStream(ctx, TailOptions{
 		// Stdout: nil — exercises default branch.

--- a/internal/license/extra_test.go
+++ b/internal/license/extra_test.go
@@ -497,7 +497,7 @@ func TestRefreshCache_InvalidLicense(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(ValidateResponse{
+		_ = json.NewEncoder(w).Encode(ValidateResponse{
 			Valid:   false,
 			Reason:  "revoked",
 			Tier:    "",
@@ -643,7 +643,7 @@ func TestValidateFull_RemoteSuccess(t *testing.T) {
 	future := time.Now().Add(30 * 24 * time.Hour)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(ValidateResponse{
+		_ = json.NewEncoder(w).Encode(ValidateResponse{
 			Valid:     true,
 			Tier:      "pro",
 			Plugins:   []string{"ai", "claw"},
@@ -677,7 +677,7 @@ func TestValidateFull_RemoteReturnsInvalid(t *testing.T) {
 	setupCacheDir(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(ValidateResponse{
+		_ = json.NewEncoder(w).Encode(ValidateResponse{
 			Valid:   false,
 			Reason:  "key not found",
 			Tier:    "",

--- a/internal/license/license_coverage2_test.go
+++ b/internal/license/license_coverage2_test.go
@@ -362,7 +362,7 @@ func TestBundleEntitled_ValidResponseTrue(t *testing.T) {
 	body, _ := json.Marshal(resp)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(body)
+		_, _ = w.Write(body)
 	}))
 	defer srv.Close()
 	t.Setenv("LICENSE_PING_URL", srv.URL)
@@ -381,7 +381,7 @@ func TestBundleEntitled_ValidResponseFalse(t *testing.T) {
 	body, _ := json.Marshal(resp)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(body)
+		_, _ = w.Write(body)
 	}))
 	defer srv.Close()
 	t.Setenv("LICENSE_PING_URL", srv.URL)
@@ -403,7 +403,7 @@ func TestBundleEntitled_ValidResponseFalseEmptyReason(t *testing.T) {
 	body, _ := json.Marshal(resp)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(body)
+		_, _ = w.Write(body)
 	}))
 	defer srv.Close()
 	t.Setenv("LICENSE_PING_URL", srv.URL)
@@ -554,7 +554,7 @@ func TestWarnFailOpenOnce_RunsTwiceOnlyWarnsOnce(t *testing.T) {
 func TestTryRemote_HTTP500C2(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`server error`))
+		_, _ = w.Write([]byte(`server error`))
 	}))
 	defer srv.Close()
 
@@ -577,7 +577,7 @@ func TestTryRemote_HTTP200_ValidResponseC2(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(respBody)
+		_, _ = w.Write(respBody)
 	}))
 	defer srv.Close()
 

--- a/internal/license/license_coverage_test.go
+++ b/internal/license/license_coverage_test.go
@@ -64,7 +64,7 @@ func TestWriteCache_CreateTempFail(t *testing.T) {
 	if err := os.Chmod(cacheDir, 0555); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Chmod(cacheDir, 0755) })
+	t.Cleanup(func() { _ = os.Chmod(cacheDir, 0755) })
 
 	cachePath := filepath.Join(cacheDir, "license.json")
 	t.Setenv("LICENSE_CACHE_PATH", cachePath)
@@ -208,7 +208,7 @@ func TestMigrateLicenseFromV1_OpenFileFail(t *testing.T) {
 	if err := os.Chmod(v2Dir, 0555); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Chmod(v2Dir, 0755) })
+	t.Cleanup(func() { _ = os.Chmod(v2Dir, 0755) })
 
 	err := MigrateLicenseFromV1(home)
 	if err == nil {

--- a/internal/license/manager.go
+++ b/internal/license/manager.go
@@ -216,14 +216,14 @@ func MigrateLicenseFromV1(home string) error {
 	if err != nil {
 		return fmt.Errorf("opening v1 license: %w", err)
 	}
-	defer src.Close()
+	defer func() { _ = src.Close() }()
 
 	// Create v2 destination with restricted permissions.
 	dst, err := os.OpenFile(v2Path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return fmt.Errorf("creating v2 license file: %w", err)
 	}
-	defer dst.Close()
+	defer func() { _ = dst.Close() }()
 
 	if _, err := io.Copy(dst, src); err != nil {
 		// Remove incomplete destination on copy failure.

--- a/internal/license/revocation_refresh_check.go
+++ b/internal/license/revocation_refresh_check.go
@@ -57,7 +57,7 @@ func RefreshRevocationList(ctx context.Context) (*RevocationCache, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetching revocation list: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotModified {
 		// Server confirms cache is current; touch FetchedAt so the

--- a/internal/license/simulate_test.go
+++ b/internal/license/simulate_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSimulateOffline_GuardRequired(t *testing.T) {
-	os.Unsetenv(SimulationGuardEnv)
+	_ = os.Unsetenv(SimulationGuardEnv)
 	_, err := SimulateOffline(7)
 	if err == nil {
 		t.Fatal("expected error when simulation guard is not set")

--- a/internal/license/tail.go
+++ b/internal/license/tail.go
@@ -67,7 +67,7 @@ func TailStream(ctx context.Context, opts TailOptions) error {
 		client = &http.Client{Timeout: 0} // streaming — no timeout
 	}
 
-	fmt.Fprintln(stdout, "Streaming license validation events (Ctrl-C to stop)...")
+	_, _ = fmt.Fprintln(stdout, "Streaming license validation events (Ctrl-C to stop)...")
 
 	backoff := time.Second
 	for {
@@ -80,7 +80,7 @@ func TailStream(ctx context.Context, opts TailOptions) error {
 			if ctx.Err() != nil {
 				return nil
 			}
-			fmt.Fprintf(stdout, "\033[33mreconnecting in %s (lost connection: %v)\033[0m\n", backoff, err)
+			_, _ = fmt.Fprintf(stdout, "\033[33mreconnecting in %s (lost connection: %v)\033[0m\n", backoff, err)
 			select {
 			case <-ctx.Done():
 				return nil
@@ -117,7 +117,7 @@ func streamOnce(ctx context.Context, client *http.Client, pingURL string, filter
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("stream endpoint returned HTTP %d", resp.StatusCode)
@@ -208,7 +208,7 @@ func printEvent(w io.Writer, ev LicenseEvent) {
 		}
 	}
 
-	fmt.Fprintf(w, "%s%s  %-10s  key=%-12s  plugin=%-20s%s\n",
+	_, _ = fmt.Fprintf(w, "%s%s  %-10s  key=%-12s  plugin=%-20s%s\n",
 		color,
 		ts,
 		strings.ToUpper(ev.Result),

--- a/internal/license/tail_test.go
+++ b/internal/license/tail_test.go
@@ -30,7 +30,7 @@ func buildEventStream(t *testing.T, events []LicenseEvent) *httptest.Server {
 				ev.Plugin,
 				ev.Result,
 			)
-			fmt.Fprintf(w, "data: %s\n\n", data)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
 			flusher.Flush()
 		}
 	}))

--- a/internal/license/validate.go
+++ b/internal/license/validate.go
@@ -227,7 +227,7 @@ func validateRemote(ctx context.Context, key string, pingURL string) (*ValidateR
 	if err != nil {
 		return nil, fmt.Errorf("network error: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("server returned %d", resp.StatusCode)

--- a/internal/license/validate_test.go
+++ b/internal/license/validate_test.go
@@ -75,7 +75,7 @@ func TestImportCache_SkipVerifyWithForceEmitsWarning(t *testing.T) {
 	// write attempt.
 	ImportCache(data) //nolint:errcheck
 
-	w.Close()
+	_ = w.Close()
 	os.Stderr = origStderr
 	buf := make([]byte, 512)
 	n, _ := r.Read(buf)

--- a/internal/migrate/firebase/firebase_migration_auth.go
+++ b/internal/migrate/firebase/firebase_migration_auth.go
@@ -106,7 +106,7 @@ func buildAuthImport(authExportFile string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening auth export: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var export firebaseAuthExport
 	if err := json.NewDecoder(f).Decode(&export); err != nil {

--- a/internal/migrate/firebase/firebase_schema.go
+++ b/internal/migrate/firebase/firebase_schema.go
@@ -134,7 +134,7 @@ func parseExportFile(path string, fields map[string]map[string]map[string]int, s
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var raw json.RawMessage
 	if err := json.NewDecoder(f).Decode(&raw); err != nil {

--- a/internal/migrate/supabase/supabase.go
+++ b/internal/migrate/supabase/supabase.go
@@ -140,7 +140,7 @@ func (c *Client) get(ctx context.Context, url string, extraHeaders map[string]st
 		if err != nil {
 			return nil, fmt.Errorf("http request: %w", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		data, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {

--- a/internal/migrate/supabase/supabase_pull.go
+++ b/internal/migrate/supabase/supabase_pull.go
@@ -169,7 +169,7 @@ func (c *Client) PullRLSPolicies(ctx context.Context) ([]RLSPolicy, error) {
 		// an artifact with a manual-review note.
 		return nil, fmt.Errorf("RLS policy fetch network error (check connectivity): %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/migration/migrator.go
+++ b/internal/migration/migrator.go
@@ -46,7 +46,7 @@ func Run(ctx context.Context, projectDir string) error {
 		return nil
 	}
 
-	fmt.Fprintln(os.Stdout, "\n"+ui.C(ui.Yellow, ui.IconWarning)+" "+ui.C(ui.Bold, fmt.Sprintf("Migrating %d v1 artifact(s) to v2...", len(artifacts)))+"\n")
+	_, _ = fmt.Fprintln(os.Stdout, "\n"+ui.C(ui.Yellow, ui.IconWarning)+" "+ui.C(ui.Bold, fmt.Sprintf("Migrating %d v1 artifact(s) to v2...", len(artifacts)))+"\n")
 
 	// 2. Stop all running containers gracefully
 	ui.Section("Stopping containers")
@@ -146,7 +146,7 @@ func Rollback(ctx context.Context, projectDir, backupTimestamp string) error {
 	}
 
 	ui.Success(fmt.Sprintf("Restored %d file(s) from backup %s", len(manifest.Files), filepath.Base(backupDir)))
-	fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout)
 	ui.Info("Rollback complete. Run `docker compose up -d` to start your v1 stack.")
 	return nil
 }

--- a/internal/migration/migrator_helpers.go
+++ b/internal/migration/migrator_helpers.go
@@ -35,13 +35,13 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("open %s: %w", src, err)
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	out, err := os.Create(dst)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", dst, err)
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return fmt.Errorf("copy %s → %s: %w", src, dst, err)
@@ -101,35 +101,35 @@ func pluginWarning(projectDir, backupDir string) {
 		reset = "\033[0m"
 		red   = "\033[31m"
 	)
-	fmt.Fprintln(os.Stdout)
-	fmt.Fprintln(os.Stdout, bold+"┌─────────────────────────────────────────────────────────┐"+reset)
-	fmt.Fprintln(os.Stdout, bold+"│  PLUGINS MUST BE RE-INSTALLED                           │"+reset)
-	fmt.Fprintln(os.Stdout, bold+"│                                                          │"+reset)
-	fmt.Fprintln(os.Stdout, bold+"│  v0.9 plugin code is not compatible with v1.0.9 signed  │"+reset)
-	fmt.Fprintln(os.Stdout, bold+"│  bundles. Re-install each plugin after migration.        │"+reset)
-	fmt.Fprintln(os.Stdout, bold+"└─────────────────────────────────────────────────────────┘"+reset)
-	fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout, bold+"┌─────────────────────────────────────────────────────────┐"+reset)
+	_, _ = fmt.Fprintln(os.Stdout, bold+"│  PLUGINS MUST BE RE-INSTALLED                           │"+reset)
+	_, _ = fmt.Fprintln(os.Stdout, bold+"│                                                          │"+reset)
+	_, _ = fmt.Fprintln(os.Stdout, bold+"│  v0.9 plugin code is not compatible with v1.0.9 signed  │"+reset)
+	_, _ = fmt.Fprintln(os.Stdout, bold+"│  bundles. Re-install each plugin after migration.        │"+reset)
+	_, _ = fmt.Fprintln(os.Stdout, bold+"└─────────────────────────────────────────────────────────┘"+reset)
+	_, _ = fmt.Fprintln(os.Stdout)
 
-	fmt.Fprintln(os.Stdout, "  Step 1: Re-enter your license key")
-	fmt.Fprintln(os.Stdout, bold+"    nself license set <your-key>"+reset)
-	fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout, "  Step 1: Re-enter your license key")
+	_, _ = fmt.Fprintln(os.Stdout, bold+"    nself license set <your-key>"+reset)
+	_, _ = fmt.Fprintln(os.Stdout)
 
 	if len(plugins) > 0 {
 		installCmd := "nself plugin install"
 		for _, p := range plugins {
 			installCmd += " " + p
 		}
-		fmt.Fprintln(os.Stdout, fmt.Sprintf("  Step 2: Re-install your %d plugin(s) (detected from v0.9 .env)", len(plugins)))
-		fmt.Fprintln(os.Stdout, bold+"    "+installCmd+reset)
+		_, _ = fmt.Fprintln(os.Stdout, fmt.Sprintf("  Step 2: Re-install your %d plugin(s) (detected from v0.9 .env)", len(plugins)))
+		_, _ = fmt.Fprintln(os.Stdout, bold+"    "+installCmd+reset)
 	} else {
-		fmt.Fprintln(os.Stdout, "  Step 2: Re-install your plugins")
-		fmt.Fprintln(os.Stdout, bold+"    nself plugin install <plugin1> <plugin2> ..."+reset)
-		fmt.Fprintln(os.Stdout, red+"    (Could not detect plugin list from .env — check manually)"+reset)
+		_, _ = fmt.Fprintln(os.Stdout, "  Step 2: Re-install your plugins")
+		_, _ = fmt.Fprintln(os.Stdout, bold+"    nself plugin install <plugin1> <plugin2> ..."+reset)
+		_, _ = fmt.Fprintln(os.Stdout, red+"    (Could not detect plugin list from .env — check manually)"+reset)
 	}
 
-	fmt.Fprintln(os.Stdout)
-	fmt.Fprintln(os.Stdout, "  See: https://nself.org/docs/migrate/from-v0.9#step-3-re-install-plugins")
-	fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout, "  See: https://nself.org/docs/migrate/from-v0.9#step-3-re-install-plugins")
+	_, _ = fmt.Fprintln(os.Stdout)
 }
 
 // parseV09Plugins reads a v0.9 .env file and returns the list of enabled plugins.

--- a/internal/migrationai/generator.go
+++ b/internal/migrationai/generator.go
@@ -113,7 +113,7 @@ func (g *Generator) Generate(ctx context.Context, prompt string, deltas []Schema
 	if err != nil {
 		return nil, fmt.Errorf("ai generate call: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(resp.Body)

--- a/internal/migrationai/generator_test.go
+++ b/internal/migrationai/generator_test.go
@@ -235,7 +235,7 @@ func TestGenerator_Generate_HappyPath(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(mockResp)
+		_ = json.NewEncoder(w).Encode(mockResp)
 	}))
 	defer srv.Close()
 
@@ -274,7 +274,7 @@ func TestGenerator_Generate_LowConfidence(t *testing.T) {
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(mockResp)
+		_ = json.NewEncoder(w).Encode(mockResp)
 	}))
 	defer srv.Close()
 

--- a/internal/nginx/nginx_test.go
+++ b/internal/nginx/nginx_test.go
@@ -356,7 +356,7 @@ func TestAuthRouteNoDoubleDomain(t *testing.T) {
 // zone.
 func TestAuthRateLimitDefault(t *testing.T) {
 	// Ensure AUTH_RATE_LIMIT is not set in env.
-	os.Unsetenv("AUTH_RATE_LIMIT")
+	_ = os.Unsetenv("AUTH_RATE_LIMIT")
 
 	cfg := &config.Config{
 		BaseDomain: "local.nself.org",
@@ -757,8 +757,8 @@ func TestServiceConf_HSTS(t *testing.T) {
 // TestAuthRateLimitOverride verifies that setting AUTH_RATE_LIMIT=10r/m causes
 // the generated rate-limits.conf to use "10r/m" for the auth zone.
 func TestAuthRateLimitOverride(t *testing.T) {
-	os.Setenv("AUTH_RATE_LIMIT", "10r/m")
-	t.Cleanup(func() { os.Unsetenv("AUTH_RATE_LIMIT") })
+	_ = os.Setenv("AUTH_RATE_LIMIT", "10r/m")
+	t.Cleanup(func() { _ = os.Unsetenv("AUTH_RATE_LIMIT") })
 
 	cfg := &config.Config{
 		BaseDomain: "local.nself.org",

--- a/internal/oauth/manual_refresh.go
+++ b/internal/oauth/manual_refresh.go
@@ -90,7 +90,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		providers = []string{opts.Provider}
 	}
 
-	fmt.Fprintf(stdout, "Triggering OAuth refresh for provider(s): %s\n", strings.Join(providers, ", "))
+	_, _ = fmt.Fprintf(stdout, "Triggering OAuth refresh for provider(s): %s\n", strings.Join(providers, ", "))
 
 	// Run providers in parallel.
 	resultCh := make(chan ProviderResult, len(providers)*4)
@@ -116,18 +116,18 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	for r := range resultCh {
 		allResults = append(allResults, r)
 		if r.Err != nil {
-			fmt.Fprintf(stderr, "  FAIL provider=%s account=%s: %v\n",
+			_, _ = fmt.Fprintf(stderr, "  FAIL provider=%s account=%s: %v\n",
 				r.Provider, r.AccountID, r.Err)
 			failCount++
 		} else {
-			fmt.Fprintf(stdout, "  OK   provider=%s account=%s\n",
+			_, _ = fmt.Fprintf(stdout, "  OK   provider=%s account=%s\n",
 				r.Provider, r.AccountID)
 		}
 	}
 
 	result := &RefreshResult{Results: allResults, FailCount: failCount}
 
-	fmt.Fprintf(stdout, "\nRefresh complete: %d/%d succeeded\n",
+	_, _ = fmt.Fprintf(stdout, "\nRefresh complete: %d/%d succeeded\n",
 		len(allResults)-failCount, len(allResults))
 
 	if failCount > 0 {
@@ -149,7 +149,7 @@ func listProviders(ctx context.Context, client *http.Client, baseURL string) ([]
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("list providers returned HTTP %d", resp.StatusCode)
@@ -191,7 +191,7 @@ func refreshProvider(ctx context.Context, client *http.Client, baseURL, provider
 			Err:       fmt.Errorf("POST %s: %w", url, err),
 		}}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return []ProviderResult{{

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -68,7 +68,7 @@ func TestHTTPMetricsMiddleware(t *testing.T) {
 	r.Use(m.Middleware("test"))
 	r.Get("/api/test", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	})
 
 	req := httptest.NewRequest("GET", "/api/test", nil)

--- a/internal/plugin/arch.go
+++ b/internal/plugin/arch.go
@@ -80,7 +80,7 @@ func downloadBinaryPlugin(name, version, platform, archiveURL, checksumURL, dest
 	if err != nil {
 		return fmt.Errorf("download binary plugin: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download binary plugin: server returned %d for %s", resp.StatusCode, archiveURL)
 	}
@@ -89,14 +89,14 @@ func downloadBinaryPlugin(name, version, platform, archiveURL, checksumURL, dest
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
 	}
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 
 	hasher := sha256.New()
 	if _, err := io.Copy(io.MultiWriter(tmp, hasher), resp.Body); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("write download: %w", err)
 	}
-	tmp.Close()
+	_ = tmp.Close()
 	actualChecksum := hex.EncodeToString(hasher.Sum(nil))
 
 	// Verify checksum if provided.
@@ -115,7 +115,7 @@ func downloadBinaryPlugin(name, version, platform, archiveURL, checksumURL, dest
 
 	// Extract tarball to destDir.
 	if err := extractTarGz(tmp.Name(), destDir); err != nil {
-		os.RemoveAll(destDir)
+		_ = os.RemoveAll(destDir)
 		return fmt.Errorf("extract binary plugin: %w", err)
 	}
 
@@ -137,7 +137,7 @@ func fetchExpectedChecksum(client *http.Client, checksumURL, filename string) (s
 	if err != nil {
 		return "", fmt.Errorf("fetch checksums.txt: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("checksums.txt returned %d", resp.StatusCode)
 	}

--- a/internal/plugin/arch_test.go
+++ b/internal/plugin/arch_test.go
@@ -89,7 +89,7 @@ func TestDownloadBinaryPlugin_ChecksumMismatch(t *testing.T) {
 	// Correct SHA-256 of tarContent would pass; we serve a WRONG checksum.
 	archiveSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/gzip")
-		w.Write(tarContent)
+		_, _ = w.Write(tarContent)
 	}))
 	defer archiveSrv.Close()
 
@@ -97,7 +97,7 @@ func TestDownloadBinaryPlugin_ChecksumMismatch(t *testing.T) {
 		// Return wrong checksum for the archive filename.
 		filename := filepath.Base(r.URL.Path)
 		_ = filename
-		fmt.Fprintf(w, "%s  test-plugin-1.0.0-linux-amd64.tar.gz\n",
+		_, _ = fmt.Fprintf(w, "%s  test-plugin-1.0.0-linux-amd64.tar.gz\n",
 			"0000000000000000000000000000000000000000000000000000000000000000")
 	}))
 	defer checksumSrv.Close()

--- a/internal/plugin/cli_binary.go
+++ b/internal/plugin/cli_binary.go
@@ -210,7 +210,7 @@ func copyExecutable(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
 	if err != nil {
@@ -218,7 +218,7 @@ func copyExecutable(src, dst string) error {
 	}
 
 	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
+		_ = out.Close()
 		_ = os.Remove(dst)
 		return err
 	}

--- a/internal/plugin/compliance.go
+++ b/internal/plugin/compliance.go
@@ -70,7 +70,7 @@ func CheckCompliance(ctx context.Context, name string, port int) *ComplianceResu
 		} else {
 			check.Status = resp.StatusCode
 			check.Available = resp.StatusCode >= 200 && resp.StatusCode < 300
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if !check.Available && ep.Required {
 				result.Compliant = false
 			}

--- a/internal/plugin/config.go
+++ b/internal/plugin/config.go
@@ -36,7 +36,7 @@ func DisablePlugin(name, pluginDir string) error {
 	if err != nil {
 		return fmt.Errorf("creating disable marker: %w", err)
 	}
-	f.Close()
+	_ = f.Close()
 	return nil
 }
 

--- a/internal/plugin/download.go
+++ b/internal/plugin/download.go
@@ -106,7 +106,7 @@ func downloadFromURL(ctx context.Context, url string, extraHeaders map[string]st
 	if err != nil {
 		return "", fmt.Errorf("HTTP GET %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("HTTP GET %s: status %d", url, resp.StatusCode)
@@ -116,10 +116,10 @@ func downloadFromURL(ctx context.Context, url string, extraHeaders map[string]st
 	if err != nil {
 		return "", fmt.Errorf("creating temp file: %w", err)
 	}
-	defer tmp.Close()
+	defer func() { _ = tmp.Close() }()
 
 	if _, err := io.Copy(tmp, resp.Body); err != nil {
-		os.Remove(tmp.Name())
+		_ = os.Remove(tmp.Name())
 		return "", fmt.Errorf("writing download to temp file: %w", err)
 	}
 
@@ -164,13 +164,13 @@ func extractTarGz(archivePath, destDir string) error {
 	if err != nil {
 		return fmt.Errorf("opening archive: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gz, err := gzip.NewReader(f)
 	if err != nil {
 		return fmt.Errorf("gzip reader: %w", err)
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 
 	tr := tar.NewReader(gz)
 	for {
@@ -216,10 +216,10 @@ func extractTarGz(archivePath, destDir string) error {
 				return fmt.Errorf("creating file %s: %w", target, err)
 			}
 			if _, err := io.Copy(outFile, tr); err != nil {
-				outFile.Close()
+				_ = outFile.Close()
 				return fmt.Errorf("writing file %s: %w", target, err)
 			}
-			outFile.Close()
+			_ = outFile.Close()
 		}
 	}
 

--- a/internal/plugin/eol_behavior_test.go
+++ b/internal/plugin/eol_behavior_test.go
@@ -147,7 +147,7 @@ func TestCheckEOLBlock_NetworkOffline(t *testing.T) {
 	ctx := context.Background()
 	// Point at a registry URL that will fail immediately.
 	_ = os.Setenv("NSELF_PLUGIN_REGISTRY", "http://127.0.0.1:0/registry.json")
-	defer os.Unsetenv("NSELF_PLUGIN_REGISTRY")
+	defer func() { _ = os.Unsetenv("NSELF_PLUGIN_REGISTRY") }()
 
 	// CheckEOLBlock must not return an error for network failures.
 	err := CheckEOLBlock(ctx, "some-plugin", false)

--- a/internal/plugin/free_account.go
+++ b/internal/plugin/free_account.go
@@ -62,7 +62,7 @@ func RegisterFreeAccount(ctx context.Context, pingURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("free-register network error: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
@@ -113,6 +113,6 @@ func SendFreeInstallTelemetry(pingURL string, licenseKey string, pluginName stri
 		if err != nil {
 			return
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 	})
 }

--- a/internal/plugin/identity_register.go
+++ b/internal/plugin/identity_register.go
@@ -80,7 +80,7 @@ func RegisterIdentity(ctx context.Context, pluginName string, pubKey ed25519.Pub
 	if err != nil {
 		return fmt.Errorf("posting identity registration to %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("identity registration returned HTTP %d for plugin %q", resp.StatusCode, pluginName)
@@ -119,7 +119,7 @@ func RevokeIdentity(ctx context.Context, pluginName string) error {
 	if err != nil {
 		return fmt.Errorf("revoking identity for %q: %w", pluginName, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// 404 means already gone — treat as success.
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {

--- a/internal/plugin/identity_test.go
+++ b/internal/plugin/identity_test.go
@@ -152,7 +152,7 @@ func TestRemoveIdentityKey(t *testing.T) {
 // TestMissingSecretReturnsError verifies that missing PLUGIN_INTERNAL_SECRET
 // is caught early.
 func TestMissingSecretReturnsError(t *testing.T) {
-	os.Unsetenv("PLUGIN_INTERNAL_SECRET")
+	_ = os.Unsetenv("PLUGIN_INTERNAL_SECRET")
 
 	dir := t.TempDir()
 	if _, err := GenerateEd25519Keypair(dir, "ai"); err == nil {

--- a/internal/plugin/install_thirdparty.go
+++ b/internal/plugin/install_thirdparty.go
@@ -106,7 +106,7 @@ func InstallFromURL(ctx context.Context, cfg *config.Config, sourceURL string, p
 	if err != nil {
 		return fmt.Errorf("downloading third-party plugin from %s: %w", u.Host, err)
 	}
-	defer os.Remove(archivePath)
+	defer func() { _ = os.Remove(archivePath) }()
 
 	// Checksum policy for unofficial sources: verify ONLY when the caller
 	// supplied an expected value (out-of-band, e.g. --checksum). Checked
@@ -130,7 +130,7 @@ func InstallFromURL(ctx context.Context, cfg *config.Config, sourceURL string, p
 	if err != nil {
 		return fmt.Errorf("creating staging directory: %w", err)
 	}
-	defer os.RemoveAll(stagingDir)
+	defer func() { _ = os.RemoveAll(stagingDir) }()
 
 	if err := extractTarGz(archivePath, stagingDir); err != nil {
 		return fmt.Errorf("extracting third-party plugin archive from %s: %w", u.Host, err)

--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -48,7 +48,7 @@ func acquireInstallLock(pluginDir string) (*os.File, error) {
 		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err == nil {
 			// Lock acquired — write our PID for diagnostic purposes.
-			fmt.Fprintf(f, "%d\n", os.Getpid())
+			_, _ = fmt.Fprintf(f, "%d\n", os.Getpid())
 			return f, nil
 		}
 		if !os.IsExist(err) {
@@ -67,8 +67,8 @@ func acquireInstallLock(pluginDir string) (*os.File, error) {
 // acquireInstallLock. Errors are silently ignored; a stale lock file will be
 // cleaned up on the next acquire attempt.
 func releaseInstallLock(f *os.File, pluginDir string) {
-	f.Close()
-	os.Remove(installLockPath(pluginDir))
+	_ = f.Close()
+	_ = os.Remove(installLockPath(pluginDir))
 }
 
 // Install downloads, extracts, and configures a plugin. For paid plugins it

--- a/internal/plugin/installer_locked.go
+++ b/internal/plugin/installer_locked.go
@@ -160,20 +160,20 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 	if err != nil {
 		return fmt.Errorf("downloading plugin %q: %w", name, err)
 	}
-	defer os.Remove(archivePath)
+	defer func() { _ = os.Remove(archivePath) }()
 
 	// Step 5: Verify checksum before extraction.
 	// For stable plugins a missing checksum is a hard error (V06-F2).
 	// For non-stable plugins an absent checksum emits a warning and continues.
 	if manifest.Checksum != "" {
 		if err := verifyChecksum(archivePath, manifest.Checksum, manifest.PublishStatus); err != nil {
-			os.Remove(archivePath)
+			_ = os.Remove(archivePath)
 			return fmt.Errorf("checksum verification for plugin %q: %w", name, err)
 		}
 	} else {
 		if err := verifyChecksum(archivePath, "", manifest.PublishStatus); err != nil {
 			// stable plugin — hard fail returned by verifyChecksum
-			os.Remove(archivePath)
+			_ = os.Remove(archivePath)
 			return fmt.Errorf("checksum verification for plugin %q: %w", name, err)
 		}
 		fmt.Fprintf(os.Stderr, "warning: no checksum in registry for plugin %q, skipping verification\n", name)
@@ -188,7 +188,7 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 	// In prod/staging these bypass vars are fatal — dev-only escapes must never reach production.
 	bypassed, bypassErr := checkSigBypassAllowed(cfg.Env, name)
 	if bypassErr != nil {
-		os.Remove(archivePath)
+		_ = os.Remove(archivePath)
 		return bypassErr
 	}
 	if bypassed {
@@ -203,7 +203,7 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 		}
 	} else {
 		if err := verifyPluginSignature(archivePath, manifest.AuthorPublicKey, manifest.Signature, manifest.PublishStatus); err != nil {
-			os.Remove(archivePath)
+			_ = os.Remove(archivePath)
 			return fmt.Errorf("signature verification for plugin %q: %w", name, err)
 		}
 	}
@@ -216,7 +216,7 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 		SkipCheck: sbomSkip,
 		Version:   manifest.Version,
 	}); err != nil {
-		os.Remove(archivePath)
+		_ = os.Remove(archivePath)
 		return fmt.Errorf("sbom verification for plugin %q: %w", name, err)
 	}
 

--- a/internal/plugin/license.go
+++ b/internal/plugin/license.go
@@ -202,7 +202,7 @@ func validateLicenseRemoteWithEntitlements(ctx context.Context, key string, ping
 	if err != nil {
 		return false, nil, fmt.Errorf("license validation request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/internal/plugin/license_cache.go
+++ b/internal/plugin/license_cache.go
@@ -29,7 +29,7 @@ func pruneExpiredCacheEntries(cachePath string, maxAge time.Duration) error {
 		// File missing or unreadable -- nothing to prune.
 		return nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	hmacKey := loadHMACKeyOrFallback()
 	now := time.Now()
@@ -71,7 +71,7 @@ func pruneExpiredCacheEntries(cachePath string, maxAge time.Duration) error {
 		kept = append(kept, line)
 	}
 
-	f.Close()
+	_ = f.Close()
 
 	// Rewrite file with only valid, non-expired entries.
 	content := strings.Join(kept, "\n")
@@ -124,7 +124,7 @@ func checkLicenseCache(key string, cacheDir string) (valid bool, found bool) {
 	if err != nil {
 		return false, false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	hmacKey := loadHMACKeyOrFallback()
 	prefix := keyPrefix(key)
@@ -143,8 +143,8 @@ func checkLicenseCache(key string, cacheDir string) (valid bool, found bool) {
 		// Verify HMAC before trusting anything in the entry.
 		if !hmacVerify(data, sig, hmacKey) {
 			// Tampered or unsigned entry — nuke cache file.
-			f.Close()
-			os.Remove(cachePath)
+			_ = f.Close()
+			_ = os.Remove(cachePath)
 			return false, false
 		}
 
@@ -182,7 +182,7 @@ func checkLicenseCacheOffline(key string, cacheDir string) (valid bool, found bo
 	if err != nil {
 		return false, false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	hmacKey := loadHMACKeyOrFallback()
 	prefix := keyPrefix(key)
@@ -200,8 +200,8 @@ func checkLicenseCacheOffline(key string, cacheDir string) (valid bool, found bo
 
 		// Verify HMAC before trusting anything in the entry.
 		if !hmacVerify(data, sig, hmacKey) {
-			f.Close()
-			os.Remove(cachePath)
+			_ = f.Close()
+			_ = os.Remove(cachePath)
 			return false, false
 		}
 

--- a/internal/plugin/network.go
+++ b/internal/plugin/network.go
@@ -28,6 +28,6 @@ func ValidateNetworkAccess(ctx context.Context, registryURL string) error {
 	if err != nil {
 		return fmt.Errorf("cannot reach plugin registry %s: %w\nCheck your network connection or set NSELF_PLUGIN_REGISTRY to a local mirror.", registryURL, err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	return nil
 }

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -161,7 +161,7 @@ func (c *registryHTTPClient) fetchFromURL(ctx context.Context, url string) (*Reg
 	if err != nil {
 		return nil, fmt.Errorf("HTTP GET %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("HTTP GET %s: status %d", url, resp.StatusCode)

--- a/internal/plugin/runtime.go
+++ b/internal/plugin/runtime.go
@@ -198,7 +198,7 @@ func health(ctx context.Context, name string, port int) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusOK, nil
 }

--- a/internal/plugin/runtime_start.go
+++ b/internal/plugin/runtime_start.go
@@ -100,13 +100,13 @@ func Start(ctx context.Context, pluginDir string, name string) error {
 	setNewProcessGroup(cmd)
 
 	if err := cmd.Start(); err != nil {
-		logFile.Close()
+		_ = logFile.Close()
 		_ = writeState(name, "failed")
 		return fmt.Errorf("starting plugin %s: %w", name, err)
 	}
 
 	pid := cmd.Process.Pid
-	logFile.Close()
+	_ = logFile.Close()
 
 	// Write PID file.
 	if err := writePID(name, pid); err != nil {

--- a/internal/plugin/runtime_test.go
+++ b/internal/plugin/runtime_test.go
@@ -67,7 +67,7 @@ func TestGracePeriod_ClampMin(t *testing.T) {
 // TestGracePeriod_Unset verifies behavior when env var key is not present at all.
 func TestGracePeriod_Unset(t *testing.T) {
 	// Ensure the env var is completely absent.
-	os.Unsetenv("DOCKER_STOP_GRACE_PERIOD")
+	_ = os.Unsetenv("DOCKER_STOP_GRACE_PERIOD")
 	got := gracePeriod()
 	if got != 30*time.Second {
 		t.Errorf("unset env var: got %v, want 30s", got)

--- a/internal/plugin/security.go
+++ b/internal/plugin/security.go
@@ -77,7 +77,7 @@ func verifyChecksum(filePath string, expectedHash string, publishStatus string) 
 	if err != nil {
 		return fmt.Errorf("opening file for checksum: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
@@ -132,7 +132,7 @@ func verifyPluginSignature(archivePath, authorPublicKeyHex, signatureHex, publis
 	if err != nil {
 		return fmt.Errorf("opening archive for signature verification: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {

--- a/internal/plugin/security_license.go
+++ b/internal/plugin/security_license.go
@@ -172,7 +172,7 @@ func checkAuthorRevocation(ctx context.Context, author string) error {
 		fmt.Fprintf(os.Stderr, "warning: could not fetch author revocation list (offline?): %v\n", err)
 		return nil
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil

--- a/internal/plugin/signature_test.go
+++ b/internal/plugin/signature_test.go
@@ -30,7 +30,7 @@ func writeTempFile(t *testing.T, content []byte) string {
 	if err != nil {
 		t.Fatalf("CreateTemp: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := f.Write(content); err != nil {
 		t.Fatalf("Write: %v", err)
 	}

--- a/internal/plugin/tarslip_test.go
+++ b/internal/plugin/tarslip_test.go
@@ -58,7 +58,7 @@ func writeTempArchive(t *testing.T, data []byte) string {
 	if err != nil {
 		t.Fatalf("CreateTemp: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := f.Write(data); err != nil {
 		t.Fatalf("Write archive: %v", err)
 	}

--- a/internal/plugin/token_client.go
+++ b/internal/plugin/token_client.go
@@ -111,7 +111,7 @@ func RequestToken(ctx context.Context, pluginDataDir, sourcePlugin, targetPlugin
 	if err != nil {
 		return "", fmt.Errorf("requesting plugin token from %s: %w", url, err)
 	}
-	defer httpResp.Body.Close()
+	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("token endpoint returned HTTP %d for %s→%s", httpResp.StatusCode, sourcePlugin, targetPlugin)

--- a/internal/plugin/token_validator.go
+++ b/internal/plugin/token_validator.go
@@ -186,7 +186,7 @@ func getPublicKey(ctx context.Context, kid string) (ed25519.PublicKey, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetching public key: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("public-key endpoint returned HTTP %d for kid=%q", resp.StatusCode, kid)

--- a/internal/plugin/verify/verify_sbom.go
+++ b/internal/plugin/verify/verify_sbom.go
@@ -45,7 +45,7 @@ func VerifySBOM(ctx context.Context, pluginName, version string, opts SBOMCheckO
 	if err != nil {
 		return fmt.Errorf("sbom: download from %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		// SBOM not present on release — warn but don't fail (older plugin releases pre-S2.T11).

--- a/internal/postgres/extensions.go
+++ b/internal/postgres/extensions.go
@@ -24,7 +24,7 @@ func InstallExtensions(ctx context.Context, dsn string, extras []string) error {
 	if err != nil {
 		return fmt.Errorf("open: %w", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	all := dedupStrings(append(DefaultExtensions, extras...))
 	for _, ext := range all {

--- a/internal/repoqa/file_size_test.go
+++ b/internal/repoqa/file_size_test.go
@@ -56,7 +56,7 @@ func oversizedFiles(t *testing.T, root string) map[string]int {
 			if err != nil {
 				return err
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			n := 0
 			sc := bufio.NewScanner(f)

--- a/internal/runbook/steps.go
+++ b/internal/runbook/steps.go
@@ -77,7 +77,7 @@ func (e *Executor) runNotifySlack(ctx context.Context, params map[string]string)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("slack webhook returned %d", resp.StatusCode)
 	}
@@ -118,7 +118,7 @@ func (e *Executor) runEscalate(ctx context.Context, params map[string]string) er
 
 func (e *Executor) printf(format string, args ...interface{}) {
 	if e.Out != nil {
-		fmt.Fprintf(e.Out, format, args...)
+		_, _ = fmt.Fprintf(e.Out, format, args...)
 	}
 }
 

--- a/internal/search/warmup.go
+++ b/internal/search/warmup.go
@@ -131,7 +131,7 @@ func issueWarmupQuery(ctx context.Context, client *http.Client, baseURL, masterK
 	if err != nil {
 		return fmt.Errorf("http: %w", err)
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// 2xx = success.  404 = index absent (brand-new instance) — treat as OK
 	// because the warm-up still exercised the Meili request-parsing path.

--- a/internal/search/warmup_test.go
+++ b/internal/search/warmup_test.go
@@ -80,7 +80,7 @@ func mockMeiliServer(t *testing.T, statusCode int) *httptest.Server {
 func serverPort(srv *httptest.Server) int {
 	addr := srv.Listener.Addr().String()
 	var port int
-	fmt.Sscanf(strings.SplitN(addr, ":", 2)[1], "%d", &port)
+	_, _ = fmt.Sscanf(strings.SplitN(addr, ":", 2)[1], "%d", &port)
 	return port
 }
 

--- a/internal/secrets/rotation_test.go
+++ b/internal/secrets/rotation_test.go
@@ -46,7 +46,7 @@ func TestLoadRotationStateDefault(t *testing.T) {
 
 func TestSaveAndLoadRotationState(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, SecretsDir), 0700)
+	_ = os.MkdirAll(filepath.Join(dir, SecretsDir), 0700)
 
 	state := &RotationState{
 		Schedules: []RotationSchedule{
@@ -73,7 +73,7 @@ func TestSaveAndLoadRotationState(t *testing.T) {
 
 func TestCheckScheduleOverdue(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, SecretsDir), 0700)
+	_ = os.MkdirAll(filepath.Join(dir, SecretsDir), 0700)
 
 	pastDue := time.Now().UTC().AddDate(0, 0, -10).Format(time.RFC3339)
 	state := &RotationState{
@@ -100,7 +100,7 @@ func TestCheckScheduleOverdue(t *testing.T) {
 
 func TestCheckScheduleWarning(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, SecretsDir), 0700)
+	_ = os.MkdirAll(filepath.Join(dir, SecretsDir), 0700)
 
 	// Due in 3 days — should trigger warning (<7d)
 	nearDue := time.Now().UTC().AddDate(0, 0, 3).Format(time.RFC3339)

--- a/internal/secrets/secrets_audit_lint.go
+++ b/internal/secrets/secrets_audit_lint.go
@@ -100,11 +100,11 @@ func decryptWithKey(projectRoot, env, key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer os.Remove(tmpKey.Name())
+	defer func() { _ = os.Remove(tmpKey.Name()) }()
 	if _, err := tmpKey.WriteString(key); err != nil {
 		return "", err
 	}
-	tmpKey.Close()
+	_ = tmpKey.Close()
 
 	cmd := exec.Command("age", "--decrypt", "-i", tmpKey.Name(), path)
 	output, err := cmd.Output()

--- a/internal/seed/fixtures.go
+++ b/internal/seed/fixtures.go
@@ -215,7 +215,7 @@ func sha256File(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("opening file for checksum %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {

--- a/internal/setup/envai.go
+++ b/internal/setup/envai.go
@@ -103,7 +103,7 @@ func writeAIConfig(projectDir string) (ok bool, err error) {
 	if err != nil {
 		return false, fmt.Errorf("open .env.secrets: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, werr := f.WriteString(block); werr != nil {
 		return false, fmt.Errorf("write AI config to .env.secrets: %w", werr)

--- a/internal/setup/setup_gitignore.go
+++ b/internal/setup/setup_gitignore.go
@@ -51,7 +51,7 @@ func ensureGitignore(workDir string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Add a header comment if the file is new or we're appending.
 	header := "\n# nSelf\n"

--- a/internal/ssl/hosts.go
+++ b/internal/ssl/hosts.go
@@ -146,7 +146,7 @@ func readHostsFile(path string) ([]string, error) {
 		}
 		return nil, fmt.Errorf("opening %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var lines []string
 	scanner := bufio.NewScanner(f)

--- a/internal/ssl/hosts_test.go
+++ b/internal/ssl/hosts_test.go
@@ -17,8 +17,8 @@ func tempHostsFile(t *testing.T, content string) string {
 	if _, err := f.WriteString(content); err != nil {
 		t.Fatalf("writing temp hosts file: %v", err)
 	}
-	f.Close()
-	t.Cleanup(func() { os.Remove(f.Name()) })
+	_ = f.Close()
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
 	return f.Name()
 }
 

--- a/internal/ssl/mkcert.go
+++ b/internal/ssl/mkcert.go
@@ -49,7 +49,7 @@ func generateWithOpenSSL(certDir string, domains []string) (int, error) {
 	if err := os.WriteFile(confPath, []byte(confContent), 0644); err != nil {
 		return 0, fmt.Errorf("writing openssl config: %w", err)
 	}
-	defer os.Remove(confPath)
+	defer func() { _ = os.Remove(confPath) }()
 
 	fullchain := filepath.Join(certDir, "fullchain.pem")
 	privkey := filepath.Join(certDir, "privkey.pem")

--- a/internal/ssl/ssl_coverage_test.go
+++ b/internal/ssl/ssl_coverage_test.go
@@ -43,8 +43,8 @@ func TestFileExists_True(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
-	defer os.Remove(f.Name())
+	_ = f.Close()
+	defer func() { _ = os.Remove(f.Name()) }()
 
 	if !fileExists(f.Name()) {
 		t.Errorf("fileExists(%q) = false, want true", f.Name())
@@ -234,11 +234,11 @@ func TestReadHostsFile_PermissionError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
-	defer os.Remove(f.Name())
+	_ = f.Close()
+	defer func() { _ = os.Remove(f.Name()) }()
 	// Remove all permissions so Open fails with EACCES
-	os.Chmod(f.Name(), 0000)
-	defer os.Chmod(f.Name(), 0644)
+	_ = os.Chmod(f.Name(), 0000)
+	defer func() { _ = os.Chmod(f.Name(), 0644) }()
 
 	_, err = readHostsFile(f.Name())
 	if err == nil {
@@ -268,10 +268,10 @@ func TestWriteHostsFile_PermissionError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
-	defer os.Remove(f.Name())
-	os.Chmod(f.Name(), 0000)
-	defer os.Chmod(f.Name(), 0644)
+	_ = f.Close()
+	defer func() { _ = os.Remove(f.Name()) }()
+	_ = os.Chmod(f.Name(), 0000)
+	defer func() { _ = os.Chmod(f.Name(), 0644) }()
 
 	err = writeHostsFile(f.Name(), "127.0.0.1 test.local\n")
 	if err != ErrSudoRequired {
@@ -320,8 +320,8 @@ func writeSelfSignedCert(t *testing.T, notBefore, notAfter time.Time) string {
 	if err := pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
-	t.Cleanup(func() { os.Remove(f.Name()) })
+	_ = f.Close()
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
 	return f.Name()
 }
 
@@ -367,9 +367,9 @@ func TestCheckCertExpiry_NoPEMBlock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.WriteString("not a pem file\n")
-	f.Close()
-	defer os.Remove(f.Name())
+	_, _ = f.WriteString("not a pem file\n")
+	_ = f.Close()
+	defer func() { _ = os.Remove(f.Name()) }()
 
 	_, err = CheckCertExpiry(f.Name())
 	if err == nil {
@@ -386,9 +386,9 @@ func TestCheckCertExpiry_InvalidPEMBytes(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Write a PEM block with garbage DER bytes
-	pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: []byte("not valid der")})
-	f.Close()
-	defer os.Remove(f.Name())
+	_ = pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: []byte("not valid der")})
+	_ = f.Close()
+	defer func() { _ = os.Remove(f.Name()) }()
 
 	_, err = CheckCertExpiry(f.Name())
 	if err == nil {
@@ -417,8 +417,8 @@ func TestCopyMkcertCerts_Success(t *testing.T) {
 
 	chainPath := filepath.Join(src, "fullchain.pem")
 	keyPath := filepath.Join(src, "privkey.pem")
-	os.WriteFile(chainPath, []byte("chain data"), 0640)
-	os.WriteFile(keyPath, []byte("key data"), 0640)
+	_ = os.WriteFile(chainPath, []byte("chain data"), 0640)
+	_ = os.WriteFile(keyPath, []byte("key data"), 0640)
 
 	if err := copyMkcertCerts(chainPath, keyPath, dst); err != nil {
 		t.Fatalf("copyMkcertCerts: unexpected error: %v", err)
@@ -446,7 +446,7 @@ func TestCopyMkcertCerts_ReadPrivkeyFail(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
 	chainPath := filepath.Join(src, "fullchain.pem")
-	os.WriteFile(chainPath, []byte("chain data"), 0640)
+	_ = os.WriteFile(chainPath, []byte("chain data"), 0640)
 
 	err := copyMkcertCerts(chainPath, "/tmp/no-such-privkey-99999.pem", dst)
 	if err == nil {
@@ -467,12 +467,12 @@ func TestCopyMkcertCerts_WriteFullchainFail(t *testing.T) {
 	src := t.TempDir()
 	chainPath := filepath.Join(src, "fullchain.pem")
 	keyPath := filepath.Join(src, "privkey.pem")
-	os.WriteFile(chainPath, []byte("chain data"), 0640)
-	os.WriteFile(keyPath, []byte("key data"), 0640)
+	_ = os.WriteFile(chainPath, []byte("chain data"), 0640)
+	_ = os.WriteFile(keyPath, []byte("key data"), 0640)
 
 	dst := t.TempDir()
-	os.Chmod(dst, 0555)
-	t.Cleanup(func() { os.Chmod(dst, 0755) })
+	_ = os.Chmod(dst, 0555)
+	t.Cleanup(func() { _ = os.Chmod(dst, 0755) })
 
 	err := copyMkcertCerts(chainPath, keyPath, dst)
 	if err == nil {
@@ -484,8 +484,8 @@ func TestCopyMkcertCerts_WritePrivkeyFail(t *testing.T) {
 	src := t.TempDir()
 	chainPath := filepath.Join(src, "fullchain.pem")
 	keyPath := filepath.Join(src, "privkey.pem")
-	os.WriteFile(chainPath, []byte("chain data"), 0640)
-	os.WriteFile(keyPath, []byte("key data"), 0640)
+	_ = os.WriteFile(chainPath, []byte("chain data"), 0640)
+	_ = os.WriteFile(keyPath, []byte("key data"), 0640)
 
 	// Make dst/privkey.pem a directory so WriteFile fails (EISDIR)
 	dst := t.TempDir()

--- a/internal/ssl/trust_test.go
+++ b/internal/ssl/trust_test.go
@@ -21,8 +21,8 @@ func TestIsCAInstalled_EmptyFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp file: %v", err)
 	}
-	defer os.Remove(f.Name())
-	f.Close()
+	defer func() { _ = os.Remove(f.Name()) }()
+	_ = f.Close()
 
 	// Should return false (not trusted), not an error.
 	installed, err := IsCAInstalled(f.Name())

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -137,7 +137,7 @@ func sendPayload(ctx context.Context, p payload) error {
 	if err != nil {
 		return fmt.Errorf("http post: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("server responded %d", resp.StatusCode)
@@ -285,7 +285,7 @@ func SendEvent(eventType string, metadata map[string]any) {
 			}
 			return
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if os.Getenv("NSELF_TELEMETRY_DEBUG") == "1" && resp.StatusCode >= 400 {
 			fmt.Fprintf(os.Stderr, "[telemetry DEBUG] SendEvent %s: server %d\n", eventType, resp.StatusCode)

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -39,7 +39,7 @@ func TestSendNoOpWhenOptInUnset(t *testing.T) {
 	_ = orig
 
 	// Ensure opt-in is NOT set.
-	os.Unsetenv("NSELF_TELEMETRY_OPT_IN")
+	_ = os.Unsetenv("NSELF_TELEMETRY_OPT_IN")
 
 	Send("test_event", map[string]any{"key": "value"})
 
@@ -84,7 +84,7 @@ func TestSendFiresWhenOptedIn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("do request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	_ = p // used above
 
@@ -95,7 +95,7 @@ func TestSendFiresWhenOptedIn(t *testing.T) {
 
 // TestIsOptedIn verifies the opt-in gate logic.
 func TestIsOptedIn(t *testing.T) {
-	os.Unsetenv("NSELF_TELEMETRY_OPT_IN")
+	_ = os.Unsetenv("NSELF_TELEMETRY_OPT_IN")
 	if IsOptedIn() {
 		t.Error("expected IsOptedIn=false when env unset")
 	}
@@ -145,9 +145,9 @@ func TestInstallSourceOneShot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Setenv("USERPROFILE", tmpHome)
 	}
-	os.Unsetenv("NSELF_INSTALL_SOURCE")
-	os.Unsetenv("NSELF_INSTALL_APP")
-	os.Unsetenv("NSELF_INSTALL_METHOD")
+	_ = os.Unsetenv("NSELF_INSTALL_SOURCE")
+	_ = os.Unsetenv("NSELF_INSTALL_APP")
+	_ = os.Unsetenv("NSELF_INSTALL_METHOD")
 
 	// Create the one-shot file.
 	dir := filepath.Join(tmpHome, ".config", "nself")

--- a/internal/telemetry/install.go
+++ b/internal/telemetry/install.go
@@ -70,7 +70,7 @@ func SendInstallEvent() {
 			}
 			return
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if os.Getenv("NSELF_TELEMETRY_DEBUG") == "1" && resp.StatusCode >= 400 {
 			fmt.Fprintf(os.Stderr, "[telemetry DEBUG] SendInstallEvent: server %d\n", resp.StatusCode)

--- a/internal/telemetry/install_id_test.go
+++ b/internal/telemetry/install_id_test.go
@@ -58,8 +58,8 @@ func TestIsEnabledDefault(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("USERPROFILE", tmpHome)
-	os.Unsetenv("NSELF_TELEMETRY")
-	os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
+	_ = os.Unsetenv("NSELF_TELEMETRY")
+	_ = os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
 
 	if !IsEnabled() {
 		t.Error("expected IsEnabled=true by default (opt-out model)")
@@ -95,7 +95,7 @@ func TestIsEnabledLegacyOptOut(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("USERPROFILE", tmpHome)
-	os.Unsetenv("NSELF_TELEMETRY")
+	_ = os.Unsetenv("NSELF_TELEMETRY")
 	t.Setenv("NSELF_TELEMETRY_OPT_OUT", "1")
 
 	if IsEnabled() {
@@ -108,8 +108,8 @@ func TestIsEnabledStatefile(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("USERPROFILE", tmpHome)
-	os.Unsetenv("NSELF_TELEMETRY")
-	os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
+	_ = os.Unsetenv("NSELF_TELEMETRY")
+	_ = os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
 
 	path := filepath.Join(tmpHome, telemetryStateFile)
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
@@ -159,8 +159,8 @@ func TestWriteStatefile(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("USERPROFILE", tmpHome)
-	os.Unsetenv("NSELF_TELEMETRY")
-	os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
+	_ = os.Unsetenv("NSELF_TELEMETRY")
+	_ = os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
 
 	if err := WriteStatefile(false); err != nil {
 		t.Fatalf("WriteStatefile(false): %v", err)

--- a/internal/telemetry/send_event_test.go
+++ b/internal/telemetry/send_event_test.go
@@ -42,8 +42,8 @@ func TestSendEventNoOpWhenDisabled(t *testing.T) {
 func TestSendEventPayloadShape(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
-	os.Unsetenv("NSELF_TELEMETRY")
-	os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
+	_ = os.Unsetenv("NSELF_TELEMETRY")
+	_ = os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
 
 	type received struct {
 		InstallID  string         `json:"install_id"`
@@ -87,7 +87,7 @@ func TestSendEventPayloadShape(t *testing.T) {
 	if err != nil {
 		t.Fatalf("do: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	select {
 	case got := <-done:
@@ -113,8 +113,8 @@ func TestSendEventPayloadShape(t *testing.T) {
 func TestSendEventNetworkFailSilent(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
-	os.Unsetenv("NSELF_TELEMETRY")
-	os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
+	_ = os.Unsetenv("NSELF_TELEMETRY")
+	_ = os.Unsetenv("NSELF_TELEMETRY_OPT_OUT")
 
 	// Start and immediately close a server — connections refused.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))

--- a/internal/tenant/audit.go
+++ b/internal/tenant/audit.go
@@ -35,7 +35,7 @@ func Audit(ctx context.Context, cfg *config.Config, opts AuditOptions) ([]AuditE
 	if err != nil {
 		return nil, fmt.Errorf("querying audit log: %w", err)
 	}
-	defer sqlDB.Close()
+	defer func() { _ = sqlDB.Close() }()
 
 	// Build query with $N placeholders. The since interval is passed as a
 	// PostgreSQL interval string derived from parseDuration (digits+unit only,
@@ -59,7 +59,7 @@ func Audit(ctx context.Context, cfg *config.Config, opts AuditOptions) ([]AuditE
 	if err != nil {
 		return nil, fmt.Errorf("querying audit log: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var entries []AuditEntry
 	for rows.Next() {

--- a/internal/tenant/billing.go
+++ b/internal/tenant/billing.go
@@ -37,7 +37,7 @@ func BillingReport(ctx context.Context, cfg *config.Config, opts BillingReportOp
 	if err != nil {
 		return "", fmt.Errorf("generating billing report: %w", err)
 	}
-	defer sqlDB.Close()
+	defer func() { _ = sqlDB.Close() }()
 
 	// Build query with $N placeholders. Filters are applied only when provided.
 	args := []interface{}{}
@@ -65,7 +65,7 @@ func BillingReport(ctx context.Context, cfg *config.Config, opts BillingReportOp
 	if err != nil {
 		return "", fmt.Errorf("generating billing report: %w", err)
 	}
-	defer dbRows.Close()
+	defer func() { _ = dbRows.Close() }()
 
 	type reportRow struct {
 		Slug   string  `json:"slug"`
@@ -117,7 +117,7 @@ func RetryStripeEvent(ctx context.Context, cfg *config.Config, eventID string) e
 	if err != nil {
 		return fmt.Errorf("retrying stripe event: %w", err)
 	}
-	defer sqlDB.Close()
+	defer func() { _ = sqlDB.Close() }()
 
 	var returnedID string
 	err = sqlDB.QueryRowContext(ctx,

--- a/internal/tenant/helpers.go
+++ b/internal/tenant/helpers.go
@@ -66,7 +66,7 @@ func openTenantDB(ctx context.Context, cfg *config.Config) (*sql.DB, error) {
 		return nil, fmt.Errorf("open tenant db: %w", err)
 	}
 	if err := db.PingContext(ctx); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("connect to tenant db: %w (is the postgres container running?)", err)
 	}
 	return db, nil

--- a/internal/tenant/metering_collectors.go
+++ b/internal/tenant/metering_collectors.go
@@ -100,7 +100,7 @@ func collectMinIOStorage(ctx context.Context, cfg *config.Config, pgContainer, p
 			continue
 		}
 		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		if resp.StatusCode == http.StatusNotFound {
 			// Bucket does not exist yet; record 0 bytes.
@@ -164,7 +164,7 @@ func collectNginxBandwidth(ctx context.Context, cfg *config.Config, pgContainer,
 		slog.Warn("Prometheus unavailable for bandwidth metering", "error", err)
 		return nil
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		slog.Warn("Prometheus returned non-200 for bandwidth query", "status", resp.StatusCode)

--- a/internal/tenant/metering_query.go
+++ b/internal/tenant/metering_query.go
@@ -31,7 +31,7 @@ func QueryUsage(ctx context.Context, cfg *config.Config, tenantID, month, format
 	if err != nil {
 		return "", fmt.Errorf("querying usage: %w", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	// Build query with $N placeholders. Month filtering appends a date-range
 	// predicate using a CAST to date so the comparison is type-safe.
@@ -48,7 +48,7 @@ func QueryUsage(ctx context.Context, cfg *config.Config, tenantID, month, format
 	if err != nil {
 		return "", fmt.Errorf("querying usage: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	type usageRow struct {
 		TenantID string `json:"tenant_id"`

--- a/internal/trust/dns_macos.go
+++ b/internal/trust/dns_macos.go
@@ -153,7 +153,7 @@ func configureDnsmasqConf() error {
 	if err != nil {
 		return fmt.Errorf("opening dnsmasq.conf: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	_, err = fmt.Fprintf(f, "\n# nself: wildcard .local DNS resolution\n%s\n", dnsmasqConfLine)
 	if err != nil {

--- a/internal/trust/trust_coverage2_test.go
+++ b/internal/trust/trust_coverage2_test.go
@@ -83,7 +83,7 @@ func TestConfigureDnsmasqConf_SyntheticAppend(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, _ = f.WriteString("\n# nself: wildcard .local DNS resolution\n" + dnsmasqConfLine + "\n")
-	f.Close()
+	_ = f.Close()
 
 	data, err := os.ReadFile(confPath)
 	if err != nil {

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -194,7 +194,7 @@ func (d *Dispatcher) dispatch(ctx context.Context, del Delivery) {
 		d.handleFailure(ctx, del, fmt.Sprintf("POST: %v", err), circ)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		// Success.

--- a/internal/webhook/ssrf_test.go
+++ b/internal/webhook/ssrf_test.go
@@ -174,8 +174,8 @@ func TestSSRFGuardInvariant(t *testing.T) {
 	// Verify SSRF_ALLOWED_HOSTS is not set from environment, so our test is clean.
 	// This test just ensures the file is exercised by go test.
 	saved := os.Getenv("SSRF_ALLOWED_HOSTS")
-	os.Unsetenv("SSRF_ALLOWED_HOSTS")
-	defer os.Setenv("SSRF_ALLOWED_HOSTS", saved)
+	_ = os.Unsetenv("SSRF_ALLOWED_HOSTS")
+	defer func() { _ = os.Setenv("SSRF_ALLOWED_HOSTS", saved) }()
 
 	// A public HTTPS URL with no private IP should pass validation (DNS may fail in CI).
 	err := ValidateWebhookURL("https://hooks.example.com/webhook")

--- a/test/e2e/license_revoke_journey_test.go
+++ b/test/e2e/license_revoke_journey_test.go
@@ -43,7 +43,7 @@ func revokeJourneyPingHandler(t *testing.T) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		if callCount == 1 {
 			// First call: license is valid.
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"valid":      true,
 				"tier":       "pro",
 				"plugins":    []string{"ai", "claw", "mux"},
@@ -53,7 +53,7 @@ func revokeJourneyPingHandler(t *testing.T) *httptest.Server {
 		}
 		// Subsequent calls: license has been revoked.
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"valid":  false,
 			"reason": "revoked",
 		})
@@ -128,7 +128,7 @@ func TestLicenseRevokeJourney_RevokedKeyBlocksPluginAccess(t *testing.T) {
 	// Start a server that always returns revoked.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"valid":  false,
 			"reason": "revoked",
 		})
@@ -170,7 +170,7 @@ func TestLicenseRevokeJourney_Headless(t *testing.T) {
 	go func() {
 		defer close(done)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"valid":  false,
 				"reason": "revoked",
 			})
@@ -197,7 +197,7 @@ func TestLicenseRevokeJourney_Headless(t *testing.T) {
 func TestLicenseRevokeJourney_CacheIgnoredAfterRevoke(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Always returns revoked regardless of what cache says.
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"valid":  false,
 			"reason": "revoked",
 		})
@@ -271,7 +271,7 @@ func validateRemoteForJourney(ctx context.Context, key, pingURL string) (*valida
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var result validateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {

--- a/test/e2e/plugin_install_journey_test.go
+++ b/test/e2e/plugin_install_journey_test.go
@@ -37,13 +37,13 @@ func pluginPingServer(t *testing.T, tier string, allowedPlugins []string) *httpt
 		case "/license/validate":
 			if tier == "" {
 				// No license — invalid.
-				json.NewEncoder(w).Encode(map[string]interface{}{
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
 					"valid":  false,
 					"reason": "no_license",
 				})
 				return
 			}
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"valid":      true,
 				"tier":       tier,
 				"plugins":    allowedPlugins,
@@ -54,7 +54,7 @@ func pluginPingServer(t *testing.T, tier string, allowedPlugins []string) *httpt
 			pluginName := r.URL.Query().Get("name")
 			if !allowedSet[pluginName] {
 				w.WriteHeader(http.StatusForbidden)
-				json.NewEncoder(w).Encode(map[string]string{
+				_ = json.NewEncoder(w).Encode(map[string]string{
 					"error":  "not_in_tier",
 					"plugin": pluginName,
 				})
@@ -62,7 +62,7 @@ func pluginPingServer(t *testing.T, tier string, allowedPlugins []string) *httpt
 			}
 			// Return a minimal plugin tarball stub (just the JSON header).
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]string{"plugin": pluginName, "status": "download_ok"})
+			_ = json.NewEncoder(w).Encode(map[string]string{"plugin": pluginName, "status": "download_ok"})
 
 		default:
 			http.NotFound(w, r)
@@ -103,7 +103,7 @@ func TestPluginInstallJourney_ProPluginWithValidLicense(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plugin download request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("plugin download for ai: status %d, want 200", resp.StatusCode)
@@ -159,7 +159,7 @@ func TestPluginInstallJourney_PluginNotInTier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plugin download request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("plugin not in tier: status %d, want 403", resp.StatusCode)

--- a/tools/flagaudit/scan.go
+++ b/tools/flagaudit/scan.go
@@ -98,7 +98,7 @@ func scanFile(path string) ([]invocation, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var out []invocation
 	scanner := bufio.NewScanner(f)


### PR DESCRIPTION
Clears the errcheck half of the golangci-lint backlog. **The gate added in 45fa83fe (P6-E2-W1-S1-T4) has been failing on main since it merged** — its inversion proof covered gofmt, not golangci-lint.

## The count was wrong, not just unmet
A default `golangci-lint run` truncates at **50 issues per linter and 3 per message**. Every run therefore reported ~128 issues while showing a different slice of the same set. Uncapped (`--max-issues-per-linter=0 --max-same-issues=0`) the real backlog was **792**.

This is why the gate looked like a small cleanup and was merged red.

## What this changes
608 unchecked error returns, now explicitly discarded — `_ =` / `_, _ =`, or a closure for deferred cleanup. Discarding is the honest encoding of what the code already did; **no behavior changes**.

Where the ignored error was inside a closure passed to `t.Cleanup`, `append`, or `go`, the fix went to the inner call rather than discarding the outer result — wrapping those would have been wrong (and in two cases did not compile, which is how they were caught).

## Remaining, tracked separately
staticcheck 157 · unused 20 · ineffassign 5 · govet 3.

Several are real defects rather than style. One is already fixed in #317: three SA1000 regexes in `internal/database/migration_audit.go` used Perl lookahead that Go's RE2 cannot compile, panicking `nself db audit` on every invocation.

## Verify
`gofmt` clean · `go build ./...` exit 0 · `go vet ./...` exit 0 · **4645 tests pass across 95 packages**.