### PR TITLE
fix(lint): clear staticcheck backlog (157 -> regex-only remainder)

### DIFF
--- a/cmd/commands/account_login.go
+++ b/cmd/commands/account_login.go
@@ -78,10 +78,9 @@ func runAccountLogin(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Step 3: poll for the token.
+	// cmdCtx never returns nil (falls back to context.Background()), so no
+	// nil-check is needed here.
 	baseCtx := cmdCtx(cmd)
-	if baseCtx == nil {
-		baseCtx = context.Background()
-	}
 	timeout := time.Duration(timeoutSec) * time.Second
 	if timeout <= 0 {
 		timeout = 5 * time.Minute

--- a/cmd/commands/bundle_list.go
+++ b/cmd/commands/bundle_list.go
@@ -49,9 +49,10 @@ func runBundleList(cmd *cobra.Command, _ []string) error {
 		}
 
 		status := "active"
-		if key == "ntask" {
+		switch key {
+		case "ntask":
 			status = "free"
-		} else if key == "nsentry" || key == "nfamily" || key == "clawde" {
+		case "nsentry", "nfamily", "clawde":
 			status = "planned"
 		}
 

--- a/cmd/commands/config_export_import.go
+++ b/cmd/commands/config_export_import.go
@@ -66,9 +66,9 @@ func runConfigExport(cmd *cobra.Command, args []string) error {
 		for _, k := range keys {
 			v := maskValue(k, pairs[k], reveal)
 			if strings.ContainsAny(v, ": \t#\"'\\") || v == "" {
-				sb.WriteString(fmt.Sprintf("%s: %q\n", k, v))
+				fmt.Fprintf(&sb, "%s: %q\n", k, v)
 			} else {
-				sb.WriteString(fmt.Sprintf("%s: %s\n", k, v))
+				fmt.Fprintf(&sb, "%s: %s\n", k, v)
 			}
 		}
 	default: // env

--- a/cmd/commands/db_migrate.go
+++ b/cmd/commands/db_migrate.go
@@ -36,7 +36,7 @@ func runDBMigrateUp(cmd *cobra.Command, _ []string) error {
 	checkCmd := exec.CommandContext(cmd.Context(), "docker", "exec", container,
 		"pg_isready", "-U", user)
 	if err := checkCmd.Run(); err != nil {
-		return fmt.Errorf("PostgreSQL is not running. Start with 'nself start' first.")
+		return fmt.Errorf("PostgreSQL is not running — start with 'nself start' first")
 	}
 
 	plugin, _ := cmd.Flags().GetString("plugin")

--- a/cmd/commands/db_remote_version.go
+++ b/cmd/commands/db_remote_version.go
@@ -72,7 +72,7 @@ func checkRemoteVersionDrift(ctx context.Context, rt dbRemoteTarget, sshFlagArgs
 	}
 
 	return fmt.Errorf(
-		"version drift: local nself is v%s but %s (env=%s) runs v%s — remote 'nself %s' output cannot be trusted across versions. Upgrade the remote CLI to v%s (e.g. ssh %s 'nself update'), or pass --allow-version-drift to run anyway.",
+		"version drift: local nself is v%s but %s (env=%s) runs v%s — remote 'nself %s' output cannot be trusted across versions; upgrade the remote CLI to v%s (e.g. ssh %s 'nself update'), or pass --allow-version-drift to run anyway",
 		localVersion, rt.SSHTarget, rt.EnvName, remoteVersion, subCmd, localVersion, rt.SSHTarget,
 	)
 }

--- a/cmd/commands/deploy_env_resolve.go
+++ b/cmd/commands/deploy_env_resolve.go
@@ -53,7 +53,7 @@ func writeResolvedDeployEnv(workdir, target string) (path string, cleanup func()
 
 	var b strings.Builder
 	b.WriteString("# GENERATED — resolved deploy env snapshot, do not commit or hand-edit.\n")
-	b.WriteString(fmt.Sprintf("# Merged from the same cascade config.Load used to build docker-compose.yml for target=%s.\n", target))
+	fmt.Fprintf(&b, "# Merged from the same cascade config.Load used to build docker-compose.yml for target=%s.\n", target)
 	for _, k := range order {
 		b.WriteString(k)
 		b.WriteString("=")

--- a/cmd/commands/doctor_ai_output.go
+++ b/cmd/commands/doctor_ai_output.go
@@ -71,11 +71,12 @@ func printWizardBanner(results []wizardStepResult, elapsed time.Duration) {
 
 	fmt.Println()
 	overall := summaryStatus(results)
-	if overall == "ok" {
+	switch overall {
+	case "ok":
 		ui.Success(fmt.Sprintf("Setup complete in %s", elapsed))
-	} else if overall == "partial" {
+	case "partial":
 		ui.Warn(fmt.Sprintf("Setup partially complete in %s", elapsed))
-	} else {
+	default:
 		ui.Error(fmt.Sprintf("Setup failed after %s", elapsed))
 	}
 

--- a/cmd/commands/functions_test.go
+++ b/cmd/commands/functions_test.go
@@ -165,11 +165,7 @@ func containsLine(text, line string) bool {
 }
 
 func testSplitLines(s string) []string {
-	var lines []string
-	for _, l := range filepath.SplitList(s) {
-		lines = append(lines, l)
-	}
-	// filepath.SplitList uses OS path separator, not newline — use manual split.
+	// filepath.SplitList uses OS path separator, not newline — split manually.
 	var result []string
 	current := ""
 	for _, c := range s {

--- a/cmd/commands/init_templates.go
+++ b/cmd/commands/init_templates.go
@@ -183,7 +183,7 @@ func runInitMarketplaceTemplate(slug, destDir string, force, quiet bool) error {
 		got := hex.EncodeToString(h.Sum(nil))
 		if got != t.TarballSHA256 {
 			return fmt.Errorf(
-				"SHA256 mismatch for template %q\n  expected: %s\n  got:      %s\nThe download may be corrupted or tampered with.",
+				"SHA256 mismatch for template %q\n  expected: %s\n  got:      %s\nthe download may be corrupted or tampered with",
 				slug, t.TarballSHA256, got,
 			)
 		}

--- a/cmd/commands/license_status.go
+++ b/cmd/commands/license_status.go
@@ -203,7 +203,7 @@ Use --json for machine-readable output.`,
 		if cache != nil {
 			fetchedAt := cache.FetchedAt
 			ttlExpiry := license.CacheTTLExpiry(cache.Tier, timeFromUnix(fetchedAt))
-			remaining := ttlExpiry.Sub(time.Now())
+			remaining := time.Until(ttlExpiry)
 			if remaining > 0 {
 				days := int(remaining.Hours() / 24)
 				daysToExpire = &days

--- a/cmd/commands/logs.go
+++ b/cmd/commands/logs.go
@@ -155,9 +155,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		targetServices = append(targetServices, args[0])
 	}
-	for _, svc := range targetServices {
-		composeArgs = append(composeArgs, svc)
-	}
+	composeArgs = append(composeArgs, targetServices...)
 
 	rawCwd, err := os.Getwd()
 	if err != nil {

--- a/cmd/commands/pitr.go
+++ b/cmd/commands/pitr.go
@@ -248,8 +248,8 @@ func runPITRRestore(cmd *cobra.Command, _ []string) error {
 	if os.Getenv("NSELF_PITR_EXPERIMENTAL") != "1" {
 		return fmt.Errorf(
 			"nself pitr restore is not yet production-ready: remote backup fetch " +
-				"and data-directory replacement are still being implemented. " +
-				"Set NSELF_PITR_EXPERIMENTAL=1 to run anyway (at your own risk).",
+				"and data-directory replacement are still being implemented; " +
+				"set NSELF_PITR_EXPERIMENTAL=1 to run anyway (at your own risk)",
 		)
 	}
 

--- a/cmd/commands/self_heal.go
+++ b/cmd/commands/self_heal.go
@@ -69,7 +69,7 @@ func runSelfHealJWT(dryRun bool, toFile string, noPrint bool) error {
 	windowDays := auth.RotationWindowDays()
 
 	if dryRun {
-		ui.Info(fmt.Sprintf("Would rotate HASURA_GRAPHQL_JWT_SECRET"))
+		ui.Info("Would rotate HASURA_GRAPHQL_JWT_SECRET")
 		ui.Info(fmt.Sprintf("  Rotation log: %s", logPath))
 		ui.Info(fmt.Sprintf("  Rotation window: %d days", windowDays))
 		ui.Info("No changes made (--dry-run)")

--- a/cmd/commands/ssl_setup.go
+++ b/cmd/commands/ssl_setup.go
@@ -121,12 +121,13 @@ func runSSLSetup(cmd *cobra.Command, args []string) error {
 
 	// Provider credentials file (certbot convention).
 	credFile := fmt.Sprintf("/etc/letsencrypt/%s.ini", provider)
-	if provider == "cloudflare" {
+	switch provider {
+	case "cloudflare":
 		certArgs = append(certArgs, "--dns-cloudflare-credentials", credFile)
-	} else if provider == "route53" {
+	case "route53":
 		// route53 uses AWS env vars, no credentials flag needed.
 		_ = credFile
-	} else if provider == "digitalocean" {
+	case "digitalocean":
 		certArgs = append(certArgs, "--dns-digitalocean-credentials", credFile)
 	}
 

--- a/cmd/commands/status_print.go
+++ b/cmd/commands/status_print.go
@@ -109,9 +109,9 @@ func wrapDockerError(err error, containerName string) error {
 		return fmt.Errorf("container %s is not running — try: nself start", containerName)
 	}
 	msg := err.Error()
-	if strings.Contains(msg, "Docker is not running") ||
+	if strings.Contains(msg, "docker is not running") ||
 		strings.Contains(msg, "Cannot connect to the Docker daemon") {
-		return fmt.Errorf("Docker is not running — start Docker Desktop or run: systemctl start docker")
+		return fmt.Errorf("docker is not running — start Docker Desktop or run: systemctl start docker")
 	}
 	if strings.Contains(msg, "No such container") || strings.Contains(msg, "not found") {
 		return fmt.Errorf("container %s is not running — try: nself start", containerName)

--- a/cmd/commands/template_publish_update.go
+++ b/cmd/commands/template_publish_update.go
@@ -39,7 +39,7 @@ func runTemplatePublish(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolving manifest path: %w", err)
 	}
 	if _, statErr := os.Stat(absManifest); os.IsNotExist(statErr) {
-		return fmt.Errorf("manifest not found at %s\nCreate a template.yml before publishing.", absManifest)
+		return fmt.Errorf("manifest not found at %s\ncreate a template.yml before publishing", absManifest)
 	}
 
 	ui.Info(fmt.Sprintf("Validating manifest at %s...", absManifest))
@@ -110,8 +110,8 @@ func runTemplateUpdate(cmd *cobra.Command, args []string) error {
 				if strings.Contains(content, "DROP ") || strings.Contains(content, "TRUNCATE ") {
 					if !force {
 						return fmt.Errorf(
-							"migration %s contains destructive changes (DROP/TRUNCATE).\n"+
-								"Re-run with --force to apply after reviewing carefully.",
+							"migration %s contains destructive changes (DROP/TRUNCATE)\n"+
+								"re-run with --force to apply after reviewing carefully",
 							e.Name(),
 						)
 					}

--- a/internal/auth/jwt_rotation_test.go
+++ b/internal/auth/jwt_rotation_test.go
@@ -396,7 +396,7 @@ func TestRotateJWTKey_CryptoRoundTrip(t *testing.T) {
 
 	// Must be valid hex.
 	for _, c := range result.NewKey {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 			t.Errorf("NewKey contains non-hex character %q", c)
 			break
 		}

--- a/internal/backup/pitr/retention.go
+++ b/internal/backup/pitr/retention.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -74,6 +75,18 @@ func PruneRetention(ctx context.Context, catalogPath string, opts PruneOptions) 
 				// Log but don't abort — partial success is better than none.
 				fmt.Fprintf(os.Stderr, "warning: failed to delete remote segment %s: %v\n", key, delErr)
 			}
+		}
+	}
+
+	// Delete local base backup files. toDeleteLocal holds the same remote keys
+	// as toDeleteRemote for entries that also have a local copy; the local
+	// file is expected to live under LocalBaseBackupDir named by the remote
+	// key's basename (see PruneOptions.LocalBaseBackupDir).
+	for _, key := range toDeleteLocal {
+		localPath := filepath.Join(opts.LocalBaseBackupDir, filepath.Base(key))
+		if delErr := os.Remove(localPath); delErr != nil && !os.IsNotExist(delErr) {
+			// Log but don't abort — partial success is better than none.
+			fmt.Fprintf(os.Stderr, "warning: failed to delete local base backup %s: %v\n", localPath, delErr)
 		}
 	}
 

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -69,12 +69,18 @@ func Restore(ctx context.Context, cfg *config.Config, opts RestoreOptions) error
 	}
 
 	if restoreComponents["minio"] && cfg.Minio.Enabled {
+		//lint:ignore SA4023 restoreMinio always errors by design (these paths
+		// are not automated) so success is never silently implied; see its
+		// doc comment.
 		if err := restoreMinio(ctx, cfg, backupDir, opts.BackupID); err != nil {
 			slog.Warn("minio restore failed", "error", err)
 		}
 	}
 
 	if restoreComponents["metadata"] {
+		//lint:ignore SA4023 restoreMetadata always errors by design (these
+		// paths are not automated) so success is never silently implied; see
+		// its doc comment.
 		if err := restoreMetadata(ctx, cfg, backupDir, opts.BackupID); err != nil {
 			slog.Warn("metadata restore failed", "error", err)
 		}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -69,19 +69,13 @@ func Restore(ctx context.Context, cfg *config.Config, opts RestoreOptions) error
 	}
 
 	if restoreComponents["minio"] && cfg.Minio.Enabled {
-		//lint:ignore SA4023 restoreMinio always errors by design (these paths
-		// are not automated) so success is never silently implied; see its
-		// doc comment.
-		if err := restoreMinio(ctx, cfg, backupDir, opts.BackupID); err != nil {
+		if err := restoreMinio(ctx, cfg, backupDir, opts.BackupID); err != nil { //nolint:staticcheck // SA4023: restoreMinio always errors by design (not automated); see its doc comment
 			slog.Warn("minio restore failed", "error", err)
 		}
 	}
 
 	if restoreComponents["metadata"] {
-		//lint:ignore SA4023 restoreMetadata always errors by design (these
-		// paths are not automated) so success is never silently implied; see
-		// its doc comment.
-		if err := restoreMetadata(ctx, cfg, backupDir, opts.BackupID); err != nil {
+		if err := restoreMetadata(ctx, cfg, backupDir, opts.BackupID); err != nil { //nolint:staticcheck // SA4023: restoreMetadata always errors by design (not automated); see its doc comment
 			slog.Warn("metadata restore failed", "error", err)
 		}
 	}
@@ -210,14 +204,14 @@ func restoreBaseBackup(_ context.Context, _ *config.Config, _, _, backupFile str
 		"pg_dump format (nself backup create)", errs.ErrBackupRestoreFailed, backupFile)
 }
 
-func restoreMinio(_ context.Context, _ *config.Config, _, backupID string) error {
+func restoreMinio(_ context.Context, _ *config.Config, _, backupID string) error { //nolint:staticcheck // SA4023: deliberately never returns nil; see comment below
 	// Return an error (not nil) so the caller's slog.Warn reflects reality:
 	// object storage is NOT restored. A silent nil falsely implied success.
 	return fmt.Errorf("%w: minio object-storage restore is not automated; restore the bucket contents manually (backup_id=%s)",
 		errs.ErrBackupRestoreFailed, backupID)
 }
 
-func restoreMetadata(_ context.Context, _ *config.Config, _, backupID string) error {
+func restoreMetadata(_ context.Context, _ *config.Config, _, backupID string) error { //nolint:staticcheck // SA4023: deliberately never returns nil; see comment below
 	// Return an error (not nil) so the caller's slog.Warn reflects reality:
 	// Hasura metadata is NOT restored. A silent nil falsely implied success.
 	return fmt.Errorf("%w: hasura metadata restore is not automated; re-apply metadata manually (backup_id=%s)",

--- a/internal/cmd/ci/serve_test.go
+++ b/internal/cmd/ci/serve_test.go
@@ -261,7 +261,7 @@ func TestWebhookHandler_concurrencyLimit(t *testing.T) {
 	body := []byte(`{"after":"aabbcc","ref":"refs/heads/main","deleted":false,"repository":{"full_name":"o/r","clone_url":"https://github.com/o/r.git"}}`)
 	handler := &webhookHandler{
 		secret:     "",
-		sem:        make(chan struct{}, 0),
+		sem:        make(chan struct{}),
 		binaryPath: "/usr/local/bin/nself-ci",
 		cfg:        ServeConfig{Concurrency: 0, JobTimeout: 60},
 	}

--- a/internal/compose/monitoring/monitoring_test.go
+++ b/internal/compose/monitoring/monitoring_test.go
@@ -73,7 +73,7 @@ func TestRenderPrometheusYAMLStableOrder(t *testing.T) {
 	idxAlpha := strings.Index(string(out1), "job_name: alpha")
 	idxMu := strings.Index(string(out1), "job_name: mu")
 	idxZeta := strings.Index(string(out1), "job_name: zeta")
-	if !(idxAlpha < idxMu && idxMu < idxZeta) {
+	if idxAlpha >= idxMu || idxMu >= idxZeta {
 		t.Fatalf("targets not in alpha order: alpha=%d mu=%d zeta=%d", idxAlpha, idxMu, idxZeta)
 	}
 }

--- a/internal/compose/order_test.go
+++ b/internal/compose/order_test.go
@@ -28,7 +28,7 @@ func TestServiceOrder(t *testing.T) {
 	yaml := string(data)
 
 	// minio MUST be present in the yaml
-	if strings.Index(yaml, "\n    minio:") < 0 {
+	if !strings.Contains(yaml, "\n    minio:") {
 		t.Fatal("minio not found in yaml")
 	}
 

--- a/internal/config/validator_ports_services.go
+++ b/internal/config/validator_ports_services.go
@@ -50,7 +50,7 @@ func ValidateHasuraDevMode(cfg *Config) error {
 		"hostname", hostname,
 		"remediation", "set HASURA_GRAPHQL_DEV_MODE=false in .env.prod",
 	)
-	return fmt.Errorf("HASURA_GRAPHQL_DEV_MODE must not be enabled in production.\nSet HASURA_GRAPHQL_DEV_MODE=false in your .env.prod file.")
+	return fmt.Errorf("HASURA_GRAPHQL_DEV_MODE must not be enabled in production\nset HASURA_GRAPHQL_DEV_MODE=false in your .env.prod file")
 }
 
 // nginx rate limit format: "30r/m", "10r/s", etc.

--- a/internal/controlplane/pipeline.go
+++ b/internal/controlplane/pipeline.go
@@ -66,11 +66,8 @@ func Run(ctx context.Context, inv *Inventory, prober Prober, composePath string)
 
 		// Step 1: Local environment — build once.
 		if env.Kind == "local" {
-			//lint:ignore SA4023 runLocal always errors by design (local
-			// deploy is not yet supported via the pipeline); see its doc
-			// comment.
-			sr, err := runLocal(ctx, env, envStatuses)
-			if err != nil {
+			sr, err := runLocal(ctx, env, envStatuses) //nolint:staticcheck // SA4023: runLocal always errors by design (local deploy not yet supported via the pipeline); see its doc comment
+			if err != nil {                            //nolint:staticcheck // SA4023: same reason as above
 				return result, fmt.Errorf("controlplane: local build: %w", err)
 			}
 			result.Servers = append(result.Servers, sr...)
@@ -159,7 +156,7 @@ func serversByRole(env Environment, statuses []TargetStatus, role ServerRole) []
 // the operator. When local-deploy execution primitives exist (future ticket),
 // this function should be replaced with a real implementation that builds a
 // ServerResult per local server.
-func runLocal(_ context.Context, env Environment, _ []TargetStatus) ([]ServerResult, error) {
+func runLocal(_ context.Context, env Environment, _ []TargetStatus) ([]ServerResult, error) { //nolint:staticcheck // SA4023: deliberately never returns nil; see comment above
 	return nil, fmt.Errorf(
 		"controlplane: local deploy target %q is not yet supported via the pipeline — "+
 			"use `nself build` and `nself start` to manage the local environment",

--- a/internal/controlplane/pipeline.go
+++ b/internal/controlplane/pipeline.go
@@ -66,6 +66,9 @@ func Run(ctx context.Context, inv *Inventory, prober Prober, composePath string)
 
 		// Step 1: Local environment — build once.
 		if env.Kind == "local" {
+			//lint:ignore SA4023 runLocal always errors by design (local
+			// deploy is not yet supported via the pipeline); see its doc
+			// comment.
 			sr, err := runLocal(ctx, env, envStatuses)
 			if err != nil {
 				return result, fmt.Errorf("controlplane: local build: %w", err)

--- a/internal/cost/alerter.go
+++ b/internal/cost/alerter.go
@@ -151,8 +151,8 @@ func (a *Alerter) formatAlert(service string, budget, actual float64) string {
 		channel = "#nself-alerts"
 	}
 	return fmt.Sprintf(
-		"[nSelf Alert] Daily AI cost exceeded budget\nService:  %s\nBudget:   $%.2f/day\nActual:   $%.2f (as of %s UTC)\nAction:   Check /ai/usage or reduce sampling rate",
-		service, budget, actual,
+		"[nSelf Alert] Daily AI cost exceeded budget\nChannel:  %s\nService:  %s\nBudget:   $%.2f/day\nActual:   $%.2f (as of %s UTC)\nAction:   Check /ai/usage or reduce sampling rate",
+		channel, service, budget, actual,
 		time.Now().UTC().Format("15:04"),
 	)
 }
@@ -181,7 +181,7 @@ func (a *Alerter) postSlack(ctx context.Context, message string) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("Slack webhook returned HTTP %d", resp.StatusCode)
+		return fmt.Errorf("slack webhook returned HTTP %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/internal/cost/alerter_test.go
+++ b/internal/cost/alerter_test.go
@@ -58,6 +58,20 @@ func TestFormatAlert(t *testing.T) {
 	if !strings.Contains(msg, "ai plugin") {
 		t.Errorf("expected service name in message, got: %s", msg)
 	}
+	// SLACK_ALERT_CHANNEL is documented as "embedded in message" — it must
+	// actually appear, defaulting to #nself-alerts when unset.
+	if !strings.Contains(msg, "#nself-alerts") {
+		t.Errorf("expected default channel in message, got: %s", msg)
+	}
+}
+
+func TestFormatAlert_CustomChannel(t *testing.T) {
+	t.Setenv("SLACK_ALERT_CHANNEL", "#custom-alerts")
+	a := &Alerter{}
+	msg := a.formatAlert("ai plugin", 5.00, 7.23)
+	if !strings.Contains(msg, "#custom-alerts") {
+		t.Errorf("expected custom channel in message, got: %s", msg)
+	}
 }
 
 func TestPostSlack_NoURL(t *testing.T) {

--- a/internal/database/hasura_git_ops.go
+++ b/internal/database/hasura_git_ops.go
@@ -176,10 +176,10 @@ func CompareSnapshots(before, after []byte) (string, error) {
 	var sb strings.Builder
 	sb.WriteString("Snapshot diff:\n")
 	for _, t := range added {
-		sb.WriteString(fmt.Sprintf("  + %s\n", t))
+		fmt.Fprintf(&sb, "  + %s\n", t)
 	}
 	for _, t := range removed {
-		sb.WriteString(fmt.Sprintf("  - %s\n", t))
+		fmt.Fprintf(&sb, "  - %s\n", t)
 	}
 	return sb.String(), nil
 }

--- a/internal/database/rls.go
+++ b/internal/database/rls.go
@@ -149,49 +149,33 @@ func ApplyDefaultRLSPolicies(ctx context.Context, cfg *config.Config, schema, ta
 		table + "_update_own",
 		table + "_delete_own",
 	} {
-		sb.WriteString(fmt.Sprintf("DROP POLICY IF EXISTS %q ON %s;\n", pol, quoted))
+		fmt.Fprintf(&sb, "DROP POLICY IF EXISTS %q ON %s;\n", pol, quoted)
 	}
 
 	if hasUserID {
 		// User-scoped predicate: owner check OR admin bypass.
 		userPredicate := `(current_setting('hasura.user', true))::uuid = user_id OR current_setting('hasura.role', true) = 'admin'`
 
-		sb.WriteString(fmt.Sprintf(
-			"CREATE POLICY %q ON %s FOR SELECT USING (%s);\n",
-			table+"_select_own", quoted, userPredicate,
-		))
-		sb.WriteString(fmt.Sprintf(
-			"CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n",
-			table+"_insert_own", quoted, userPredicate,
-		))
-		sb.WriteString(fmt.Sprintf(
-			"CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n",
-			table+"_update_own", quoted, userPredicate, userPredicate,
-		))
-		sb.WriteString(fmt.Sprintf(
-			"CREATE POLICY %q ON %s FOR DELETE USING (%s);\n",
-			table+"_delete_own", quoted, userPredicate,
-		))
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR SELECT USING (%s);\n",
+			table+"_select_own", quoted, userPredicate)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n",
+			table+"_insert_own", quoted, userPredicate)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n",
+			table+"_update_own", quoted, userPredicate, userPredicate)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR DELETE USING (%s);\n",
+			table+"_delete_own", quoted, userPredicate)
 	} else {
 		// No user_id column: admin-only access for all operations.
 		adminPredicate := `current_setting('hasura.role', true) = 'admin'`
 
-		sb.WriteString(fmt.Sprintf(
-			"CREATE POLICY %q ON %s FOR SELECT USING (%s);\n",
-			table+"_select_own", quoted, adminPredicate,
-		))
-		sb.WriteString(fmt.Sprintf(
-			"CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n",
-			table+"_insert_own", quoted, adminPredicate,
-		))
-		sb.WriteString(fmt.Sprintf(
-			"CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n",
-			table+"_update_own", quoted, adminPredicate, adminPredicate,
-		))
-		sb.WriteString(fmt.Sprintf(
-			"CREATE POLICY %q ON %s FOR DELETE USING (%s);\n",
-			table+"_delete_own", quoted, adminPredicate,
-		))
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR SELECT USING (%s);\n",
+			table+"_select_own", quoted, adminPredicate)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n",
+			table+"_insert_own", quoted, adminPredicate)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n",
+			table+"_update_own", quoted, adminPredicate, adminPredicate)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR DELETE USING (%s);\n",
+			table+"_delete_own", quoted, adminPredicate)
 	}
 
 	slog.InfoContext(ctx, "rls_policies_apply",

--- a/internal/database/rls_tenant.go
+++ b/internal/database/rls_tenant.go
@@ -70,8 +70,8 @@ func GenerateTenantRLSSQL(cfg TenantRLSConfig) (string, error) {
 	var sb strings.Builder
 
 	// Enable and force RLS.
-	sb.WriteString(fmt.Sprintf("ALTER TABLE %s ENABLE ROW LEVEL SECURITY;\n", quoted))
-	sb.WriteString(fmt.Sprintf("ALTER TABLE %s FORCE ROW LEVEL SECURITY;\n", quoted))
+	fmt.Fprintf(&sb, "ALTER TABLE %s ENABLE ROW LEVEL SECURITY;\n", quoted)
+	fmt.Fprintf(&sb, "ALTER TABLE %s FORCE ROW LEVEL SECURITY;\n", quoted)
 
 	// Drop pre-existing standard policies (idempotent).
 	for _, pol := range []string{
@@ -80,7 +80,7 @@ func GenerateTenantRLSSQL(cfg TenantRLSConfig) (string, error) {
 		tbl + "_update_own",
 		tbl + "_delete_own",
 	} {
-		sb.WriteString(fmt.Sprintf("DROP POLICY IF EXISTS %q ON %s;\n", pol, quoted))
+		fmt.Fprintf(&sb, "DROP POLICY IF EXISTS %q ON %s;\n", pol, quoted)
 	}
 
 	switch cfg.Pattern {
@@ -90,10 +90,10 @@ func GenerateTenantRLSSQL(cfg TenantRLSConfig) (string, error) {
 			`(current_setting('hasura.user', true))::uuid = %s OR current_setting('hasura.role', true) = 'admin'`,
 			col,
 		)
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR SELECT USING (%s);\n", tbl+"_select_own", quoted, pred))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n", tbl+"_insert_own", quoted, pred))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n", tbl+"_update_own", quoted, pred, pred))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR DELETE USING (%s);\n", tbl+"_delete_own", quoted, pred))
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR SELECT USING (%s);\n", tbl+"_select_own", quoted, pred)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n", tbl+"_insert_own", quoted, pred)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n", tbl+"_update_own", quoted, pred, pred)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR DELETE USING (%s);\n", tbl+"_delete_own", quoted, pred)
 
 	case PatternTenantScoped:
 		col := cfg.tenantColumn()
@@ -101,24 +101,24 @@ func GenerateTenantRLSSQL(cfg TenantRLSConfig) (string, error) {
 			`(current_setting('hasura.tenant', true))::uuid = %s OR current_setting('hasura.role', true) = 'admin'`,
 			col,
 		)
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR SELECT USING (%s);\n", tbl+"_select_own", quoted, pred))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n", tbl+"_insert_own", quoted, pred))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n", tbl+"_update_own", quoted, pred, pred))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR DELETE USING (%s);\n", tbl+"_delete_own", quoted, pred))
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR SELECT USING (%s);\n", tbl+"_select_own", quoted, pred)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n", tbl+"_insert_own", quoted, pred)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n", tbl+"_update_own", quoted, pred, pred)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR DELETE USING (%s);\n", tbl+"_delete_own", quoted, pred)
 
 	case PatternPublic:
 		// Public: always return true — no filter on any operation.
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR SELECT USING (true);\n", tbl+"_select_own", quoted))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR INSERT WITH CHECK (true);\n", tbl+"_insert_own", quoted))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR UPDATE USING (true) WITH CHECK (true);\n", tbl+"_update_own", quoted))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR DELETE USING (true);\n", tbl+"_delete_own", quoted))
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR SELECT USING (true);\n", tbl+"_select_own", quoted)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR INSERT WITH CHECK (true);\n", tbl+"_insert_own", quoted)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR UPDATE USING (true) WITH CHECK (true);\n", tbl+"_update_own", quoted)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR DELETE USING (true);\n", tbl+"_delete_own", quoted)
 
 	case PatternAdminOnly:
 		pred := `current_setting('hasura.role', true) = 'admin'`
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR SELECT USING (%s);\n", tbl+"_select_own", quoted, pred))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n", tbl+"_insert_own", quoted, pred))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n", tbl+"_update_own", quoted, pred, pred))
-		sb.WriteString(fmt.Sprintf("CREATE POLICY %q ON %s FOR DELETE USING (%s);\n", tbl+"_delete_own", quoted, pred))
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR SELECT USING (%s);\n", tbl+"_select_own", quoted, pred)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR INSERT WITH CHECK (%s);\n", tbl+"_insert_own", quoted, pred)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR UPDATE USING (%s) WITH CHECK (%s);\n", tbl+"_update_own", quoted, pred, pred)
+		fmt.Fprintf(&sb, "CREATE POLICY %q ON %s FOR DELETE USING (%s);\n", tbl+"_delete_own", quoted, pred)
 
 	default:
 		return "", fmt.Errorf("generate tenant rls sql: unknown pattern %q", cfg.Pattern)
@@ -152,8 +152,8 @@ func GenerateRollbackSQL(schema, table string) string {
 		table + "_update_own",
 		table + "_delete_own",
 	} {
-		sb.WriteString(fmt.Sprintf("DROP POLICY IF EXISTS %q ON %s;\n", pol, quoted))
+		fmt.Fprintf(&sb, "DROP POLICY IF EXISTS %q ON %s;\n", pol, quoted)
 	}
-	sb.WriteString(fmt.Sprintf("ALTER TABLE %s DISABLE ROW LEVEL SECURITY;\n", quoted))
+	fmt.Fprintf(&sb, "ALTER TABLE %s DISABLE ROW LEVEL SECURITY;\n", quoted)
 	return sb.String()
 }

--- a/internal/deploy/bluegreen/bluegreen_lifecycle.go
+++ b/internal/deploy/bluegreen/bluegreen_lifecycle.go
@@ -181,18 +181,18 @@ func GenerateNginxUpstream(cfg DeployConfig, canaryPercent int) string {
 	sb.WriteString("upstream nself_api {\n")
 
 	if blueWeight > 0 {
-		sb.WriteString(fmt.Sprintf("    server 127.0.0.1:%d weight=%d;   # blue\n", blueBase, blueWeight))
+		fmt.Fprintf(&sb, "    server 127.0.0.1:%d weight=%d;   # blue\n", blueBase, blueWeight)
 	}
 	if greenWeight > 0 {
-		sb.WriteString(fmt.Sprintf("    server 127.0.0.1:%d weight=%d;   # green (%d%% canary)\n", greenBase, greenWeight, canaryPercent))
+		fmt.Fprintf(&sb, "    server 127.0.0.1:%d weight=%d;   # green (%d%% canary)\n", greenBase, greenWeight, canaryPercent)
 	}
 
 	// When one side has 0 weight, still include it as backup to avoid nginx config errors.
 	if blueWeight == 0 {
-		sb.WriteString(fmt.Sprintf("    server 127.0.0.1:%d weight=0 backup;   # blue (idle)\n", blueBase))
+		fmt.Fprintf(&sb, "    server 127.0.0.1:%d weight=0 backup;   # blue (idle)\n", blueBase)
 	}
 	if greenWeight == 0 {
-		sb.WriteString(fmt.Sprintf("    server 127.0.0.1:%d weight=0 backup;   # green (idle)\n", greenBase))
+		fmt.Fprintf(&sb, "    server 127.0.0.1:%d weight=0 backup;   # green (idle)\n", greenBase)
 	}
 
 	sb.WriteString("}\n")

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -992,7 +992,7 @@ func TestComposeBaseArgs_WithFilesForStop(t *testing.T) {
 func TestStop_PsErrorDoesNotPreventStop(t *testing.T) {
 	// Simulate the decision logic in runStop:
 	// "if psErr == nil && len(containers) == 0 && len(args) == 0 → nothing to do"
-	var psErr error = fmt.Errorf("compose ps failed")
+	var psErr = fmt.Errorf("compose ps failed")
 	containers := []ContainerInfo{}
 	args := []string{}
 

--- a/internal/docker/inspect.go
+++ b/internal/docker/inspect.go
@@ -94,13 +94,13 @@ func GetHealthStatus(ctx context.Context, name string) (string, error) {
 				return "not_found", nil
 			}
 			if strings.Contains(stderr, "Cannot connect to the Docker daemon") {
-				return "", fmt.Errorf("Docker is not running — start Docker Desktop or run: systemctl start docker")
+				return "", fmt.Errorf("docker is not running — start Docker Desktop or run: systemctl start docker")
 			}
 			return "", fmt.Errorf("docker inspect health for %q: %s", name, stderr)
 		}
 		// Handle cases where docker is not installed or the daemon error appears outside stderr.
 		if strings.Contains(err.Error(), "Cannot connect to the Docker daemon") {
-			return "", fmt.Errorf("Docker is not running — start Docker Desktop or run: systemctl start docker")
+			return "", fmt.Errorf("docker is not running — start Docker Desktop or run: systemctl start docker")
 		}
 		return "", fmt.Errorf("docker inspect health for %q: %w", name, err)
 	}

--- a/internal/doctor/check_ci_token.go
+++ b/internal/doctor/check_ci_token.go
@@ -59,7 +59,7 @@ func CheckCIToken(projectDir string) CheckResult {
 				"The version-lockstep CI workflow (version-lockstep.yml) requires a GitHub token "+
 				"with contents:read on nself-org/admin and nself-org/homebrew-nself. "+
 				"Set NSELF_CI_TOKEN via GitHub Actions secret or .env.secrets.", ciTokenEnvKey),
-			FixCmd: fmt.Sprintf("gh secret set NSELF_CI_TOKEN --repo nself-org/cli --body '<token>'"),
+			FixCmd: "gh secret set NSELF_CI_TOKEN --repo nself-org/cli --body '<token>'",
 		}
 	}
 

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -66,11 +66,11 @@ func NginxServerBlock(domain, upstream, sslDir string, hasSSL bool) string {
 		sb.WriteString("    listen [::]:80;\n")
 	}
 
-	sb.WriteString(fmt.Sprintf("    server_name %s;\n", domain))
+	fmt.Fprintf(&sb, "    server_name %s;\n", domain)
 
 	if hasSSL {
-		sb.WriteString(fmt.Sprintf("\n    ssl_certificate /etc/letsencrypt/live/%s/fullchain.pem;\n", domain))
-		sb.WriteString(fmt.Sprintf("    ssl_certificate_key /etc/letsencrypt/live/%s/privkey.pem;\n", domain))
+		fmt.Fprintf(&sb, "\n    ssl_certificate /etc/letsencrypt/live/%s/fullchain.pem;\n", domain)
+		fmt.Fprintf(&sb, "    ssl_certificate_key /etc/letsencrypt/live/%s/privkey.pem;\n", domain)
 		sb.WriteString("\n    add_header Strict-Transport-Security \"max-age=31536000; includeSubDomains; preload\" always;\n")
 	}
 

--- a/internal/embedded/pg_socket_bridge.go
+++ b/internal/embedded/pg_socket_bridge.go
@@ -156,11 +156,7 @@ func (b *PGSocketBridge) handleConn(ctx context.Context, client net.Conn) {
 	// client → backend: intercept unsupported commands.
 	go func() {
 		defer wg.Done()
-		//lint:ignore SA4023 proxyClientToBackend's loop only exits via an
-		// error return (connection close/EOF is the normal exit path), so
-		// the error is intentionally discarded here rather than treated as
-		// a real failure.
-		if err := proxyClientToBackend(client, backend); err != nil {
+		if err := proxyClientToBackend(client, backend); err != nil { //nolint:staticcheck // SA4023: the loop only exits via an error return (EOF/connection-close is the normal path); discarded intentionally
 			// Connection closed or read error — normal EOF.
 		}
 	}()
@@ -174,7 +170,7 @@ func (b *PGSocketBridge) handleConn(ctx context.Context, client net.Conn) {
 // the client instead.
 //
 // The function returns when either side closes the connection.
-func proxyClientToBackend(client, backend net.Conn) error {
+func proxyClientToBackend(client, backend net.Conn) error { //nolint:staticcheck // SA4023: deliberately never returns nil; see comment above
 	for {
 		// Read one Postgres message from the client.
 		// Postgres frontend message format:

--- a/internal/embedded/pg_socket_bridge.go
+++ b/internal/embedded/pg_socket_bridge.go
@@ -156,6 +156,10 @@ func (b *PGSocketBridge) handleConn(ctx context.Context, client net.Conn) {
 	// client → backend: intercept unsupported commands.
 	go func() {
 		defer wg.Done()
+		//lint:ignore SA4023 proxyClientToBackend's loop only exits via an
+		// error return (connection close/EOF is the normal exit path), so
+		// the error is intentionally discarded here rather than treated as
+		// a real failure.
 		if err := proxyClientToBackend(client, backend); err != nil {
 			// Connection closed or read error — normal EOF.
 		}

--- a/internal/errs/structured.go
+++ b/internal/errs/structured.go
@@ -31,15 +31,15 @@ type CLIError struct {
 // Error implements the error interface with the structured 4-field format.
 func (e *CLIError) Error() string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("[%s] %s", e.Code, e.What))
+	fmt.Fprintf(&b, "[%s] %s", e.Code, e.What)
 	if e.Why != "" {
-		b.WriteString(fmt.Sprintf("\n  Why: %s", e.Why))
+		fmt.Fprintf(&b, "\n  Why: %s", e.Why)
 	}
 	if e.Fix != "" {
-		b.WriteString(fmt.Sprintf("\n  Fix: %s", e.Fix))
+		fmt.Fprintf(&b, "\n  Fix: %s", e.Fix)
 	}
 	if e.DocsPath != "" {
-		b.WriteString(fmt.Sprintf("\n  Docs: https://nself.org/docs/%s", e.DocsPath))
+		fmt.Fprintf(&b, "\n  Docs: https://nself.org/docs/%s", e.DocsPath)
 	}
 	return b.String()
 }

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"context"
 	"testing"
 )
 
@@ -49,7 +50,7 @@ func TestResolveServiceHealth_DirectServiceNameMatch(t *testing.T) {
 		"hasura":   "starting",
 	}
 
-	result := resolveServiceHealth(nil, "myproject", "postgres", composeMap)
+	result := resolveServiceHealth(context.Background(), "myproject", "postgres", composeMap)
 	if result.Status != "healthy" {
 		t.Errorf("expected status %q, got %q", "healthy", result.Status)
 	}
@@ -68,7 +69,7 @@ func TestResolveServiceHealth_ContainerNameFallback(t *testing.T) {
 		"nclaw_postgres": "healthy",
 	}
 
-	result := resolveServiceHealth(nil, "nclaw", "postgres", composeMap)
+	result := resolveServiceHealth(context.Background(), "nclaw", "postgres", composeMap)
 	if result.Status != "healthy" {
 		t.Errorf("expected status %q via container name fallback, got %q", "healthy", result.Status)
 	}
@@ -83,7 +84,7 @@ func TestResolveServiceHealth_ComposeV2NameFallback(t *testing.T) {
 		"myapp-redis-1": "healthy",
 	}
 
-	result := resolveServiceHealth(nil, "myapp", "redis", composeMap)
+	result := resolveServiceHealth(context.Background(), "myapp", "redis", composeMap)
 	if result.Status != "healthy" {
 		t.Errorf("expected status %q via v2 name fallback, got %q", "healthy", result.Status)
 	}
@@ -92,7 +93,7 @@ func TestResolveServiceHealth_ComposeV2NameFallback(t *testing.T) {
 // TestBuildComposeHealthMap_EmptyWorkdir verifies that buildComposeHealthMap
 // returns an empty map (not nil, not a panic) when workdir is empty string.
 func TestBuildComposeHealthMap_EmptyWorkdir(t *testing.T) {
-	m := buildComposeHealthMap(nil, "")
+	m := buildComposeHealthMap(context.Background(), "")
 	if m == nil {
 		t.Fatal("buildComposeHealthMap(\"\") returned nil, expected empty map")
 	}
@@ -119,7 +120,7 @@ func TestHealthReport_AllServicesHealthy(t *testing.T) {
 	}
 
 	for _, svc := range services {
-		result := resolveServiceHealth(nil, "testproj", svc, composeMap)
+		result := resolveServiceHealth(context.Background(), "testproj", svc, composeMap)
 		if result.Status == "healthy" {
 			report.Healthy++
 		} else {
@@ -212,7 +213,7 @@ func TestHealthReport_AllServicesHealthy_RunningCountsHealthy(t *testing.T) {
 	}
 
 	for _, svc := range services {
-		result := resolveServiceHealth(nil, "testproj", svc, composeMap)
+		result := resolveServiceHealth(context.Background(), "testproj", svc, composeMap)
 		if result.OK() {
 			report.Healthy++
 		} else {

--- a/internal/license/validator.go
+++ b/internal/license/validator.go
@@ -151,7 +151,7 @@ func tryRemote(ctx context.Context, key string, opts *ValidatorOptions) (*Valida
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	var doer HTTPDoer = opts.HTTPClient
+	var doer = opts.HTTPClient
 	if doer == nil {
 		doer = &http.Client{Timeout: 30 * time.Second}
 	}

--- a/internal/migrate/firebase/firebase_helpers.go
+++ b/internal/migrate/firebase/firebase_helpers.go
@@ -19,15 +19,15 @@ import (
 
 func buildSummary(collections []CollectionInfo, projectName string) []byte {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("# Firebase → nSelf Migration Summary\n\n"))
-	sb.WriteString(fmt.Sprintf("**Project:** %s  \n", projectName))
-	sb.WriteString(fmt.Sprintf("**Generated:** %s\n\n", time.Now().UTC().Format(time.RFC3339)))
+	sb.WriteString("# Firebase → nSelf Migration Summary\n\n")
+	fmt.Fprintf(&sb, "**Project:** %s  \n", projectName)
+	fmt.Fprintf(&sb, "**Generated:** %s\n\n", time.Now().UTC().Format(time.RFC3339))
 
 	sb.WriteString("## Inferred Tables\n\n")
 	sb.WriteString("| Firestore Collection | PostgreSQL Table | Columns | Documents Sampled |\n")
 	sb.WriteString("|---|---|---|---|\n")
 	for _, c := range collections {
-		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %d | %d |\n", c.Name, c.TableName, len(c.Columns), c.SampleCount))
+		fmt.Fprintf(&sb, "| `%s` | `%s` | %d | %d |\n", c.Name, c.TableName, len(c.Columns), c.SampleCount)
 	}
 
 	sb.WriteString("\n## Next Steps\n\n")

--- a/internal/migrate/firebase/firebase_migration_auth.go
+++ b/internal/migrate/firebase/firebase_migration_auth.go
@@ -17,17 +17,17 @@ import (
 
 func buildSchemaMigration(collections []CollectionInfo, projectName string) []byte {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("-- Firebase → nSelf schema migration\n"))
-	sb.WriteString(fmt.Sprintf("-- Project: %s\n", projectName))
-	sb.WriteString(fmt.Sprintf("-- Generated: %s\n", time.Now().UTC().Format(time.RFC3339)))
+	sb.WriteString("-- Firebase → nSelf schema migration\n")
+	fmt.Fprintf(&sb, "-- Project: %s\n", projectName)
+	fmt.Fprintf(&sb, "-- Generated: %s\n", time.Now().UTC().Format(time.RFC3339))
 	sb.WriteString("-- Review carefully before applying to production.\n\n")
 
 	sb.WriteString("BEGIN;\n\n")
 
 	for _, coll := range collections {
-		sb.WriteString(fmt.Sprintf("-- Collection: %s\n", coll.Name))
-		sb.WriteString(fmt.Sprintf("-- Documents sampled: %d\n", coll.SampleCount))
-		sb.WriteString(fmt.Sprintf("CREATE TABLE IF NOT EXISTS public.%s (\n", coll.TableName))
+		fmt.Fprintf(&sb, "-- Collection: %s\n", coll.Name)
+		fmt.Fprintf(&sb, "-- Documents sampled: %d\n", coll.SampleCount)
+		fmt.Fprintf(&sb, "CREATE TABLE IF NOT EXISTS public.%s (\n", coll.TableName)
 
 		for i, col := range coll.Columns {
 			nullStr := " NOT NULL"
@@ -39,17 +39,17 @@ func buildSchemaMigration(collections []CollectionInfo, projectName string) []by
 				suffix = ""
 			}
 			if col.Name == "id" {
-				sb.WriteString(fmt.Sprintf("  id TEXT NOT NULL PRIMARY KEY%s\n", suffix))
+				fmt.Fprintf(&sb, "  id TEXT NOT NULL PRIMARY KEY%s\n", suffix)
 			} else {
-				sb.WriteString(fmt.Sprintf("  %s %s%s%s\n", col.Name, col.SQLType, nullStr, suffix))
+				fmt.Fprintf(&sb, "  %s %s%s%s\n", col.Name, col.SQLType, nullStr, suffix)
 			}
 		}
 
 		sb.WriteString(");\n\n")
 
 		// Basic RLS scaffold.
-		sb.WriteString(fmt.Sprintf("ALTER TABLE public.%s ENABLE ROW LEVEL SECURITY;\n", coll.TableName))
-		sb.WriteString(fmt.Sprintf("-- TODO: add RLS policies for public.%s (Firebase security rules → Postgres RLS)\n\n", coll.TableName))
+		fmt.Fprintf(&sb, "ALTER TABLE public.%s ENABLE ROW LEVEL SECURITY;\n", coll.TableName)
+		fmt.Fprintf(&sb, "-- TODO: add RLS policies for public.%s (Firebase security rules → Postgres RLS)\n\n", coll.TableName)
 	}
 
 	sb.WriteString("COMMIT;\n")
@@ -71,11 +71,11 @@ func buildHasuraMetadata(collections []CollectionInfo) []byte {
 	sb.WriteString("    tables:\n")
 
 	for _, coll := range collections {
-		sb.WriteString(fmt.Sprintf("      - table:\n"))
-		sb.WriteString(fmt.Sprintf("          schema: public\n"))
-		sb.WriteString(fmt.Sprintf("          name: %s\n", coll.TableName))
-		sb.WriteString(fmt.Sprintf("        # Collection: %s (%d documents sampled)\n", coll.Name, coll.SampleCount))
-		sb.WriteString(fmt.Sprintf("        # TODO: configure select/insert/update/delete permissions\n"))
+		sb.WriteString("      - table:\n")
+		sb.WriteString("          schema: public\n")
+		fmt.Fprintf(&sb, "          name: %s\n", coll.TableName)
+		fmt.Fprintf(&sb, "        # Collection: %s (%d documents sampled)\n", coll.Name, coll.SampleCount)
+		sb.WriteString("        # TODO: configure select/insert/update/delete permissions\n")
 	}
 
 	return []byte(sb.String())
@@ -119,8 +119,8 @@ func buildAuthImport(authExportFile string) ([]byte, error) {
 
 	var sb strings.Builder
 	sb.WriteString("-- Firebase Auth user import\n")
-	sb.WriteString(fmt.Sprintf("-- Source: %s\n", authExportFile))
-	sb.WriteString(fmt.Sprintf("-- Users: %d\n", len(export.Users)))
+	fmt.Fprintf(&sb, "-- Source: %s\n", authExportFile)
+	fmt.Fprintf(&sb, "-- Users: %d\n", len(export.Users))
 	sb.WriteString("-- Review carefully; passwords are NOT migrated (users must reset).\n\n")
 	sb.WriteString("BEGIN;\n\n")
 
@@ -130,7 +130,7 @@ func buildAuthImport(authExportFile string) ([]byte, error) {
 		}
 		email := sanitizeSQL(u.Email)
 		displayName := sanitizeSQL(u.DisplayName)
-		sb.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&sb,
 			"INSERT INTO auth.users (id, email, email_confirmed_at, raw_user_meta_data, created_at, is_sso_user)\n"+
 				"VALUES (gen_random_uuid(), '%s', %s, '{\"display_name\":\"%s\",\"firebase_uid\":\"%s\"}'::jsonb, NOW(), false)\n"+
 				"ON CONFLICT (email) DO NOTHING;\n\n",
@@ -138,7 +138,7 @@ func buildAuthImport(authExportFile string) ([]byte, error) {
 			boolToSQLTimestamp(u.EmailVerified),
 			displayName,
 			sanitizeSQL(u.LocalID),
-		))
+		)
 	}
 
 	sb.WriteString("COMMIT;\n")

--- a/internal/migration/migrator_helpers.go
+++ b/internal/migration/migrator_helpers.go
@@ -119,7 +119,7 @@ func pluginWarning(projectDir, backupDir string) {
 		for _, p := range plugins {
 			installCmd += " " + p
 		}
-		_, _ = fmt.Fprintln(os.Stdout, fmt.Sprintf("  Step 2: Re-install your %d plugin(s) (detected from v0.9 .env)", len(plugins)))
+		_, _ = fmt.Fprintf(os.Stdout, "  Step 2: Re-install your %d plugin(s) (detected from v0.9 .env)\n", len(plugins))
 		_, _ = fmt.Fprintln(os.Stdout, bold+"    "+installCmd+reset)
 	} else {
 		_, _ = fmt.Fprintln(os.Stdout, "  Step 2: Re-install your plugins")

--- a/internal/nginx/upstream.go
+++ b/internal/nginx/upstream.go
@@ -63,18 +63,18 @@ func GenerateWeightedUpstream(cfg UpstreamConfig, canaryPercent int) (string, er
 	greenWeight := canaryPercent
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("upstream %s {\n", name))
+	fmt.Fprintf(&sb, "upstream %s {\n", name)
 
 	if blueWeight > 0 {
-		sb.WriteString(fmt.Sprintf("    server %s:%d weight=%d;   # blue\n", cfg.BlueHost, cfg.BluePort, blueWeight))
+		fmt.Fprintf(&sb, "    server %s:%d weight=%d;   # blue\n", cfg.BlueHost, cfg.BluePort, blueWeight)
 	} else {
-		sb.WriteString(fmt.Sprintf("    server %s:%d weight=0 backup;   # blue (idle)\n", cfg.BlueHost, cfg.BluePort))
+		fmt.Fprintf(&sb, "    server %s:%d weight=0 backup;   # blue (idle)\n", cfg.BlueHost, cfg.BluePort)
 	}
 
 	if greenWeight > 0 {
-		sb.WriteString(fmt.Sprintf("    server %s:%d weight=%d;   # green (%d%% canary)\n", cfg.GreenHost, cfg.GreenPort, greenWeight, canaryPercent))
+		fmt.Fprintf(&sb, "    server %s:%d weight=%d;   # green (%d%% canary)\n", cfg.GreenHost, cfg.GreenPort, greenWeight, canaryPercent)
 	} else {
-		sb.WriteString(fmt.Sprintf("    server %s:%d weight=0 backup;   # green (idle)\n", cfg.GreenHost, cfg.GreenPort))
+		fmt.Fprintf(&sb, "    server %s:%d weight=0 backup;   # green (idle)\n", cfg.GreenHost, cfg.GreenPort)
 	}
 
 	sb.WriteString("}\n")

--- a/internal/onboarding/funnel.go
+++ b/internal/onboarding/funnel.go
@@ -52,40 +52,44 @@ func RunFunnel() FunnelReport {
 	// Stage 2 — Activation
 	s2 := checkStage2Activation(skipping)
 	report.Stages = append(report.Stages, s2)
-	if s2.Status == StatusPass {
+	switch s2.Status {
+	case StatusPass:
 		report.Position = 2
 		emitTelemetry(2, "onboard.activation", s2.Metadata)
-	} else if s2.Status == StatusFail {
+	case StatusFail:
 		skipping = true
 	}
 
 	// Stage 3 — First-use
 	s3 := checkStage3FirstUse(skipping, s1)
 	report.Stages = append(report.Stages, s3)
-	if s3.Status == StatusPass {
+	switch s3.Status {
+	case StatusPass:
 		report.Position = 3
 		emitTelemetry(3, "onboard.first_use", s3.Metadata)
-	} else if s3.Status == StatusFail {
+	case StatusFail:
 		skipping = true
 	}
 
 	// Stage 4 — First-plugin
 	s4 := checkStage4FirstPlugin(skipping)
 	report.Stages = append(report.Stages, s4)
-	if s4.Status == StatusPass {
+	switch s4.Status {
+	case StatusPass:
 		report.Position = 4
 		emitTelemetry(4, "onboard.first_plugin", s4.Metadata)
-	} else if s4.Status == StatusFail {
+	case StatusFail:
 		skipping = true
 	}
 
 	// Stage 5 — First-value
 	s5 := checkStage5FirstValue(skipping)
 	report.Stages = append(report.Stages, s5)
-	if s5.Status == StatusPass {
+	switch s5.Status {
+	case StatusPass:
 		report.Position = 5
 		emitTelemetry(5, "onboard.first_value", s5.Metadata)
-	} else if s5.Status == StatusFail {
+	case StatusFail:
 		skipping = true
 	}
 

--- a/internal/onboarding/stages.go
+++ b/internal/onboarding/stages.go
@@ -75,10 +75,10 @@ func checkStage3FirstUse(skip bool, s1 StageResult) StageResult {
 	}
 	daysAgo := int(time.Since(t).Hours() / 24)
 	var durationStr string
-	switch {
-	case daysAgo == 0:
+	switch daysAgo {
+	case 0:
 		durationStr = "today"
-	case daysAgo == 1:
+	case 1:
 		durationStr = "1 day ago"
 	default:
 		durationStr = fmt.Sprintf("%d days ago", daysAgo)

--- a/internal/plugin/installer_locked.go
+++ b/internal/plugin/installer_locked.go
@@ -50,7 +50,7 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 	switch manifest.PublishStatus {
 	case "planned":
 		return fmt.Errorf(
-			"plugin %q is not yet available — coming soon.\nSee https://nself.org/plugins/%s for the release timeline.\nRun 'nself plugin list' to see available plugins.",
+			"plugin %q is not yet available — coming soon\nsee https://nself.org/plugins/%s for the release timeline\nrun 'nself plugin list' to see available plugins",
 			name, name,
 		)
 	case "experimental":

--- a/internal/plugin/license_validation_test.go
+++ b/internal/plugin/license_validation_test.go
@@ -152,14 +152,11 @@ func TestCheckLicenseCacheOffline_InvalidEntryDenied(t *testing.T) {
 	// Fresh cache, but marked invalid.
 	writeCacheEntryWithAge(t, cacheDir, key, "invalid", 0)
 
-	valid, found := checkLicenseCacheOffline(key, cacheDir)
-	if !found {
-		// An "invalid" entry IS found — it is returned so the caller can see
-		// that the cache says invalid (not just missing).
-		// Accept this as a valid outcome too; the key constraint is valid=false.
-	}
-	// Regardless of found, valid must be false for an "invalid" cached entry.
-	_ = found
+	// An "invalid" entry IS found — it is returned so the caller can see that
+	// the cache says invalid (not just missing) — but `found` isn't asserted
+	// either way here; regardless of found, valid must be false for an
+	// "invalid" cached entry.
+	valid, _ := checkLicenseCacheOffline(key, cacheDir)
 	if valid {
 		t.Fatal("offline grace must not grant access when cached result is 'invalid'")
 	}

--- a/internal/plugin/network.go
+++ b/internal/plugin/network.go
@@ -26,7 +26,7 @@ func ValidateNetworkAccess(ctx context.Context, registryURL string) error {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("cannot reach plugin registry %s: %w\nCheck your network connection or set NSELF_PLUGIN_REGISTRY to a local mirror.", registryURL, err)
+		return fmt.Errorf("cannot reach plugin registry %s: %w\ncheck your network connection or set NSELF_PLUGIN_REGISTRY to a local mirror", registryURL, err)
 	}
 	_ = resp.Body.Close()
 	return nil

--- a/internal/plugin/registry_field_coverage_test.go
+++ b/internal/plugin/registry_field_coverage_test.go
@@ -135,7 +135,7 @@ func populate(t *testing.T, v reflect.Value) {
 			f.Set(m)
 		case reflect.Struct:
 			populate(t, f)
-		case reflect.Ptr:
+		case reflect.Pointer:
 			p := reflect.New(f.Type().Elem())
 			if p.Elem().Kind() == reflect.Struct {
 				populate(t, p.Elem())

--- a/internal/plugin/security_license.go
+++ b/internal/plugin/security_license.go
@@ -141,9 +141,9 @@ func CheckEOLBlock(ctx context.Context, name string, allowEOL bool) error {
 	}
 	if manifest.PublishStatus == "eol" && !allowEOL {
 		return fmt.Errorf(
-			"plugin %q has reached end-of-life and cannot be installed.\n"+
-				"Use --allow-eol to override (not recommended).\n"+
-				"Run 'nself plugin info %s' for details.",
+			"plugin %q has reached end-of-life and cannot be installed\n"+
+				"use --allow-eol to override (not recommended)\n"+
+				"run 'nself plugin info %s' for details",
 			name, name,
 		)
 	}

--- a/internal/ports/holder.go
+++ b/internal/ports/holder.go
@@ -54,7 +54,7 @@ func FormatConflictMessage(port int, holder *Holder) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("port %d is held by %s (pid %d)", port, holder.Name, holder.PID))
+	fmt.Fprintf(&sb, "port %d is held by %s (pid %d)", port, holder.Name, holder.PID)
 
 	if holder.IsOurs {
 		sb.WriteString(" [nSelf container]")
@@ -64,7 +64,7 @@ func FormatConflictMessage(port int, holder *Holder) string {
 
 	// Suggest the likely env var name based on the port.
 	if envVar := portEnvVar(port); envVar != "" {
-		sb.WriteString(fmt.Sprintf(" (e.g. %s)", envVar))
+		fmt.Fprintf(&sb, " (e.g. %s)", envVar)
 	}
 
 	return sb.String()

--- a/internal/seed/matrix.go
+++ b/internal/seed/matrix.go
@@ -104,9 +104,9 @@ func PrintMatrix(matrix EnvMatrix) string {
 	var sb strings.Builder
 	for _, env := range envs {
 		files := matrix[env]
-		sb.WriteString(fmt.Sprintf("[%s] (%d file(s))\n", env, len(files)))
+		fmt.Fprintf(&sb, "[%s] (%d file(s))\n", env, len(files))
 		for _, f := range files {
-			sb.WriteString(fmt.Sprintf("  %s\n", f))
+			fmt.Fprintf(&sb, "  %s\n", f)
 		}
 	}
 

--- a/internal/setup/setup_env_files.go
+++ b/internal/setup/setup_env_files.go
@@ -232,12 +232,12 @@ func writeFullEnvFiles(workDir, projectName, baseDomain string) ([]string, error
 	var created []string
 
 	// .env.dev
-	devContent := fmt.Sprintf(`# Development environment overrides
+	devContent := `# Development environment overrides
 ENV=dev
 BASE_DOMAIN=local.nself.org
 HASURA_GRAPHQL_ENABLE_CONSOLE=true
 HASURA_GRAPHQL_DEV_MODE=true
-`)
+`
 	if err := writeFile(filepath.Join(workDir, ".env.dev"), devContent, 0600); err != nil {
 		return nil, err
 	}

--- a/internal/ssl/generator_trust.go
+++ b/internal/ssl/generator_trust.go
@@ -84,7 +84,7 @@ func hostsManualNote(hostnames []string) string {
 	sb.WriteString("  sudo nself dns-setup\n\n")
 	sb.WriteString("Or add manually to /etc/hosts:\n")
 	for _, h := range hostnames {
-		sb.WriteString(fmt.Sprintf("  127.0.0.1\t%s\n", h))
+		fmt.Fprintf(&sb, "  127.0.0.1\t%s\n", h)
 	}
 	return sb.String()
 }

--- a/internal/tenant/billing.go
+++ b/internal/tenant/billing.go
@@ -99,9 +99,9 @@ func BillingReport(ctx context.Context, cfg *config.Config, opts BillingReportOp
 
 	// Format as table.
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%-20s %-12s %-25s %15s\n", "TENANT", "PLAN", "METRIC", "TOTAL"))
+	fmt.Fprintf(&sb, "%-20s %-12s %-25s %15s\n", "TENANT", "PLAN", "METRIC", "TOTAL")
 	for _, r := range rows {
-		sb.WriteString(fmt.Sprintf("%-20s %-12s %-25s %15.2f\n", r.Slug, r.Plan, r.Metric, r.Total))
+		fmt.Fprintf(&sb, "%-20s %-12s %-25s %15.2f\n", r.Slug, r.Plan, r.Metric, r.Total)
 	}
 	return sb.String(), nil
 }

--- a/internal/tenant/lint_report.go
+++ b/internal/tenant/lint_report.go
@@ -170,8 +170,8 @@ func GenerateRemediationSQL(report *LintRLSReport) string {
 		qTable := quoteIdent(t.Table)
 		sb.WriteString("-- Remediation for " + t.Schema + "." + t.Table + "\n")
 		if !t.HasRLS {
-			sb.WriteString(fmt.Sprintf("ALTER TABLE %s.%s ENABLE ROW LEVEL SECURITY;\n", qSchema, qTable))
-			sb.WriteString(fmt.Sprintf("ALTER TABLE %s.%s FORCE ROW LEVEL SECURITY;\n", qSchema, qTable))
+			fmt.Fprintf(&sb, "ALTER TABLE %s.%s ENABLE ROW LEVEL SECURITY;\n", qSchema, qTable)
+			fmt.Fprintf(&sb, "ALTER TABLE %s.%s FORCE ROW LEVEL SECURITY;\n", qSchema, qTable)
 		}
 		if !t.HasPolicy {
 			idCol := "tenant_id"
@@ -190,20 +190,14 @@ func GenerateRemediationSQL(report *LintRLSReport) string {
 			policyOwner := quoteIdent(safeName + "_owner")
 			policyAdmin := quoteIdent(safeName + "_admin")
 			if idCol == "tenant_id" {
-				sb.WriteString(fmt.Sprintf(
-					"CREATE POLICY %s ON %s.%s USING (%s = (current_setting('%s', true)::jsonb->>'x-hasura-tenant-id')::uuid) WITH CHECK (%s = (current_setting('%s', true)::jsonb->>'x-hasura-tenant-id')::uuid);\n",
-					policyOwner, qSchema, qTable, qIDCol, setting, qIDCol, setting,
-				))
+				fmt.Fprintf(&sb, "CREATE POLICY %s ON %s.%s USING (%s = (current_setting('%s', true)::jsonb->>'x-hasura-tenant-id')::uuid) WITH CHECK (%s = (current_setting('%s', true)::jsonb->>'x-hasura-tenant-id')::uuid);\n",
+					policyOwner, qSchema, qTable, qIDCol, setting, qIDCol, setting)
 			} else {
-				sb.WriteString(fmt.Sprintf(
-					"CREATE POLICY %s ON %s.%s USING (%s = current_setting('hasura.user.id', true)::uuid) WITH CHECK (%s = current_setting('hasura.user.id', true)::uuid);\n",
-					policyOwner, qSchema, qTable, qIDCol, qIDCol,
-				))
+				fmt.Fprintf(&sb, "CREATE POLICY %s ON %s.%s USING (%s = current_setting('hasura.user.id', true)::uuid) WITH CHECK (%s = current_setting('hasura.user.id', true)::uuid);\n",
+					policyOwner, qSchema, qTable, qIDCol, qIDCol)
 			}
-			sb.WriteString(fmt.Sprintf(
-				"CREATE POLICY %s ON %s.%s FOR ALL TO nself_admin USING (true) WITH CHECK (true);\n",
-				policyAdmin, qSchema, qTable,
-			))
+			fmt.Fprintf(&sb, "CREATE POLICY %s ON %s.%s FOR ALL TO nself_admin USING (true) WITH CHECK (true);\n",
+				policyAdmin, qSchema, qTable)
 		}
 		sb.WriteString("\n")
 	}

--- a/internal/tenant/metering_query.go
+++ b/internal/tenant/metering_query.go
@@ -84,7 +84,7 @@ func QueryUsage(ctx context.Context, cfg *config.Config, tenantID, month, format
 	var sb strings.Builder
 	sb.WriteString("tenant_id,day,metric,value\n")
 	for _, r := range results {
-		sb.WriteString(fmt.Sprintf("%s,%s,%s,%d\n", r.TenantID, r.Day, r.Metric, r.Value))
+		fmt.Fprintf(&sb, "%s,%s,%s,%d\n", r.TenantID, r.Day, r.Metric, r.Value)
 	}
 	return strings.TrimSpace(sb.String()), nil
 }

--- a/internal/tenant/sanitize_test.go
+++ b/internal/tenant/sanitize_test.go
@@ -311,7 +311,7 @@ func TestSanitize_UnicodeAndNullBytes(t *testing.T) {
 		{"null_byte", "foo\x00bar"},
 		{"unicode_smp", "𝕳𝖊𝖑𝖑𝖔"}, // supplementary plane chars
 		{"rtl_text", "مرحبا"},
-		{"zero_width", "a​b"},        // zero-width space
+		{"zero_width", "a\u200bb"},   // zero-width space
 		{"bom", "\xef\xbb\xbfhello"}, // byte order mark (UTF-8 BOM)
 		{"sql_metachar_mix", "'; UPDATE tenants SET plan='enterprise' WHERE '1'='1"},
 		{"newline_in_value", "line1\nline2"},

--- a/internal/tenant/tenant_slog_test.go
+++ b/internal/tenant/tenant_slog_test.go
@@ -65,7 +65,7 @@ func TestHashTenantID_IsHex(t *testing.T) {
 	id := "550e8400-e29b-41d4-a716-446655440000"
 	h := hashTenantID(id)
 	for _, c := range h {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("hashTenantID contains non-hex character %q in %q", c, h)
 		}
 	}

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -98,7 +98,7 @@ func (t *Table) printRow(values []string) {
 		}
 		// Left-align with 1 space padding on each side
 		b.WriteString(" ")
-		b.WriteString(fmt.Sprintf("%-*s", w-2, val))
+		fmt.Fprintf(&b, "%-*s", w-2, val)
 		b.WriteString(" │")
 	}
 	fmt.Println(b.String())

--- a/internal/ux/error.go
+++ b/internal/ux/error.go
@@ -32,9 +32,9 @@ type UXError struct {
 // Error implements the error interface.
 func (e *UXError) Error() string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("[%s] %s", e.Code, e.What))
+	fmt.Fprintf(&b, "[%s] %s", e.Code, e.What)
 	if e.Why != "" {
-		b.WriteString(fmt.Sprintf(" (%s)", e.Why))
+		fmt.Fprintf(&b, " (%s)", e.Why)
 	}
 	return b.String()
 }

--- a/tools/wikigen/render.go
+++ b/tools/wikigen/render.go
@@ -211,10 +211,10 @@ func flagTable(c *cobra.Command) string {
 			name = "`--" + f.Name + "`, `-" + f.Shorthand + "`"
 		}
 		def := f.DefValue
-		switch {
-		case def == "":
+		switch def {
+		case "":
 			def = `""`
-		case def == "[]":
+		case "[]":
 			def = "—"
 		}
 		rows = append(rows, row{name, "`" + def + "`", escapeCell(f.Usage)})


### PR DESCRIPTION
## Summary
- Resolves all staticcheck findings except SA1000 (invalid Perl-syntax regexes in `internal/database/migration_audit.go`), which is already being fixed on `fix/db-audit-regex-panic`.
- Fixes 4 SA4023 false-positive sites with targeted `//nolint:staticcheck` (not `//lint:ignore` — golangci-lint 2.13.2 does not honor raw staticcheck ignore comments; verified empirically) in `internal/backup/restore.go`, `internal/controlplane/pipeline.go`, `internal/embedded/pg_socket_bridge.go`. The underlying "always errors by design" functions are untouched.
- Fixes 2 real SA4010 dead-code bugs: `internal/backup/pitr/retention.go` collected local base-backup paths to delete and never deleted them (now wired up); a test helper in `cmd/commands/functions_test.go` built an unused slice.
- Fixes 1 real bug found via the ineffassign side-effect of an ST1005 pass: `internal/cost/alerter.go` read `SLACK_ALERT_CHANNEL`, defaulted it, and never included it in the Slack message despite the doc comment saying "embedded in message" — now wired in, with a regression test for both the default and a custom channel.
- Remaining ~30 mechanical fixes (QF1001/QF1002/QF1003/QF1011/QF1012, S1003/S1011/S1019/S1024/S1038/S1039, ST1005, ST1018, SA1012) via `golangci-lint run --fix` plus hand-fixes where `--fix` skipped files or only half-applied a rewrite (firebase migration helpers, two De Morgan test files).

## Scope notes
- Did not touch `cmd/commands/start.go`, `internal/build/orchestrator.go`, `internal/config/loader_known_vars.go`, `internal/config/loader_parse_env.go`, `internal/embedded/emscripten_abi.go` (reserved for the file-splitting pass) or `internal/database/migration_audit.go` (reserved for the regex-panic fix).
- `unused` (20) and `ineffassign` (remaining 4, unrelated to the alerter.go fix) are out of scope — being handled on `fix/lint-unused-ineffassign`.

## Verification
- `gofmt -l cmd internal` — clean
- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test ./... -count=1` — 4642 passed, 94 packages, exit 0
- `internal/repoqa` file-size gate — 14/14 passed
- `golangci-lint run ./... --max-issues-per-linter=0 --max-same-issues=0` — staticcheck 157 -> 10 (all SA1000, out of scope)