### PR TITLE
fix(plugin): nself plugin install addressed a container that does not exist

### DIFF
--- a/internal/plugin/schema.go
+++ b/internal/plugin/schema.go
@@ -39,9 +39,29 @@ func quoteIdent(s string) string {
 	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 }
 
+// postgresContainer returns the Postgres container name for the project.
+//
+// Purpose: address the container that `nself build` actually generates.
+// Inputs:  the loaded project config.
+// Outputs: "<project>_postgres".
+// Constraints: this MUST match the `container_name:` that nself build writes.
+//
+//	nself build emits `container_name: ${PROJECT_NAME}_postgres`, which
+//	overrides Docker Compose's default `<project>-postgres-1` naming. These
+//	two call sites used the Compose default, so every `docker exec` here hit
+//	"No such container" and `nself plugin install` failed for EVERY
+//	schema-bearing plugin on EVERY project. The rest of the CLI already spells
+//	it correctly in eight places (internal/database/helpers.go,
+//	internal/tenant/*.go, internal/database/backup.go) — this file was the
+//	odd one out.
+
+func postgresContainer(cfg *config.Config) string {
+	return cfg.ProjectName + "_postgres"
+}
+
 // execPSQL runs a SQL statement inside the Postgres container via docker exec.
 func execPSQL(ctx context.Context, cfg *config.Config, sql string) error {
-	containerName := cfg.ProjectName + "-postgres-1"
+	containerName := postgresContainer(cfg)
 	cmd := exec.CommandContext(ctx, "docker", "exec", containerName,
 		"psql", "-U", cfg.Postgres.User, "-d", cfg.Postgres.DB,
 		"-c", sql,
@@ -56,7 +76,7 @@ func execPSQL(ctx context.Context, cfg *config.Config, sql string) error {
 // queryPSQL runs a SQL query and returns the trimmed stdout. It uses -tA
 // (tuples-only, unaligned) so the result contains only raw values.
 func queryPSQL(ctx context.Context, cfg *config.Config, sql string) (string, error) {
-	containerName := cfg.ProjectName + "-postgres-1"
+	containerName := postgresContainer(cfg)
 	cmd := exec.CommandContext(ctx, "docker", "exec", containerName,
 		"psql", "-U", cfg.Postgres.User, "-d", cfg.Postgres.DB,
 		"-tA", "-c", sql,

--- a/internal/plugin/schema_container_test.go
+++ b/internal/plugin/schema_container_test.go
@@ -1,0 +1,52 @@
+package plugin
+
+// schema_container_test.go — Pins the Postgres container name this package uses.
+//
+// Purpose: `nself plugin install` shells out to `docker exec <container> psql`
+//          to create a plugin's schema. Both call sites in schema.go used
+//          "<project>-postgres-1", Docker Compose's DEFAULT naming — but
+//          `nself build` writes `container_name: ${PROJECT_NAME}_postgres`,
+//          which overrides that default. Every exec therefore failed with
+//          "No such container", and plugin install was broken for EVERY
+//          schema-bearing plugin on EVERY project. A live smoke test of
+//          ntask's 7 declared plugins installed 0 of 7 for this reason.
+// Inputs:  a config with a project name.
+// Outputs: assertions on the container name string.
+// Constraints: pure string construction — no docker, no network.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+func TestPostgresContainer_MatchesGeneratedComposeName(t *testing.T) {
+	got := postgresContainer(&config.Config{ProjectName: "ntask"})
+
+	// This is the literal container_name nself build emits for ntask.
+	if want := "ntask_postgres"; got != want {
+		t.Errorf("postgresContainer = %q, want %q", got, want)
+	}
+
+	// The specific wrong answer that shipped. Compose's default naming is
+	// <project>-<service>-<index>; nself build overrides it, so this form
+	// addresses a container that does not exist.
+	if strings.Contains(got, "-postgres-1") {
+		t.Error("container name regressed to Docker Compose default naming; " +
+			"nself build sets container_name explicitly and this will 'No such container'")
+	}
+}
+
+// TestPostgresContainer_AgreesWithRestOfCLI guards the convention rather than
+// one spelling. internal/database/helpers.go, internal/database/backup.go and
+// six files under internal/tenant all build this name as
+// ProjectName + "_postgres". This package was the only one that disagreed.
+func TestPostgresContainer_AgreesWithRestOfCLI(t *testing.T) {
+	for _, project := range []string{"ntask", "nself-web", "my_app", "a"} {
+		got := postgresContainer(&config.Config{ProjectName: project})
+		if want := project + "_postgres"; got != want {
+			t.Errorf("project %q: got %q, want %q", project, got, want)
+		}
+	}
+}


### PR DESCRIPTION
`nself plugin install` has been broken for **every schema-bearing plugin on every nSelf project**.

## The defect
Both `docker exec` call sites in `internal/plugin/schema.go` built the Postgres container name as `<project>-postgres-1` — Docker Compose's **default** naming. But `nself build` writes:
```yaml
container_name: ${PROJECT_NAME}_postgres
```
which overrides that default. Every exec hit "No such container", and schema creation failed.

## How it surfaced
A live smoke test of ntask's 7 declared free plugins (P6-E3-W2-S1-T5) installed **0 of 7**, all failing identically:
```
No such container: ntask-postgres-1
```
while `ntask/backend/docker-compose.yml` line 15 plainly reads `container_name: ntask_postgres`.

## This file was the odd one out
The rest of the CLI already spells it correctly in **eight** places — `internal/database/helpers.go`, `internal/database/backup.go`, and six files under `internal/tenant`, all `ProjectName + "_postgres"`. Only this one file disagreed, which is why nothing else broke and nobody noticed.

## Tests
Two, and one of them guards the convention rather than a spelling:
- against the literal name `nself build` emits for ntask, and failing specifically if the Compose-default form ever returns
- across several project names, asserting agreement with the rest of the CLI

## Deliberately not done here
The convention is now written out in nine places, and ASI Policy 3 says extract on the third copy. Consolidating means touching nine files across packages other agents are actively working in, so it is recorded rather than done — the fix stays in the file that had the bug.

`gofmt`, `go build`, `go vet` clean.