### PR TITLE
fix(ssl,config): install renewed certs before reload; show config set's real write path

### DIFF
--- a/cmd/commands/config_set.go
+++ b/cmd/commands/config_set.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -33,6 +32,11 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+
 	projectDir, err := resolveProjectDir()
 	if err != nil {
 		return err
@@ -47,10 +51,21 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// FindNSelfRoot's monorepo convenience silently resolves to a
+	// `.backend/` project root above cwd when one exists — fine for reads,
+	// but a write with no indication of where it actually landed is
+	// dangerous: a user working in a nested app dir sees "Added KEY to
+	// .env" with no signal the file is two directories up. Surface the
+	// redirection explicitly whenever it happens; this does not change
+	// where the write lands, only what gets printed.
+	if projectDir != cwd {
+		ui.Info(fmt.Sprintf("Using monorepo backend at %s (found via .backend/ in a parent directory)", projectDir))
+	}
+
 	if updated {
-		ui.Success(fmt.Sprintf("Updated %s in %s", key, filepath.Base(envFile)))
+		ui.Success(fmt.Sprintf("Updated %s in %s", key, envFile))
 	} else {
-		ui.Success(fmt.Sprintf("Added %s to %s", key, filepath.Base(envFile)))
+		ui.Success(fmt.Sprintf("Added %s to %s", key, envFile))
 	}
 	return nil
 }

--- a/cmd/commands/config_set_test.go
+++ b/cmd/commands/config_set_test.go
@@ -1,0 +1,85 @@
+package commands
+
+// config_set_test.go — Regression coverage for the T16 fix: `nself config
+// set` inherits FindNSelfRoot's monorepo auto-chdir (a `.backend/` marker
+// found in a parent directory silently becomes the project root) and used to
+// print a bare "Added KEY to .env" with no indication the write actually
+// landed in `.backend/.env`, two directories above where the user was
+// standing.
+//
+// This reproduces the exact scratch-fixture scenario from the ticket
+// description: a monorepo root with a `.backend/.env`, and a nested
+// `apps/foo/` subdirectory with nothing of its own. Running `config set`
+// from `apps/foo/` must still write to `.backend/.env` (that resolution
+// behavior is intentional and unchanged) but must now say so.
+//
+// Inputs: a temp monorepo fixture; cwd inside its nested app dir.
+// Outputs: assertions on the file actually written and on stdout.
+// Constraints: no certbot/docker/network; same package as config_test.go so
+// it reuses newConfigCmd() and captureStdout() rather than redefining them.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestConfigSet_MonorepoRedirectIsVisible proves the T16 fix: running
+// `config set` from a nested monorepo subdirectory still writes to
+// `.backend/.env` (unchanged write-target resolution) but now prints the
+// full resolved path plus an explicit redirection notice, instead of a bare
+// ".env" that gives no indication the write happened somewhere else.
+//
+// Before the fix, the success message was built from filepath.Base(envFile),
+// which always prints exactly ".env" regardless of which directory it came
+// from — this test fails against that code because the output contains no
+// path separator at all, let alone the backend directory's full path.
+func TestConfigSet_MonorepoRedirectIsVisible(t *testing.T) {
+	monorepoRoot := t.TempDir()
+	backendDir := filepath.Join(monorepoRoot, ".backend")
+	nestedDir := filepath.Join(monorepoRoot, "apps", "foo")
+
+	if err := os.MkdirAll(backendDir, 0o750); err != nil {
+		t.Fatalf("mkdir .backend: %v", err)
+	}
+	if err := os.MkdirAll(nestedDir, 0o750); err != nil {
+		t.Fatalf("mkdir apps/foo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(backendDir, ".env"), []byte("EXISTING=root\n"), 0o600); err != nil {
+		t.Fatalf("seed .backend/.env: %v", err)
+	}
+
+	t.Chdir(nestedDir)
+
+	root := newConfigCmd()
+	root.SetArgs([]string{"config", "set", "TEST_KEY", "hello"})
+
+	output, err := captureStdout(t, func() error { return root.Execute() })
+	if err != nil {
+		t.Fatalf("config set failed: %v", err)
+	}
+
+	// Write-target resolution is unchanged: the value lands in
+	// .backend/.env, and nothing is created in the nested dir itself.
+	backendEnv, readErr := os.ReadFile(filepath.Join(backendDir, ".env"))
+	if readErr != nil {
+		t.Fatalf("read .backend/.env: %v", readErr)
+	}
+	if !strings.Contains(string(backendEnv), "TEST_KEY=hello") {
+		t.Errorf("expected TEST_KEY=hello in .backend/.env, got:\n%s", backendEnv)
+	}
+	if _, statErr := os.Stat(filepath.Join(nestedDir, ".env")); !os.IsNotExist(statErr) {
+		t.Errorf("expected no .env created in the nested dir, stat err: %v", statErr)
+	}
+
+	// The printed output must contain the full resolved path (not a bare
+	// ".env" with no directory context) and must name the redirection.
+	if !strings.Contains(output, filepath.Join(backendDir, ".env")) {
+		t.Errorf("expected output to contain the full path %q, got:\n%s",
+			filepath.Join(backendDir, ".env"), output)
+	}
+	if !strings.Contains(output, "monorepo") {
+		t.Errorf("expected output to name the monorepo redirection, got:\n%s", output)
+	}
+}

--- a/cmd/commands/ssl.go
+++ b/cmd/commands/ssl.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -178,69 +177,5 @@ func runSSLStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("one or more certificates are expired")
 	}
 
-	return nil
-}
-
-// runSSLRenew implements `nself ssl renew [domain]`.
-func runSSLRenew(cmd *cobra.Command, args []string) error {
-	ui.CommandHeader("nself ssl renew", "Reload nginx and optionally renew certificates")
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		ui.Error("Failed to determine working directory")
-		return fmt.Errorf("getting working directory: %w", err)
-	}
-
-	workdir, err := config.FindNSelfRoot(cwd)
-	if err != nil {
-		return fmt.Errorf("no nself project found in current directory or parents: run 'nself init' to create a project")
-	}
-
-	// 1. Reload nginx via docker compose exec.
-	fmt.Println("Reloading nginx...")
-	reloadCmd := exec.Command("docker", "compose", "exec", "nginx", "nginx", "-s", "reload")
-	reloadCmd.Dir = workdir
-	reloadCmd.Stdout = os.Stdout
-	reloadCmd.Stderr = os.Stderr
-	if err := reloadCmd.Run(); err != nil {
-		// Non-fatal: nginx container may not be running.
-		fmt.Fprintf(os.Stderr, "Warning: nginx reload reported an error (may not be running): %v\n", err)
-	} else {
-		fmt.Println("  nginx reloaded.")
-	}
-
-	// 2. certbot if available and domain provided.
-	if len(args) > 0 {
-		domain := args[0]
-		if certbotPath, lookErr := exec.LookPath("certbot"); lookErr == nil {
-			fmt.Printf("Running certbot renew for %s...\n", domain)
-			certbotCmd := exec.Command(certbotPath, "renew", "--cert-name", domain)
-			certbotCmd.Stdout = os.Stdout
-			certbotCmd.Stderr = os.Stderr
-			if err := certbotCmd.Run(); err != nil {
-				return fmt.Errorf("certbot renew failed: %w", err)
-			}
-		} else {
-			fmt.Println("certbot not found — skipping ACME renewal (nginx reloaded only).")
-		}
-	}
-
-	// 3. Show updated certificate status for the provided domain.
-	if len(args) > 0 {
-		domain := args[0]
-		fmt.Printf("\nCertificate status for %s:\n", domain)
-		cert, tlsErr := checkDomainTLS(domain, 10*time.Second)
-		if tlsErr != nil {
-			fmt.Printf("  Could not connect to %s: %v\n", domain, tlsErr)
-		} else {
-			now := time.Now()
-			daysRemaining := int(cert.NotAfter.Sub(now).Hours()) / 24
-			issuer := certIssuer(cert)
-			fmt.Printf("  Issuer: %s\n", issuer)
-			fmt.Printf("  Expiry: %s (%d days remaining)\n", cert.NotAfter.Format("2006-01-02"), daysRemaining)
-		}
-	}
-
-	fmt.Println("SSL renew complete.")
 	return nil
 }

--- a/cmd/commands/ssl_renew.go
+++ b/cmd/commands/ssl_renew.go
@@ -1,0 +1,145 @@
+package commands
+
+// Purpose: Implements `nself ssl renew` — split out of ssl.go (file-size
+// ratchet, internal/repoqa) alongside the other ssl_*.go concern splits
+// (ssl_add.go, ssl_install.go, ssl_setup.go, ssl_renewal.go).
+// Inputs: an optional domain arg; the project workdir.
+// Outputs: a reloaded nginx, and — when certbot actually renewed the
+// lineage — the renewed cert installed at ssl/certificates/<domain-safe>/.
+// Constraints: certbot renew --cert-name must run BEFORE any nginx reload
+// (reloading first serves whatever cert is already on disk, which is a
+// no-op for freshness); installIssuedCert must only run on a genuine
+// renewal, never unconditionally.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/ui"
+
+	"github.com/spf13/cobra"
+)
+
+// runSSLRenew implements `nself ssl renew [domain]`.
+func runSSLRenew(cmd *cobra.Command, args []string) error {
+	ui.CommandHeader("nself ssl renew", "Reload nginx and optionally renew certificates")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		ui.Error("Failed to determine working directory")
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+
+	workdir, err := config.FindNSelfRoot(cwd)
+	if err != nil {
+		return fmt.Errorf("no nself project found in current directory or parents: run 'nself init' to create a project")
+	}
+
+	// 1. certbot if available and domain provided. This MUST run before any
+	// nginx reload — reloading first (the previous order) reloads whatever
+	// cert is already on disk and accomplishes nothing toward serving a
+	// freshly renewed one.
+	if len(args) > 0 {
+		domain := args[0]
+		if certbotPath, lookErr := exec.LookPath("certbot"); lookErr == nil {
+			// Capture the live cert's mtime before renewing so we can tell
+			// whether certbot actually renewed it or the lineage is not yet
+			// within its renewal window (a no-op certbot exits 0 for either
+			// case). Missing file (zero time) counts as "any post-run file
+			// is new".
+			liveCertPath := filepath.Join(letsEncryptLiveDir, domain, "fullchain.pem")
+			var beforeMtime time.Time
+			if info, statErr := os.Stat(liveCertPath); statErr == nil {
+				beforeMtime = info.ModTime()
+			}
+
+			fmt.Printf("Running certbot renew for %s...\n", domain)
+			certbotCmd := exec.Command(certbotPath, "renew", "--cert-name", domain)
+			certbotCmd.Stdout = os.Stdout
+			certbotCmd.Stderr = os.Stderr
+			if err := certbotCmd.Run(); err != nil {
+				return fmt.Errorf("certbot renew failed: %w", err)
+			}
+
+			renewed, installErr := installRenewedCertIfDue(domain, workdir, beforeMtime)
+			if installErr != nil {
+				return fmt.Errorf("installing renewed certificate for %s: %w", domain, installErr)
+			}
+			if renewed {
+				fmt.Println("  renewed certificate installed for nginx.")
+			} else {
+				fmt.Println("  certificate not yet due for renewal — nothing to install.")
+			}
+		} else {
+			fmt.Println("certbot not found — skipping ACME renewal (nginx reload only).")
+		}
+	}
+
+	// 2. Reload nginx via docker compose exec — after any renewal+install
+	// above, so a freshly installed cert is the one actually served.
+	fmt.Println("Reloading nginx...")
+	reloadCmd := exec.Command("docker", "compose", "exec", "nginx", "nginx", "-s", "reload")
+	reloadCmd.Dir = workdir
+	reloadCmd.Stdout = os.Stdout
+	reloadCmd.Stderr = os.Stderr
+	if err := reloadCmd.Run(); err != nil {
+		// Non-fatal: nginx container may not be running.
+		fmt.Fprintf(os.Stderr, "Warning: nginx reload reported an error (may not be running): %v\n", err)
+	} else {
+		fmt.Println("  nginx reloaded.")
+	}
+
+	// 3. Show updated certificate status for the provided domain.
+	if len(args) > 0 {
+		domain := args[0]
+		fmt.Printf("\nCertificate status for %s:\n", domain)
+		cert, tlsErr := checkDomainTLS(domain, 10*time.Second)
+		if tlsErr != nil {
+			fmt.Printf("  Could not connect to %s: %v\n", domain, tlsErr)
+		} else {
+			now := time.Now()
+			daysRemaining := int(cert.NotAfter.Sub(now).Hours()) / 24
+			issuer := certIssuer(cert)
+			fmt.Printf("  Issuer: %s\n", issuer)
+			fmt.Printf("  Expiry: %s (%d days remaining)\n", cert.NotAfter.Format("2006-01-02"), daysRemaining)
+		}
+	}
+
+	fmt.Println("SSL renew complete.")
+	return nil
+}
+
+// installRenewedCertIfDue installs domain's certbot-renewed cert into workdir's
+// ssl/certificates/<domain-safe>/ tree — the path nginx actually mounts — but
+// only when certbot genuinely renewed it (the live fullchain.pem's mtime moved
+// past beforeMtime). certbot renew --cert-name exits 0 whether or not a
+// lineage was actually due, so without this check every invocation would
+// needlessly rewrite unchanged files and could mask a certbot failure by
+// reinstalling stale local files as if they were fresh.
+//
+// certDir is derived with domainToFilesafe, the exact convention ssl_add.go
+// and ssl_setup.go already use at their installIssuedCert call sites — do not
+// reimplement the dash-safe transform here.
+func installRenewedCertIfDue(domain, workdir string, beforeMtime time.Time) (bool, error) {
+	liveCertPath := filepath.Join(letsEncryptLiveDir, domain, "fullchain.pem")
+	info, err := os.Stat(liveCertPath)
+	if err != nil {
+		return false, fmt.Errorf("checking renewed cert for %s (did certbot succeed?): %w", domain, err)
+	}
+	if !info.ModTime().After(beforeMtime) {
+		return false, nil
+	}
+
+	certDir := filepath.Join(workdir, "ssl", "certificates", domainToFilesafe(domain))
+	if err := os.MkdirAll(certDir, 0750); err != nil {
+		return false, fmt.Errorf("creating %s: %w", certDir, err)
+	}
+	if err := installIssuedCert(domain, certDir); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/cmd/commands/ssl_renew_test.go
+++ b/cmd/commands/ssl_renew_test.go
@@ -1,0 +1,139 @@
+package commands
+
+// ssl_renew_test.go — Regression coverage for the T15 fix: `nself ssl renew`
+// used to never call installIssuedCert, so a genuinely-renewed Let's Encrypt
+// cert could sit on disk unused while nginx kept serving the stale one.
+//
+// installRenewedCertIfDue is the extracted, testable half of runSSLRenew
+// (the certbot exec itself is not testable without a certbot binary): given
+// a "before" mtime captured prior to renewal, it decides whether certbot
+// actually renewed the lineage and, if so, installs it exactly where
+// ssl_add.go/ssl_setup.go already do.
+//
+// Inputs: a domain, a scratch workdir, and a beforeMtime.
+// Outputs: assertions on whether ssl/certificates/<domain-safe>/ was
+// populated (and at 0600) or left untouched.
+// Constraints: no certbot, docker, or network.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestInstallRenewedCertIfDue_InstallsWhenRenewed proves the T15 fix: when
+// the live cert's mtime moved past the pre-renewal baseline (certbot actually
+// renewed it), the renewed files land in ssl/certificates/<domain-safe>/ at
+// 0600 — the path nginx reads — closing the gap where a renewed cert never
+// reached nginx.
+//
+// Before the fix, runSSLRenew never called installIssuedCert at all, so this
+// exact scenario left ssl/certificates/ empty; this test fails against that
+// code (no such function existed) and passes once installRenewedCertIfDue is
+// wired in and called after a genuine renewal.
+func TestInstallRenewedCertIfDue_InstallsWhenRenewed(t *testing.T) {
+	const domain = "renew.nself.org"
+
+	liveRoot := t.TempDir()
+	liveDomainDir := filepath.Join(liveRoot, domain)
+	if err := os.MkdirAll(liveDomainDir, 0o750); err != nil {
+		t.Fatalf("mkdir live domain dir: %v", err)
+	}
+
+	orig := letsEncryptLiveDir
+	letsEncryptLiveDir = liveRoot
+	t.Cleanup(func() { letsEncryptLiveDir = orig })
+
+	// beforeMtime simulates "captured just before certbot ran".
+	beforeMtime := time.Now().Add(-1 * time.Hour)
+
+	// certbot "renewed" the lineage: fullchain/privkey now exist with a
+	// current mtime, which is after beforeMtime.
+	for name, body := range map[string]string{
+		"fullchain.pem": "RENEWED-FULLCHAIN",
+		"privkey.pem":   "RENEWED-PRIVKEY",
+	} {
+		if err := os.WriteFile(filepath.Join(liveDomainDir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	workdir := t.TempDir()
+	renewed, err := installRenewedCertIfDue(domain, workdir, beforeMtime)
+	if err != nil {
+		t.Fatalf("installRenewedCertIfDue: %v", err)
+	}
+	if !renewed {
+		t.Fatal("expected renewed=true when the live cert's mtime is after beforeMtime")
+	}
+
+	certDir := filepath.Join(workdir, "ssl", "certificates", domainToFilesafe(domain))
+	for name, want := range map[string]string{
+		"fullchain.pem": "RENEWED-FULLCHAIN",
+		"privkey.pem":   "RENEWED-PRIVKEY",
+	} {
+		path := filepath.Join(certDir, name)
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			t.Fatalf("expected %s to exist: %v", path, statErr)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("%s: got perm %o, want 0600", path, perm)
+		}
+		got, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("read %s: %v", path, readErr)
+		}
+		if string(got) != want {
+			t.Errorf("%s: got %q, want %q", path, got, want)
+		}
+	}
+}
+
+// TestInstallRenewedCertIfDue_SkipsWhenNotDue proves the "not unconditional"
+// half of the fix: when certbot's renew was a no-op (the lineage is not yet
+// within its renewal window, so the live cert's mtime did NOT move past
+// beforeMtime), installRenewedCertIfDue must not touch the filesystem at
+// all — no ssl/certificates/ dir is created, and installIssuedCert is not
+// invoked. An unconditional install would pass the happy-path test above but
+// would needlessly rewrite unchanged files on every `ssl renew` call, and
+// could mask a certbot failure by reinstalling stale local files as fresh.
+func TestInstallRenewedCertIfDue_SkipsWhenNotDue(t *testing.T) {
+	const domain = "notdue.nself.org"
+
+	liveRoot := t.TempDir()
+	liveDomainDir := filepath.Join(liveRoot, domain)
+	if err := os.MkdirAll(liveDomainDir, 0o750); err != nil {
+		t.Fatalf("mkdir live domain dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(liveDomainDir, "fullchain.pem"), []byte("OLD-FULLCHAIN"), 0o600); err != nil {
+		t.Fatalf("seed fullchain.pem: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(liveDomainDir, "privkey.pem"), []byte("OLD-PRIVKEY"), 0o600); err != nil {
+		t.Fatalf("seed privkey.pem: %v", err)
+	}
+
+	orig := letsEncryptLiveDir
+	letsEncryptLiveDir = liveRoot
+	t.Cleanup(func() { letsEncryptLiveDir = orig })
+
+	// beforeMtime is in the future relative to the file we just wrote, so
+	// the file's mtime cannot be "after" it — simulating a certbot renew
+	// that was a no-op because the lineage isn't due yet.
+	beforeMtime := time.Now().Add(1 * time.Hour)
+
+	workdir := t.TempDir()
+	renewed, err := installRenewedCertIfDue(domain, workdir, beforeMtime)
+	if err != nil {
+		t.Fatalf("installRenewedCertIfDue: %v", err)
+	}
+	if renewed {
+		t.Fatal("expected renewed=false when the live cert's mtime did not move past beforeMtime")
+	}
+
+	certDir := filepath.Join(workdir, "ssl", "certificates", domainToFilesafe(domain))
+	if _, statErr := os.Stat(certDir); !os.IsNotExist(statErr) {
+		t.Errorf("expected %s to not be created on a not-yet-due renewal, stat err: %v", certDir, statErr)
+	}
+}


### PR DESCRIPTION
## Summary
- **P6-E2-W2-S3-T15**: `nself ssl renew` reordered so certbot renewal runs before any nginx reload, and only after a genuine renewal (live cert mtime moved) does it call `installIssuedCert` into `ssl/certificates/<domain-safe>/` — closing the gap where a renewed LE cert never reached nginx. Extracted into `ssl_renew.go` to keep both files under the 300-line cap (ssl.go was 303 after the inline fix).
- **P6-E2-W2-S3-T16**: `nself config set` still redirects to a monorepo's `.backend/.env` via `FindNSelfRoot` (unchanged), but now prints the full resolved path and an explicit "Using monorepo backend at ..." notice instead of a bare `Added KEY to .env` that gave no indication of where the write landed.

Base branch is `fix/ssl-cert-dir-docs-coverage` (#316, not yet merged) — it exports `internal/ssl.DomainToDirName`; ssl.go's fix reuses the package-local `domainToFilesafe` (same-package convention already used by ssl_add.go/ssl_setup.go) rather than that export, so this PR is independent of #316's own changes. Please retarget/rebase onto `main` once #316 merges.

## Test plan
- [x] `TestInstallRenewedCertIfDue_InstallsWhenRenewed` / `_SkipsWhenNotDue` (ssl_renew_test.go) — before: build failure (`undefined: installRenewedCertIfDue`); after: PASS
- [x] `TestConfigSet_MonorepoRedirectIsVisible` (config_set_test.go) — before: FAIL (`✓ Added TEST_KEY to .env`, no path/notice); after: PASS
- [x] `gofmt -l cmd internal` — exit 0
- [x] `go build ./...` — exit 0
- [x] `go vet ./...` — exit 0
- [x] `go test ./internal/ssl/ ./cmd/commands/ ./internal/config/ -count=1` — exit 0
- [x] `go test ./internal/repoqa/... -run FileSize` — exit 0 (file-size ratchet unaffected)