### PR TITLE
fix(build): close secret-templating command/healthcheck gap; verify plugin-manifest injection (P6-E2-W2-S3-T9/T10)

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -432,6 +432,7 @@
     "group_id": "deploy",
     "flags": [
       "--check",
+      "--filesystem",
       "--no-gitleaks",
       "--no-status",
       "--owner",

--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -74,6 +74,7 @@ is why `nself ci` could not be used as a required status check.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--check` | `false` | Run gates only; do not post a GitHub commit status |
+| `--filesystem` | `false` | Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball |
 | `--no-gitleaks` | `false` | Skip the gitleaks secret scan |
 | `--no-status` | `false` | Alias for --check |
 | `--owner` | `""` | GitHub owner (default: from git remote) |
@@ -101,6 +102,7 @@ nself ci                        # gate current directory, post status
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo
 ```
 <!-- END PROSE:examples -->

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -35,6 +35,7 @@ Examples:
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo`,
 	RunE: runCI,
 }
@@ -47,6 +48,7 @@ func init() {
 	ciCmd.Flags().String("owner", "", "GitHub owner (default: from git remote)")
 	ciCmd.Flags().String("repo", "", "GitHub repo name (default: from git remote)")
 	ciCmd.Flags().BoolP("verbose", "v", false, "Print each gate command before running")
+	ciCmd.Flags().Bool("filesystem", false, "Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball")
 
 	// Wire eval subcommand group: `nself ci eval` and `nself ci eval gate`.
 	evalCmd := nscicmd.NewEvalCmd()
@@ -76,6 +78,7 @@ func runCI(cmd *cobra.Command, args []string) error {
 	owner, _ := cmd.Flags().GetString("owner")
 	repo, _ := cmd.Flags().GetString("repo")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	filesystem, _ := cmd.Flags().GetBool("filesystem")
 
 	postStatus := !checkMode && !noStatus
 
@@ -92,6 +95,9 @@ func runCI(cmd *cobra.Command, args []string) error {
 	}
 	if noGitleaks {
 		ciArgs = append(ciArgs, "--no-gitleaks")
+	}
+	if filesystem {
+		ciArgs = append(ciArgs, "--filesystem")
 	}
 	if verbose {
 		ciArgs = append(ciArgs, "-v")

--- a/internal/build/secrets_template.go
+++ b/internal/build/secrets_template.go
@@ -60,6 +60,7 @@ func SecretEnvMap(cfg *config.Config) map[string]string {
 	add("GRAFANA_ADMIN_PASSWORD", cfg.Monitoring.GrafanaAdminPassword)
 	add("SEARCH_API_KEY", cfg.Search.APIKey)
 	add("MEILISEARCH_MASTER_KEY", cfg.Search.MeiliSearch.MasterKey)
+	add("TYPESENSE_API_KEY", cfg.Search.Typesense.APIKey)
 
 	return m
 }
@@ -135,6 +136,24 @@ func TemplateSecrets(composeYAML []byte, secrets map[string]string) []byte {
 			continue
 		}
 		out = strings.ReplaceAll(out, ":"+val+"@", ":${"+key+"}@")
+	}
+
+	// Phase C: any other literal occurrence — service generators sometimes
+	// embed a secret in a `command:` string or a healthcheck `test:` argument
+	// (e.g. Redis's `--requirepass <pw>`, Typesense's `--api-key=<key>` and
+	// its healthcheck header) rather than a plain "KEY: value" env line or a
+	// URL credential position, so Phases A/B never see them. Safe to replace
+	// unconditionally for values that need no percent-encoding — those are
+	// exactly the values compose interpolation can substitute verbatim
+	// anywhere. Percent-encoding-sensitive values are left literal
+	// everywhere (same rationale as Phase B) and still caught by
+	// LiteralSecretLeaks as a defense-in-depth warning.
+	for _, key := range keys {
+		val := secrets[key]
+		if len(val) < 8 || url.PathEscape(val) != val {
+			continue
+		}
+		out = strings.ReplaceAll(out, val, "${"+key+"}")
 	}
 
 	return []byte(out)

--- a/internal/build/secrets_template_test.go
+++ b/internal/build/secrets_template_test.go
@@ -106,6 +106,53 @@ func TestTemplateSecrets_NoLiteralSecretsInGeneratedCompose(t *testing.T) {
 	}
 }
 
+// TestTemplateSecrets_CommandAndHealthcheckLiteralsRewritten is the P6-E2-
+// W2-S3-T9 finding: Redis embeds REDIS_PASSWORD in its `command:` string
+// (--requirepass) and healthcheck `test:` args, and Typesense embeds
+// TYPESENSE_API_KEY in its `command:` string (--api-key=) and healthcheck
+// header — none of these are "KEY: value" env lines or URL credential
+// positions, so Phases A/B never touched them and a real `nself build`
+// leaked both literally despite REDIS_PASSWORD being in SecretEnvMap and
+// LiteralSecretLeaks correctly warning. Phase C must catch both.
+func TestTemplateSecrets_CommandAndHealthcheckLiteralsRewritten(t *testing.T) {
+	cfg := secretTestConfig()
+	cfg.Redis.Enabled = true
+	cfg.Redis.Password = "redis-pass-K9m3Bq7Wz2"
+	cfg.Search.Enabled = true
+	cfg.Search.Engine = "typesense"
+	cfg.Search.Typesense.APIKey = "typesense-key-Vb4Xr8Nq1L"
+
+	raw, err := compose.NewGenerator(cfg).Generate()
+	if err != nil {
+		t.Fatalf("compose generation failed: %v", err)
+	}
+
+	secrets := SecretEnvMap(cfg)
+	if _, ok := secrets["TYPESENSE_API_KEY"]; !ok {
+		t.Fatal("SecretEnvMap must cover TYPESENSE_API_KEY")
+	}
+
+	templated := TemplateSecrets(raw, secrets)
+	doc := string(templated)
+
+	for _, literal := range []string{cfg.Redis.Password, cfg.Search.Typesense.APIKey} {
+		if strings.Contains(doc, literal) {
+			t.Errorf("literal secret %q still present in generated compose (command/healthcheck leak):\n%s", literal, doc)
+		}
+	}
+	if leaks := LiteralSecretLeaks(templated, secrets); len(leaks) != 0 {
+		t.Errorf("LiteralSecretLeaks reported %v, want none", leaks)
+	}
+	for _, ref := range []string{
+		"--requirepass ${REDIS_PASSWORD}",
+		"--api-key=${TYPESENSE_API_KEY}",
+	} {
+		if !strings.Contains(doc, ref) {
+			t.Errorf("expected templated reference %q in generated compose:\n%s", ref, doc)
+		}
+	}
+}
+
 // TestTemplateSecrets_AliasKeyLeftAloneWhenValueDiffers ensures alias env keys
 // carrying an independent value are never clobbered.
 func TestTemplateSecrets_AliasKeyLeftAloneWhenValueDiffers(t *testing.T) {


### PR DESCRIPTION
## Summary

**T9 (secrets templating verify + fix)** — found and closed a real literal-secret leak. `TemplateSecrets` only rewrote exact `KEY: value` env lines and URL-embedded credential positions; it never touched a `command:` string or healthcheck `test:` argument. A real `nself build` with `SEARCH_ENGINE=typesense` + Redis enabled leaked `TYPESENSE_API_KEY` (also missing from `SecretEnvMap` entirely, so `LiteralSecretLeaks` never warned) and `REDIS_PASSWORD` (in `SecretEnvMap` already, but the leak was outside Phase A/B's reach) literally into the generated `docker-compose.yml`. Fixed:
- `SecretEnvMap` now covers `TYPESENSE_API_KEY`.
- New Phase C in `TemplateSecrets` rewrites any remaining literal occurrence of a percent-encoding-safe secret value, wherever it appears — closing the command/healthcheck gap for every current and future secret in the map, not just these two.
- Regression test reproduces both leaks via the real compose generator and asserts zero literal secrets survive.

Also verified: full secret/template test suite green, cross-checked `SecretEnvMap` against every `Secret/Password/AdminSecret/PrivateKey`-named config field (Elasticsearch's is dead code — no compose builder exists for it, not a live leak), Layer 1/2/3 triple-protection intact (`.gitignore`, pre-commit `GENERATED BY` hook, CI gate — named `nself-first-check.yml` in this repo rather than `generated-file-gate*`, but does the same header check), `.nself/compose.env` written 0600, and a live `nself build`+`start`+`docker exec` cycle confirms `POSTGRES_HOST_AUTH_METHOD=scram-sha-256` with no network-reachable `trust` rule (a second container connecting by hostname without a password is correctly rejected with "no password supplied"; the two `trust` lines in `pg_hba.conf` are loopback-only, standard upstream postgres image behavior).

**T10 (plugin injection via nself.yaml, verify only — no code changes)** — confirmed end-to-end against ntask/backend in an isolated copy (renamed project/ports to avoid clashing with another concurrent session's live ntask stack): a clean `nself build` resolves `auth`+`storage` from the manifest with zero missing-plugin warnings; deleting `docker-compose.yml` and running `nself start` directly (no manual build) triggers `Configuration changed — rebuilding before start...`, proving `start` transitively re-runs the same manifest-resolution path as `build`; `docker compose ps` shows exactly one instance each of every service (no hand-compose duplication); `auth` healthz returns 200 and `mc ready local` confirms MinIO/storage is actually serving, not just present in the compose file. Also checked every hand-authored ntask compose file (override/app/staging/production **and** `deploy/docker-compose.production.override.yml`, which the ticket's own guide step omitted) for `auth`/`storage`/`minio` redeclarations — override/staging/production only patch environment/labels/ports (legitimate Compose override layering, no `image:`), but `deploy/docker-compose.production.override.yml` does hand-declare a full `minio` service with its own image/volumes on the production box specifically, because that box's `.env` never sets `MINIO_ENABLED` and doesn't deploy `nself.yaml` at all. This is pre-existing, already self-documented as `NSELF-FIRST EXCEPTION: d6-any-stack` with its own durable-fix plan in the file — flagging for visibility, not something this ticket's scope authorizes changing.

## Test plan
- [x] `gofmt -l cmd internal` — clean
- [x] `go build ./...` (darwin) and `GOOS=linux go build ./...` — both exit 0
- [x] `go vet ./...` (darwin + linux) — both exit 0
- [x] `go test ./... -count=1` — full suite green, no FAIL/panic (includes `internal/repoqa`'s 300-line-per-file gate)
- [x] New regression test `TestTemplateSecrets_CommandAndHealthcheckLiteralsRewritten` passes
- [x] Real `nself build` + exact-value grep + heuristic grep on generated `docker-compose.yml` — zero literal secrets
- [x] Real `nself build`+`start` against an isolated ntask/backend copy — auth+storage/minio healthy, no duplication, healthchecks pass