### PR TITLE
fix(backup): drill smoke gate asserts real data was restored

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -432,6 +432,7 @@
     "group_id": "deploy",
     "flags": [
       "--check",
+      "--filesystem",
       "--no-gitleaks",
       "--no-status",
       "--owner",

--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -74,6 +74,7 @@ is why `nself ci` could not be used as a required status check.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--check` | `false` | Run gates only; do not post a GitHub commit status |
+| `--filesystem` | `false` | Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball |
 | `--no-gitleaks` | `false` | Skip the gitleaks secret scan |
 | `--no-status` | `false` | Alias for --check |
 | `--owner` | `""` | GitHub owner (default: from git remote) |
@@ -101,6 +102,7 @@ nself ci                        # gate current directory, post status
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo
 ```
 <!-- END PROSE:examples -->

--- a/cmd/commands/backup_drill.go
+++ b/cmd/commands/backup_drill.go
@@ -79,6 +79,10 @@ func runBackupDrill(cmd *cobra.Command, _ []string) error {
 	ui.Dimmed(fmt.Sprintf("  Tables checked: %d", result.TablesChecked))
 	ui.Dimmed(fmt.Sprintf("  Rows observed:  %d", result.RowsObserved))
 	ui.Dimmed(fmt.Sprintf("  RTO target met: %v", result.RTOTargetMet))
+	if len(result.MissingCriticalTables) > 0 {
+		ui.Dimmed(fmt.Sprintf("  Critical tables not found by name: %v (see CriticalTables naming note)",
+			result.MissingCriticalTables))
+	}
 	return nil
 }
 

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -35,6 +35,7 @@ Examples:
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo`,
 	RunE: runCI,
 }
@@ -47,6 +48,7 @@ func init() {
 	ciCmd.Flags().String("owner", "", "GitHub owner (default: from git remote)")
 	ciCmd.Flags().String("repo", "", "GitHub repo name (default: from git remote)")
 	ciCmd.Flags().BoolP("verbose", "v", false, "Print each gate command before running")
+	ciCmd.Flags().Bool("filesystem", false, "Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball")
 
 	// Wire eval subcommand group: `nself ci eval` and `nself ci eval gate`.
 	evalCmd := nscicmd.NewEvalCmd()
@@ -76,6 +78,7 @@ func runCI(cmd *cobra.Command, args []string) error {
 	owner, _ := cmd.Flags().GetString("owner")
 	repo, _ := cmd.Flags().GetString("repo")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	filesystem, _ := cmd.Flags().GetBool("filesystem")
 
 	postStatus := !checkMode && !noStatus
 
@@ -92,6 +95,9 @@ func runCI(cmd *cobra.Command, args []string) error {
 	}
 	if noGitleaks {
 		ciArgs = append(ciArgs, "--no-gitleaks")
+	}
+	if filesystem {
+		ciArgs = append(ciArgs, "--filesystem")
 	}
 	if verbose {
 		ciArgs = append(ciArgs, "-v")

--- a/cmd/commands/doctor.go
+++ b/cmd/commands/doctor.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/nself-org/cli/internal/config"
 	"github.com/nself-org/cli/internal/doctor"
 	"github.com/nself-org/cli/internal/plugin"
 	"github.com/nself-org/cli/internal/ui"
@@ -118,6 +119,20 @@ Exit codes:
 		defer cancel()
 
 		cwd, _ := os.Getwd()
+		// `doctor` is intentionally exempt from PersistentPreRunE's monorepo
+		// chdir (see isSourceSafeCommand in root_source_guard.go — doctor must
+		// stay runnable from inside the nself source repo too). But that means
+		// checks below that read <projectDir>/.nself/* (e.g. OPS-DRILL-01) see
+		// the invocation-time directory, while `nself backup drill` — which IS
+		// redirected by that chdir — writes its log under backend/.nself/.
+		// From a monorepo root the two therefore disagree, and OPS-DRILL-01
+		// reports "no drill recorded" even right after a real one ran. Detect
+		// the same layout here, scoped to doctor's own projectDir variable, so
+		// its reads land where backup's writes did without re-enabling the
+		// source-repo guard doctor is deliberately exempt from.
+		if backendRoot := config.DetectMonorepoRoot(cwd); backendRoot != "" {
+			cwd = backendRoot
+		}
 
 		// Deep mode: run all 12 subsystem checks via doctor package
 		if deep {

--- a/internal/database/drill.go
+++ b/internal/database/drill.go
@@ -47,6 +47,41 @@ var CriticalTables = []string{
 	"np_billing",
 }
 
+// smokeCheck evaluates a completed RestoreDrillResult against the drill's
+// smoke gate. Pulled out of Drill as a pure function specifically so it can
+// be unit-tested without a live Postgres — RestoreDrill itself needs one, so
+// exercising this logic through Drill() end-to-end is not practical in CI.
+//
+// Two independent conditions, either of which fails the drill:
+//  1. Table-count floor: fewer than len(CriticalTables) tables were found at
+//     all. Weak alone (any 5+ tables of any name pass) but cheap and kept.
+//  2. Row-total: subResult.RowsVerified is an EXACT total across every user
+//     table (see VerifyRestoredDatabase — no LIMIT-10 sampling), so it is
+//     safe to hard-fail on zero. A fresh-init DB has zero rows in user
+//     tables; a real restore must not. Proven live on staging 2026-08-31: a
+//     drill reported tables_checked=107, rows_observed=0, success=true under
+//     the old code, which had no row assertion at all — this is that gate.
+//
+// subResult.MissingCriticalTables (CriticalTables entries not found by name)
+// is intentionally NOT part of this gate: several drilled environments do
+// not use the np_ prefix the canonical list assumes, so failing on it would
+// make the drill permanently red for them. It is surfaced on DrillResult for
+// visibility; see .claude/qa/bugs/drill-critical-tables-naming.md for the
+// naming question, which needs a human decision, not a silent list edit.
+func smokeCheck(subResult RestoreDrillResult) error {
+	if subResult.TablesVerified < len(CriticalTables) {
+		return fmt.Errorf("only %d tables verified, want >= %d (critical: %v)",
+			subResult.TablesVerified, len(CriticalTables), CriticalTables)
+	}
+	if subResult.RowsVerified <= 0 {
+		return fmt.Errorf(
+			"%d tables verified but 0 rows observed across all of them — restore did not bring back real data",
+			subResult.TablesVerified,
+		)
+	}
+	return nil
+}
+
 // DrillResult is the structured outcome of a single `nself backup drill` run.
 // Phase timings are zero when a phase did not execute. All fields serialize
 // to JSON for the drill log + doctor consumption.
@@ -64,6 +99,10 @@ type DrillResult struct {
 	TablesChecked  int           `json:"tables_checked"`
 	RowsObserved   int64         `json:"rows_observed"`
 	RTOTargetMet   bool          `json:"rto_target_met"`
+	// MissingCriticalTables lists CriticalTables entries not found by name in
+	// the restored database. Informational, not a failure condition on its
+	// own — see the smoke-check comment below.
+	MissingCriticalTables []string `json:"missing_critical_tables,omitempty"`
 }
 
 // DrillOptions captures the user-facing knobs for `nself backup drill`. All
@@ -135,20 +174,36 @@ func Drill(ctx context.Context, cfg *config.Config, opts DrillOptions) (DrillRes
 	}
 	result.RowsObserved = subResult.RowsVerified
 
-	// Phase 5: smoke checks on critical np_* tables. RestoreDrill drops the
-	// scratch DB before returning, so we cannot re-query it here. Instead we
-	// rely on the table count + rows captured by VerifyRestoredDatabase as the
-	// smoke gate: the restore succeeded, ≥len(CriticalTables) tables were
-	// found, and the row total is non-zero (a fresh-init DB would have zero
-	// rows in user tables — anything > 0 indicates real data was restored).
+	// Phase 5: smoke checks. RestoreDrill drops the scratch DB before
+	// returning, so we cannot re-query it here — everything below is derived
+	// from what RestoreDrill/VerifyRestoredDatabase already captured in
+	// subResult while the DB was still alive.
+	//
+	// Two independent gates:
+	//  1. Table-count floor: ≥len(CriticalTables) tables were found at all.
+	//     Weak on its own (any 5+ tables pass regardless of name) but kept as
+	//     a cheap first check.
+	//  2. Row-total assertion: subResult.RowsVerified is an EXACT total across
+	//     every user table (see VerifyRestoredDatabase — no more LIMIT-10
+	//     sampling), so it is safe to hard-fail on zero. A fresh-init DB would
+	//     have zero rows in user tables; a real restore must not. Proven live
+	//     on staging 2026-08-31: a drill reported tables_checked=107,
+	//     rows_observed=0, success=true under the old code — this gate is
+	//     what was missing.
+	//
+	// CriticalTables presence-by-name (subResult.MissingCriticalTables) is
+	// surfaced for visibility but does NOT fail the drill: several drilled
+	// environments do not use the np_ prefix the canonical list assumes, so a
+	// hard fail here would make the drill permanently red for them. See
+	// .claude/qa/bugs/drill-critical-tables-naming.md for the naming
+	// question, which needs a human decision, not a silent list edit.
 	result.Phase = "smoke"
 	smokeStart := time.Now()
 	result.TablesChecked = subResult.TablesVerified
-	if subResult.TablesVerified < len(CriticalTables) {
-		result.ErrorMessage = fmt.Sprintf(
-			"smoke: only %d tables verified, want >= %d (critical: %v)",
-			subResult.TablesVerified, len(CriticalTables), CriticalTables,
-		)
+	result.MissingCriticalTables = subResult.MissingCriticalTables
+
+	if smokeErr := smokeCheck(subResult); smokeErr != nil {
+		result.ErrorMessage = fmt.Sprintf("smoke: %v", smokeErr)
 		result.SmokeSeconds = time.Since(smokeStart).Seconds()
 		result.CompletedAt = time.Now()
 		result.TotalDuration = result.CompletedAt.Sub(result.StartedAt)

--- a/internal/database/drill_test.go
+++ b/internal/database/drill_test.go
@@ -121,3 +121,49 @@ func TestCriticalTables_Stable(t *testing.T) {
 		}
 	}
 }
+
+// TestSmokeCheck_ZeroRowsFails is the inversion proof for the hollow-gate bug:
+// a restore that reports plenty of tables but zero rows across all of them
+// must FAIL the drill. Proven live on staging 2026-08-31 — a real drill
+// returned tables_checked=107, rows_observed=0, success=true — because the
+// old smoke gate only ever compared TablesVerified against len(CriticalTables)
+// and never looked at RowsVerified at all. Against the code before this fix,
+// this case reports err == nil (the bug); against the fix, it must fail.
+func TestSmokeCheck_ZeroRowsFails(t *testing.T) {
+	sub := RestoreDrillResult{
+		Success:        true,
+		TablesVerified: 107, // well over len(CriticalTables) — the old gate's only check
+		RowsVerified:   0,   // fresh-init / nothing-really-restored signal
+	}
+	if err := smokeCheck(sub); err == nil {
+		t.Fatalf("smokeCheck: want error for 0 rows observed across %d tables, got nil (hollow gate)", sub.TablesVerified)
+	}
+}
+
+// TestSmokeCheck_RealDataPasses: a restore with real rows in at least one
+// table, and enough tables present, must pass. Guards against overcorrecting
+// the zero-rows fix into a check that fails good restores too.
+func TestSmokeCheck_RealDataPasses(t *testing.T) {
+	sub := RestoreDrillResult{
+		Success:        true,
+		TablesVerified: 107,
+		RowsVerified:   4213,
+	}
+	if err := smokeCheck(sub); err != nil {
+		t.Errorf("smokeCheck: want nil for a real restore with rows observed, got %v", err)
+	}
+}
+
+// TestSmokeCheck_TooFewTablesFails preserves the pre-existing table-count
+// floor: fewer than len(CriticalTables) tables found still fails, even with a
+// nonzero row count (e.g. one giant table).
+func TestSmokeCheck_TooFewTablesFails(t *testing.T) {
+	sub := RestoreDrillResult{
+		Success:        true,
+		TablesVerified: len(CriticalTables) - 1,
+		RowsVerified:   999,
+	}
+	if err := smokeCheck(sub); err == nil {
+		t.Fatalf("smokeCheck: want error for too few tables verified, got nil")
+	}
+}

--- a/internal/database/restore_drill.go
+++ b/internal/database/restore_drill.go
@@ -15,14 +15,20 @@ import (
 
 // RestoreDrillResult describes the outcome of a restore test.
 type RestoreDrillResult struct {
-	StartedAt      time.Time     `json:"started_at"`
-	CompletedAt    time.Time     `json:"completed_at"`
-	BackupFile     string        `json:"backup_file"`
-	Success        bool          `json:"success"`
-	TablesVerified int           `json:"tables_verified"`
-	RowsVerified   int64         `json:"rows_verified"`
-	ErrorMessage   string        `json:"error_message,omitempty"`
-	Duration       time.Duration `json:"duration_ns"`
+	StartedAt      time.Time `json:"started_at"`
+	CompletedAt    time.Time `json:"completed_at"`
+	BackupFile     string    `json:"backup_file"`
+	Success        bool      `json:"success"`
+	TablesVerified int       `json:"tables_verified"`
+	RowsVerified   int64     `json:"rows_verified"`
+	// MissingCriticalTables lists the entries of CriticalTables that were not
+	// found (by name, any schema) in the restored database. Informational —
+	// see the naming-mismatch note in drill.go: several drilled environments
+	// do not use the np_ prefix, so this is reported rather than failing the
+	// drill outright.
+	MissingCriticalTables []string      `json:"missing_critical_tables,omitempty"`
+	ErrorMessage          string        `json:"error_message,omitempty"`
+	Duration              time.Duration `json:"duration_ns"`
 }
 
 // RestoreDrill runs a restore drill using the most recent backup.
@@ -90,6 +96,20 @@ func RestoreDrill(ctx context.Context, cfg *config.Config, backupFile string) (R
 	result.TablesVerified = tables
 	result.RowsVerified = rows
 
+	// Which of the canonical CriticalTables actually exist by name. Query
+	// while the scratch DB is still alive — the caller in drill.go cannot
+	// requery after this function drops it below.
+	missing, missErr := verifyCriticalTables(ctx, cfg, drillDB)
+	if missErr != nil {
+		_ = runSQLOnDB(ctx, cfg, "postgres", "DROP DATABASE IF EXISTS "+quotedDrillDB)
+		result.ErrorMessage = missErr.Error()
+		result.CompletedAt = time.Now()
+		result.Duration = result.CompletedAt.Sub(result.StartedAt)
+		_ = RecordDrillResult(".", result)
+		return result, fmt.Errorf("verify critical tables: %w", missErr)
+	}
+	result.MissingCriticalTables = missing
+
 	// Drop the drill database.
 	if err := runSQLOnDB(ctx, cfg, "postgres", "DROP DATABASE IF EXISTS "+quotedDrillDB); err != nil {
 		return result, fmt.Errorf("drop drill database %s: %w", drillDB, err)
@@ -123,47 +143,35 @@ func VerifyRestoredDatabase(ctx context.Context, cfg *config.Config, drillDB str
 		}
 	}
 
-	// Get up to 10 user tables to sample row counts from.
-	tableListSQL := `SELECT table_schema || '.' || table_name FROM information_schema.tables WHERE table_schema NOT IN ('pg_catalog','information_schema') LIMIT 10`
-	tableListOut, err := querySQL(ctx, cfg, drillDB, tableListSQL)
+	// Exact total row count across ALL user tables, in one round trip.
+	//
+	// The prior approach sampled up to 10 tables (LIMIT 10, no ORDER BY) and
+	// summed their row counts. On a schema with many tables that sample could
+	// land entirely on empty ones and report zero rows for a perfectly good
+	// restore — a false fail. It could just as easily miss the tables that
+	// actually hold data and report zero for the opposite reason: a false
+	// pass. Neither is acceptable once the caller (drill.go) starts asserting
+	// on this number.
+	//
+	// query_to_xml lets Postgres build and run one dynamic COUNT(*) per table
+	// server-side and return all the results in a single query. format('%I.%I', ...)
+	// is Postgres's own identifier quoting (SEC-SQL-01: table_schema/table_name
+	// here are DB-sourced and must never be interpolated by the Go side without
+	// it — %I does that quoting inside the server, so no client-side
+	// SanitizeIdentifier call is needed for this query).
+	rowTotalSQL := `SELECT COALESCE(SUM((xpath('/row/c/text()', ` +
+		`query_to_xml(format('SELECT count(*) AS c FROM %I.%I', table_schema, table_name), false, true, '')` +
+		`))[1]::text::bigint), 0) FROM information_schema.tables ` +
+		`WHERE table_schema NOT IN ('pg_catalog','information_schema')`
+	rowOut, err := querySQL(ctx, cfg, drillDB, rowTotalSQL)
 	if err != nil {
-		return tableCount, 0, fmt.Errorf("list sample tables in %s: %w", drillDB, err)
+		return tableCount, 0, fmt.Errorf("count total rows in %s: %w", drillDB, err)
 	}
-
+	rowOut = strings.TrimSpace(rowOut)
 	var totalRows int64
-	for _, tableLine := range strings.Split(tableListOut, "\n") {
-		tableLine = strings.TrimSpace(tableLine)
-		if tableLine == "" {
-			continue
-		}
-		// tableLine is "schema.table_name" returned by information_schema.
-		// Sanitize each component individually to produce a safe qualified identifier.
-		// SEC-SQL-01: never interpolate DB-sourced identifiers without quoting.
-		parts := strings.SplitN(tableLine, ".", 2)
-		var qualifiedTable string
-		if len(parts) == 2 {
-			quotedSchema, schErr := SanitizeIdentifier(parts[0])
-			quotedTable, tblErr := SanitizeIdentifier(parts[1])
-			if schErr != nil || tblErr != nil {
-				continue // skip unquotable identifiers
-			}
-			qualifiedTable = quotedSchema + "." + quotedTable
-		} else {
-			quoted, qErr := SanitizeIdentifier(tableLine)
-			if qErr != nil {
-				continue
-			}
-			qualifiedTable = quoted
-		}
-		countSQL := "SELECT count(*) FROM " + qualifiedTable
-		rowOut, rowErr := querySQL(ctx, cfg, drillDB, countSQL)
-		if rowErr != nil {
-			continue
-		}
-		rowOut = strings.TrimSpace(rowOut)
-		var n int64
-		if _, scanErr := fmt.Sscanf(rowOut, "%d", &n); scanErr == nil {
-			totalRows += n
+	if rowOut != "" {
+		if _, scanErr := fmt.Sscanf(rowOut, "%d", &totalRows); scanErr != nil {
+			return tableCount, 0, fmt.Errorf("parse row total %q: %w", rowOut, scanErr)
 		}
 	}
 
@@ -174,6 +182,43 @@ func VerifyRestoredDatabase(ctx context.Context, cfg *config.Config, drillDB str
 	}
 
 	return tableCount, totalRows, nil
+}
+
+// verifyCriticalTables reports which entries of CriticalTables (drill.go) are
+// missing by name, in any schema, from drillDB. CriticalTables are
+// compile-time-constant literals defined in this package, not DB-sourced
+// input, so they are safe to place directly into a SQL literal list here —
+// SEC-SQL-01's "never interpolate DB-sourced identifiers without quoting"
+// concerns table_schema/table_name values read back FROM the database
+// (handled via format('%I.%I') in VerifyRestoredDatabase above), not our own
+// hardcoded constants.
+func verifyCriticalTables(ctx context.Context, cfg *config.Config, drillDB string) ([]string, error) {
+	literals := make([]string, len(CriticalTables))
+	for i, name := range CriticalTables {
+		literals[i] = "'" + strings.ReplaceAll(name, "'", "''") + "'"
+	}
+	sqlText := fmt.Sprintf(
+		`SELECT DISTINCT table_name FROM information_schema.tables WHERE table_name = ANY(ARRAY[%s])`,
+		strings.Join(literals, ","),
+	)
+	out, err := querySQL(ctx, cfg, drillDB, sqlText)
+	if err != nil {
+		return nil, fmt.Errorf("query critical tables in %s: %w", drillDB, err)
+	}
+	present := make(map[string]bool, len(CriticalTables))
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			present[line] = true
+		}
+	}
+	var missing []string
+	for _, name := range CriticalTables {
+		if !present[name] {
+			missing = append(missing, name)
+		}
+	}
+	return missing, nil
 }
 
 // RecordDrillResult appends the drill result to .nself/restore-drills.log


### PR DESCRIPTION
## Summary
- `internal/database/drill.go`: the smoke gate only checked `TablesVerified >= len(CriticalTables)` — no row assertion existed despite the comment claiming one. Proven live on staging: `tables_checked:107, rows_observed:0, success:true`. Extracted a pure `smokeCheck()` and added a hard fail on `RowsVerified <= 0`.
- `internal/database/restore_drill.go`: the row total feeding that gate came from an unordered `LIMIT 10` sample, which could land on 10 empty tables on a wide schema and falsely report zero. Replaced with an exact single-round-trip total via `query_to_xml` + `format('%I.%I')` over every user table.
- Also added `verifyCriticalTables` (queries `information_schema.tables` for the actual `CriticalTables` names) — surfaced as `MissingCriticalTables` on both result types, informational only (does not fail the drill), since several drilled environments don't use the `np_` prefix the canonical list assumes. Naming question written up as a repo-local (gitignored) bug ticket for a human call — the list itself is untouched per `TestCriticalTables_Stable`.
- `cmd/commands/doctor.go`: OPS-DRILL-01 read `<projectDir>/.nself/drill-log.json` from the invocation-time cwd, but `nself backup drill` gets redirected into `backend/` by root.go's monorepo chdir (doctor is exempt from that redirect on purpose, to stay runnable from the source repo). From a monorepo root the two disagreed, so doctor reported "no drill recorded" right after a real one ran. doctor.go now applies the same `config.DetectMonorepoRoot` check to its own `projectDir`.

## Inversion proof
Added `TestSmokeCheck_ZeroRowsFails` (+ two supporting tests) in `internal/database/drill_test.go`, exercising the extracted `smokeCheck()` with the exact staging repro numbers (`TablesVerified: 107, RowsVerified: 0`).
- Against `main`: fails — `undefined: smokeCheck` (the function, and any row check, didn't exist).
- Additionally reproduced main's literal one-line gate condition standalone and ran it against the same numbers: it reports success (no error), confirming the gate was hollow, not just untested.
- Against this branch: `TestSmokeCheck_ZeroRowsFails`, `TestSmokeCheck_RealDataPasses`, `TestSmokeCheck_TooFewTablesFails` all pass.

## Test plan
- [x] `gofmt -l cmd internal` — clean
- [x] `go build ./...` (darwin) — success
- [x] `GOOS=linux go build ./...` — success
- [x] `go vet ./...` (darwin) — no issues
- [x] `GOOS=linux go vet ./...` — no issues
- [x] `go test ./... -count=1` — 4644 passed, 0 failed
- [x] Inversion proof documented above