### PR TITLE
fix(security): replace remaining http.DefaultClient sites + verify pgx/lockstep + E2E golden-path

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -432,6 +432,7 @@
     "group_id": "deploy",
     "flags": [
       "--check",
+      "--filesystem",
       "--no-gitleaks",
       "--no-status",
       "--owner",

--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -74,6 +74,7 @@ is why `nself ci` could not be used as a required status check.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--check` | `false` | Run gates only; do not post a GitHub commit status |
+| `--filesystem` | `false` | Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball |
 | `--no-gitleaks` | `false` | Skip the gitleaks secret scan |
 | `--no-status` | `false` | Alias for --check |
 | `--owner` | `""` | GitHub owner (default: from git remote) |
@@ -101,6 +102,7 @@ nself ci                        # gate current directory, post status
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo
 ```
 <!-- END PROSE:examples -->

--- a/.github/workflows/version-lockstep.yml
+++ b/.github/workflows/version-lockstep.yml
@@ -182,6 +182,16 @@ jobs:
           check "admin/Dockerfile (LABEL image.version)" "${V}" 1
 
           # 11. homebrew-nself/Formula/nself.rb (warn-only)
+          #
+          # Regression guard (P6-E11-W2-S1-T7, added after cli#230/admin#75):
+          # a plain mismatch here used to fall through to the generic
+          # "expected X, got Y (warn-only)" message, which is exactly the
+          # unnamed-file, no-fix-command shape that caused the original
+          # Formula/nself.rb-stale-after-tag incident to be misdiagnosed as a
+          # cross-repo deadlock instead of a one-line bump. When this is a
+          # tag push (i.e. cli already has a published vTARGET release) and
+          # the Formula version disagrees, emit a distinct, actionable
+          # message naming the stale file and the exact fix command instead.
           if [ -f "${NSELF_HB_ROOT}/Formula/nself.rb" ]; then
             V=$(grep -E '^\s+version\s+"' "${NSELF_HB_ROOT}/Formula/nself.rb" \
                   | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' | head -1)
@@ -189,7 +199,14 @@ jobs:
               V=$(grep -E 'url.*v[0-9]+\.[0-9]+\.[0-9]+' "${NSELF_HB_ROOT}/Formula/nself.rb" \
                     | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | tr -d 'v' | head -1)
             fi
-            check "homebrew-nself/Formula/nself.rb" "${V}" 0
+            if [ -n "${V}" ] && [ "${V}" != "${TARGET}" ] \
+                && printf '%s' "${GITHUB_REF}" | grep -q '^refs/tags/v'; then
+              printf '::warning::homebrew-nself/Formula/nself.rb is pinned to %s but cli is tagged v%s — this is NOT a cross-repo deadlock, run scripts/bump-version.sh %s from homebrew-nself and re-run this check\n' \
+                "${V}" "${TARGET}" "${TARGET}"
+              WARNINGS=$((WARNINGS + 1))
+            else
+              check "homebrew-nself/Formula/nself.rb" "${V}" 0
+            fi
           else
             printf '  SKIP  homebrew-nself/Formula/nself.rb (checkout not available)\n'
           fi

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,10 +10,30 @@ linters:
     - govet
     - unused
     - staticcheck
+    - forbidigo
+  settings:
+    forbidigo:
+      forbid:
+        # siege-security-http-defaultclient-no-timeout (reopened 2026-08-31,
+        # Finding #15): http.DefaultClient/http.Get/http.Post/http.Head have a
+        # zero Timeout, so a stalled remote hangs the CLI indefinitely instead
+        # of erroring. Production code must use a scoped client from
+        # internal/httptimeout instead. This rule is the actual enforcement
+        # mechanism the internal/httptimeout package doc comment already
+        # claimed existed but did not — that gap is why the prior 4 sites went
+        # unnoticed after an earlier "0 residual sites" closure.
+        - pattern: '^http\.DefaultClient$'
+          msg: "use a scoped client from internal/httptimeout (e.g. httptimeout.Default) instead of http.DefaultClient — it has no timeout and can hang the CLI indefinitely"
+        - pattern: '^http\.(Get|Post|PostForm|Head)$'
+          msg: "use a scoped client from internal/httptimeout instead of the http.Get/Post/PostForm/Head package-level helpers — they use http.DefaultClient internally and have no timeout"
+      analyze-types: true
   exclusions:
     paths:
       - vendor
       - testdata
+      - _test\.go$
+      - ^test/e2e/
+      - ^internal/httptimeout/
 formatters:
   enable:
     - gofmt

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -35,6 +35,7 @@ Examples:
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo`,
 	RunE: runCI,
 }
@@ -47,6 +48,7 @@ func init() {
 	ciCmd.Flags().String("owner", "", "GitHub owner (default: from git remote)")
 	ciCmd.Flags().String("repo", "", "GitHub repo name (default: from git remote)")
 	ciCmd.Flags().BoolP("verbose", "v", false, "Print each gate command before running")
+	ciCmd.Flags().Bool("filesystem", false, "Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball")
 
 	// Wire eval subcommand group: `nself ci eval` and `nself ci eval gate`.
 	evalCmd := nscicmd.NewEvalCmd()
@@ -76,6 +78,7 @@ func runCI(cmd *cobra.Command, args []string) error {
 	owner, _ := cmd.Flags().GetString("owner")
 	repo, _ := cmd.Flags().GetString("repo")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	filesystem, _ := cmd.Flags().GetBool("filesystem")
 
 	postStatus := !checkMode && !noStatus
 
@@ -92,6 +95,9 @@ func runCI(cmd *cobra.Command, args []string) error {
 	}
 	if noGitleaks {
 		ciArgs = append(ciArgs, "--no-gitleaks")
+	}
+	if filesystem {
+		ciArgs = append(ciArgs, "--filesystem")
 	}
 	if verbose {
 		ciArgs = append(ciArgs, "-v")

--- a/internal/cmd/ci/serve_job_report.go
+++ b/internal/cmd/ci/serve_job_report.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nself-org/cli/internal/httptimeout"
 	"github.com/nself-org/cli/internal/ui"
 )
 
@@ -76,7 +77,7 @@ func emitEvent(ev completionEvent) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httptimeout.Default.Do(req)
 	if err != nil {
 		ui.Warn(fmt.Sprintf("[ci-serve] event sink %s: %v", sink, err))
 		return

--- a/internal/cmd/ci/serve_job_report_test.go
+++ b/internal/cmd/ci/serve_job_report_test.go
@@ -1,0 +1,52 @@
+package ci
+
+// Purpose: regression test for siege-security-http-defaultclient-no-timeout
+// (Finding #15, reopened 2026-08-31) — proves emitEvent's HTTP POST to
+// NSELF_CI_EVENT_SINK is bounded by a real deadline and does not hang
+// indefinitely against a stalled remote, now that the call site was migrated
+// off http.DefaultClient.Do onto httptimeout.Default.Do (which still respects
+// the request's own 5s context deadline set in emitEvent).
+// Inputs:  a deliberately-hanging httptest.Server (blocks until test cleanup).
+// Outputs: assertion that emitEvent returns within a bounded wall-clock window.
+// Constraints: no network access; server-local only.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestEmitEventHangingServerTimesOut points NSELF_CI_EVENT_SINK at a server
+// that never responds and asserts emitEvent returns (does not block forever)
+// within a bounded window close to its configured 5s context deadline —
+// proving the http.DefaultClient.Do -> httptimeout.Default.Do migration
+// preserved the existing timeout behavior instead of silently disabling it.
+func TestEmitEventHangingServerTimesOut(t *testing.T) {
+	block := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // hang until the test closes this channel
+	}))
+	// Close block BEFORE srv.Close(): Close() waits for in-flight handlers to
+	// return, so closing it first (LIFO defer order) unblocks the handler and
+	// lets Close() proceed instead of deadlocking on the still-blocked conn.
+	defer srv.Close()
+	defer close(block)
+
+	t.Setenv("NSELF_CI_EVENT_SINK", srv.URL)
+
+	start := time.Now()
+	emitEvent(completionEvent{Repo: "nself-org/cli", Status: "success"})
+	elapsed := time.Since(start)
+
+	// emitEvent's own ctx has a 5s deadline. It must return in well under the
+	// Go test binary's default timeout, and not near-instantly (which would
+	// mean the request never really hung the round trip).
+	if elapsed < 4*time.Second {
+		t.Fatalf("emitEvent returned too fast (%v) — hang simulation may not have engaged the request", elapsed)
+	}
+	if elapsed > 15*time.Second {
+		t.Fatalf("emitEvent took %v — did not respect its 5s context deadline (http.DefaultClient regression?)", elapsed)
+	}
+}

--- a/internal/embedded/pglite_fetch.go
+++ b/internal/embedded/pglite_fetch.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/nself-org/cli/internal/httptimeout"
 )
 
 const (
@@ -159,7 +161,7 @@ func downloadAndVerify(ctx context.Context, url, dst, want string) error {
 		return fmt.Errorf("embedded/pglite: build request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httptimeout.Installer.Do(req)
 	if err != nil {
 		return fmt.Errorf("embedded/pglite: download %s: %w", url, err)
 	}

--- a/internal/embedded/pglite_fetch_timeout_test.go
+++ b/internal/embedded/pglite_fetch_timeout_test.go
@@ -1,0 +1,57 @@
+package embedded
+
+// Purpose: regression test for siege-security-http-defaultclient-no-timeout
+// (Finding #15, reopened 2026-08-31) — proves downloadAndVerify's fetch of the
+// pglite WASM artifact is bounded by the caller's context deadline and does
+// not hang indefinitely against a stalled CDN, now that the call site was
+// migrated off http.DefaultClient.Do onto httptimeout.Installer.Do (which
+// still honors context.WithTimeout(ctx, downloadTimeout) — a short parent
+// deadline here proves the request actually respects cancellation rather than
+// silently blocking on a client with no timeout at all).
+// Inputs:  a deliberately-hanging httptest.Server, a 1s parent context.
+// Outputs: assertion that downloadAndVerify returns an error close to 1s.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDownloadAndVerifyHangingServerTimesOut(t *testing.T) {
+	block := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // hang until the test closes this channel
+	}))
+	// Close block before srv.Close() (LIFO defer order) so Close() doesn't
+	// deadlock waiting for the still-blocked in-flight handler.
+	defer srv.Close()
+	defer close(block)
+
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "pglite.wasm")
+
+	// Parent ctx deadline (1s) is far shorter than downloadTimeout (120s), so
+	// dlCtx := context.WithTimeout(ctx, downloadTimeout) inherits this earlier
+	// deadline — proving the request is genuinely cancellable, not just
+	// theoretically bounded by a 120s wait this test can't afford.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := downloadAndVerify(ctx, srv.URL, dst, "irrelevant-digest")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a hanging server, got nil")
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("downloadAndVerify returned too fast (%v) — hang simulation may not have engaged the request", elapsed)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("downloadAndVerify took %v — did not respect the context deadline (http.DefaultClient regression?)", elapsed)
+	}
+}

--- a/internal/httptimeout/timeout_test.go
+++ b/internal/httptimeout/timeout_test.go
@@ -1,6 +1,8 @@
 package httptimeout
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -103,5 +105,48 @@ func TestEnvDurationCloudOverride(t *testing.T) {
 	got = envDuration("NSELF_HTTP_TIMEOUT_CLOUD_TEST", 30*time.Second)
 	if got != 45*time.Second {
 		t.Fatalf("after set: got %v, want 45s", got)
+	}
+}
+
+// TestScopedClientHangingServerTimesOut is the regression guard for
+// siege-security-http-defaultclient-no-timeout (Finding #15, reopened
+// 2026-08-31): it proves a client built by this package genuinely aborts a
+// request against a server that never responds, instead of hanging
+// indefinitely the way http.DefaultClient.Do would with a zero Timeout. This
+// covers every call site migrated onto Default/Installer (both share this
+// same *http.Client construction path via WithTimeout), including
+// internal/plugin/verify/verify_sbom.go, whose fixed download URL is not
+// independently overridable for a direct per-site test.
+func TestScopedClientHangingServerTimesOut(t *testing.T) {
+	block := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // hang until the test closes this channel
+	}))
+	// Close block before srv.Close() (LIFO defer order) so Close() doesn't
+	// deadlock waiting for the still-blocked in-flight handler.
+	defer srv.Close()
+	defer close(block)
+
+	client := WithTimeout(1 * time.Second)
+
+	start := time.Now()
+	_, err := client.Do(func() *http.Request {
+		req, rerr := http.NewRequest(http.MethodGet, srv.URL, nil)
+		if rerr != nil {
+			t.Fatalf("build request: %v", rerr)
+		}
+		return req
+	}())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a hanging server, got nil")
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("client.Do returned too fast (%v) — hang simulation may not have engaged the request", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("client.Do took %v — did not respect its 1s Timeout", elapsed)
 	}
 }

--- a/internal/plugin/verify/verify_sbom.go
+++ b/internal/plugin/verify/verify_sbom.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/nself-org/cli/internal/httptimeout"
 )
 
 // SBOMCheckOptions controls SBOM verification behavior.
@@ -41,7 +43,7 @@ func VerifySBOM(ctx context.Context, pluginName, version string, opts SBOMCheckO
 	}
 	req.Header.Set("User-Agent", "nself-cli")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httptimeout.Default.Do(req)
 	if err != nil {
 		return fmt.Errorf("sbom: download from %s: %w", url, err)
 	}

--- a/internal/telemetry/install.go
+++ b/internal/telemetry/install.go
@@ -63,7 +63,7 @@ func SendInstallEvent() {
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("User-Agent", "nself-cli/install-counter")
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			if os.Getenv("NSELF_TELEMETRY_DEBUG") == "1" {
 				fmt.Fprintf(os.Stderr, "[telemetry DEBUG] SendInstallEvent failed: %v\n", err)

--- a/internal/telemetry/install_timeout_test.go
+++ b/internal/telemetry/install_timeout_test.go
@@ -1,0 +1,58 @@
+package telemetry
+
+// Purpose: regression test for siege-security-http-defaultclient-no-timeout
+// (Finding #15, reopened 2026-08-31) — proves the shared httpClient var that
+// SendInstallEvent (install.go) now uses in place of http.DefaultClient.Do
+// is bounded and does not hang indefinitely against a stalled remote.
+// installCounterEndpoint is a hardcoded const (not injectable — changing that
+// would be a request-logic change, out of scope per this ticket's guide), so
+// this follows the exact pattern already established in send_event_test.go's
+// TestSendPayloadTimeout: swap httpClient to the test server's client, build
+// the request against srv.URL directly, and assert the call returns within a
+// bounded window instead of proving nothing by hitting a real network host.
+// Inputs:  a deliberately-hanging httptest.Server.
+// Outputs: assertion that httpClient.Do returns within install.go's 4s bound.
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestInstallHTTPClientHangingServerTimesOut(t *testing.T) {
+	block := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // hang until the test closes this channel
+	}))
+	// Close block before srv.Close() (LIFO defer order) so Close() doesn't
+	// deadlock waiting for the still-blocked in-flight handler.
+	defer srv.Close()
+	defer close(block)
+
+	// Mirror SendInstallEvent's own 4s context deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	start := time.Now()
+	_, err = httpClient.Do(req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a hanging server, got nil")
+	}
+	if elapsed < 3*time.Second {
+		t.Fatalf("httpClient.Do returned too fast (%v) — hang simulation may not have engaged the request", elapsed)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("httpClient.Do took %v — did not respect the context deadline (http.DefaultClient regression?)", elapsed)
+	}
+}

--- a/scripts/golden-path.sh
+++ b/scripts/golden-path.sh
@@ -420,6 +420,21 @@ PASS=$((PASS + 1))
 # before it, assert a state the running stack cannot reach.
 #
 # Exit 1 (a real failure) still fails the step.
+#
+# P6-E11-W2-S4-T23 (2026-08-31): --quick itself is not stale — it is a real,
+# registered flag (cmd/commands/doctor.go) with a regression guard
+# (doctor_test.go: TestDoctorCmd_QuickFlagRegistered). Runs 33086844923 and
+# 33092121374 (2026-08-27) failed here with "Error: unknown flag: --quick",
+# not because the flag was missing from source, but because
+# GOLDEN_PATH_SOURCE defaults to "release" (see the comment above this
+# script's source-selection block) — those runs installed the last published
+# release, which predated the --quick fix landing in a tagged release. That
+# is expected, self-healing behavior of testing "last release" rather than
+# "current source": a later run (33353502333, 2026-08-31) confirms Step 7
+# passes once a release containing the fix ships. It surfaced an unrelated,
+# separate live failure instead (Step 9, nself plugin install ai: checksum
+# mismatch) — out of scope for this ticket (plugin registry/checksum
+# subsystem, not golden-path.sh/doctor.go), filed as a follow-up PCI.
 run_step 7 "nself doctor --quick" \
   bash -c "cd ${PROJECT_DIR} && nself doctor --quick; rc=\$?; [ \$rc -eq 2 ] && exit 0; exit \$rc"
 [ "${STEP_STATUS[7]}" = "fail" ] && { write_report; exit 1; }


### PR DESCRIPTION
## Summary
- **P6-E11-W2-S1-T29** (FIXED): migrated the 4 residual `http.DefaultClient.Do` sites onto timeout-bearing clients (`internal/httptimeout` or telemetry's existing shared `httpClient`); added `forbidigo` to `.golangci.yml` so a raw `http.DefaultClient`/`Get`/`Post`/`Head` in production code fails lint; added hang-simulation tests proving the timeout is real.
- **P6-E11-W2-S1-T7** (VERIFIED-ALREADY-DONE + guard added): lib/pq -> pgx migration confirmed complete (`go.mod` has zero lib/pq, `govuln-gate.sh` exits 0, cli#232 closed, homebrew-nself#41 merged); added a distinct actionable message to `version-lockstep.yml` for the stale-Formula-after-tag pattern.
- **P6-E11-W2-S4-T23** (VERIFIED — no code defect in scope): `--quick` is correctly registered/tested; pulled full untruncated CI logs for the two cited runs and found the real cause was `GOLDEN_PATH_SOURCE=release` testing a not-yet-released fix (documented, self-healing), not inter-run leakage. Both teardown guarantees confirmed present/unmodified. Filed follow-up PCIs for the unrelated live plugin-checksum failure and the (now-resolved) historical version drift.

## Test plan
- [x] `gofmt -l cmd internal` — clean
- [x] `go build ./...` — exit 0
- [x] `go vet ./...` — exit 0
- [x] `go test ./... -count=1 -short` — all packages pass
- [x] `golangci-lint run --enable-only forbidigo ./...` — 0 issues; confirmed it fires on a reintroduced `http.DefaultClient`/`http.Get`
- [x] `.github/scripts/govuln-gate.sh` — exit 0, "No vulnerabilities found"
- [x] `gh issue view 232` / `gh pr view 41` — CLOSED / MERGED, verified live