### PR TITLE
cli: resolve bundle membership from bundles.json (ADR-P6-03)

### DIFF
--- a/cmd/commands/bundle.go
+++ b/cmd/commands/bundle.go
@@ -1,100 +1,22 @@
 package commands
 
 import (
+	"context"
 	"fmt"
+
+	"github.com/nself-org/cli/internal/bundle"
 
 	"github.com/spf13/cobra"
 )
 
-// Bundle describes a canonical nSelf plugin bundle.
-type Bundle struct {
-	Name        string
-	Price       string
-	Description string
-	Plugins     []string
-}
-
-// bundleSlugAliases maps informal/marketing slugs to their canonical bundle
-// slug for user-facing lookups (info). Kept in sync with
-// internal/bundle.bundleAliases; aliases never appear in listings.
-var bundleSlugAliases = map[string]string{
-	"sentry": "nsentry",
-}
-
-// canonicalBundles is the authoritative bundle membership map (mirrors F06-BUNDLE-INVENTORY.md).
-// Keys are the system names used as CLI arguments.
-var canonicalBundles = map[string]Bundle{
-	"nclaw": {
-		Name:  "ɳClaw",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"ai", "claw", "claw-web", "mux", "voice", "browser",
-			"google", "notify", "cron", "claw-budget", "claw-news",
-			"mcp", "knowledge-base",
-		},
-	},
-	"nchat": {
-		Name:  "ɳChat",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"chat", "livekit", "recording", "moderation", "bots", "realtime", "auth",
-			"support",
-		},
-	},
-	"nfamily": {
-		Name:  "ɳFamily",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"social", "photos", "activity-feed", "moderation", "realtime", "cms", "chat",
-			"geolocation", "calendar",
-		},
-	},
-	"ntv": {
-		Name:  "ɳTV",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"media-processing", "streaming", "epg", "tmdb", "podcast", "recording",
-			"game-metadata", "file-processing", "subtitle-manager", "vpn", "stream-gateway",
-		},
-	},
-	"clawde": {
-		Name:  "ClawDE",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"claw", "ai", "realtime", "auth", "notify", "cms",
-			"mcp", "knowledge-base",
-		},
-	},
-	"nsentry": {
-		Name:  "ɳSentry",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"nself-uptime-monitor", "nself-status-page", "nself-incident-mgmt",
-			"nself-alert-router", "nself-slo-tracker", "nself-synthetic-monitor",
-			"nself-rum", "nself-errors", "nself-cron-monitor", "nself-oncall",
-			"nself-crash", "nself-anomaly", "nself-audit",
-		},
-	},
-	"nself-plus": {
-		Name:        "ɳSelf+",
-		Price:       "$3.99/mo or $39.99/yr",
-		Description: "All 6 paid bundles + all apps + support",
-		Plugins:     nil, // meta-bundle — no individual plugin list
-	},
-	"ntask": {
-		Name:        "ɳTask",
-		Price:       "FREE",
-		Description: "Free bundle — uses free plugins only",
-		Plugins:     []string{"(free plugins only — see: nself plugin list)"},
-	},
-}
-
-// bundleDisplayOrder sets the print order for bundle list.
-var bundleDisplayOrder = []string{
-	"nclaw", "nchat", "nfamily", "ntv", "clawde", "nsentry", "ntask", "nself-plus",
-}
-
 // ── Parent command ──────────────────────────────────────────────────
+//
+// Bundle membership (name/price/plugins) is resolved from bundles.json via
+// internal/bundle — NEVER hand-maintained here. Every subcommand below reads
+// through internal/bundle.Get/Names/All so there is exactly one bundle map
+// in the CLI (P6-E4-W3-S3-T10; a second hand-copied map here previously
+// diverged from internal/bundle's, the same drift shape that caused 68 paid
+// plugins to 404 in the license allowlist bug).
 
 var bundleCmd = &cobra.Command{
 	Use:   "bundle",
@@ -104,6 +26,16 @@ var bundleCmd = &cobra.Command{
 Subcommands:
   list         List all available bundles with pricing
   info <name>  Show bundle details, plugins, and license status`,
+	// PersistentPreRunE eager-fetches+validates bundles.json once per command
+	// invocation (no lazy-init on first Get/All access), backed by cache
+	// fallback on fetch failure. See internal/bundle/registry.go.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		return bundle.Load(ctx)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return cmd.Help()

--- a/cmd/commands/bundle_info.go
+++ b/cmd/commands/bundle_info.go
@@ -3,15 +3,17 @@ package commands
 // Purpose: the "nself bundle info" subcommand, its RunE, and the license/
 // plugin-install status helpers it uses (resolveBundleLicenseStatus,
 // checkPluginInstalled). Inputs are the cobra command/args or a bundle/plugin
-// key; outputs are printed bundle info or a status string/bool.
+// key; outputs are printed bundle info or a status string/bool. Bundle
+// membership is resolved from bundles.json via internal/bundle
+// (P6-E4-W3-S3-T10 — no local bundle map here).
 // Constraints: split out of bundle.go (CLI-R12) as a pure move, no behavior change.
 
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 
+	"github.com/nself-org/cli/internal/bundle"
 	"github.com/nself-org/cli/internal/license"
 	"github.com/nself-org/cli/internal/plugin"
 
@@ -35,8 +37,10 @@ var bundleInfoCmd = &cobra.Command{
 	Short: "Show bundle details, plugins, and license status",
 	Long: `Display the full plugin membership, pricing, and your current license status for a bundle.
 
+Both short (claw) and legacy n-prefixed (nclaw) slugs are accepted.
+
 Examples:
-  nself bundle info nclaw
+  nself bundle info claw
   nself bundle info nclaw --json
   nself bundle info nself-plus`,
 	Args: cobra.ExactArgs(1),
@@ -45,34 +49,26 @@ Examples:
 
 func runBundleInfo(cmd *cobra.Command, args []string) error {
 	key := strings.ToLower(strings.TrimSpace(args[0]))
-	// Resolve informal slug aliases (e.g. "sentry" -> "nsentry") the same way
-	// internal/bundle.Get does, so info/install/remove behave consistently.
-	// Aliases never appear in listings or error hints.
-	if canonical, ok := bundleSlugAliases[key]; ok {
-		key = canonical
-	}
-	b, ok := canonicalBundles[key]
+
+	b, ok := bundle.Get(key)
 	if !ok {
-		// Collect valid names for the error hint.
-		var names []string
-		for k := range canonicalBundles {
-			names = append(names, k)
-		}
-		sort.Strings(names)
-		return fmt.Errorf("bundle not found: %q\n\nRun 'nself bundle list' for available bundles.\nAvailable: %s", key, strings.Join(names, ", "))
+		return fmt.Errorf("bundle not found: %q\n\nRun 'nself bundle list' for available bundles.\nAvailable: %s", key, strings.Join(bundle.Names(), ", "))
 	}
+	// Report under the bundle's own canonical slug so both alias forms
+	// (nclaw / claw) print identical output, per acceptance criteria.
+	slug := b.Slug
 
 	asJSON := false
 	if cmd != nil {
 		asJSON, _ = cmd.Flags().GetBool("json")
 	}
 
-	licenseStatus := resolveBundleLicenseStatus(key)
+	licenseStatus := resolveBundleLicenseStatus(slug)
 
 	// Build install hint string.
 	var installHint string
-	switch key {
-	case "ntask":
+	switch slug {
+	case "task":
 		installHint = "nself plugin install <plugin-name>  (no license required)"
 	case "nself-plus":
 		installHint = "nself license set <key>  |  Buy: https://nself.org/pricing"
@@ -90,7 +86,7 @@ func runBundleInfo(cmd *cobra.Command, args []string) error {
 			plugins = []string{}
 		}
 		row := bundleInfoJSON{
-			Slug:          key,
+			Slug:          slug,
 			Name:          b.Name,
 			Price:         b.Price,
 			Description:   b.Description,
@@ -104,7 +100,7 @@ func runBundleInfo(cmd *cobra.Command, args []string) error {
 		return enc.Encode(row)
 	}
 
-	fmt.Printf("Bundle: %s (%s)\n", b.Name, key)
+	fmt.Printf("Bundle: %s (%s)\n", b.Name, slug)
 	fmt.Printf("Price:  %s\n", b.Price)
 	if b.Description != "" {
 		fmt.Printf("Note:   %s\n", b.Description)
@@ -115,8 +111,8 @@ func runBundleInfo(cmd *cobra.Command, args []string) error {
 
 	// ── Plugin membership ──────────────────────────────────────────
 	fmt.Println()
-	if key == "nself-plus" {
-		fmt.Println("Includes all 6 paid bundles (nclaw, nchat, nfamily, ntv, clawde, nsentry)")
+	if slug == "nself-plus" {
+		fmt.Println("Includes every paid bundle (claw, chat, family, tv, clawde, sentry)")
 		fmt.Println("+ all nSelf apps + support via chat.nself.org or the nChat app")
 	} else if b.Plugins != nil {
 		fmt.Printf("Plugins (%d):\n", len(b.Plugins))
@@ -142,9 +138,10 @@ func runBundleInfo(cmd *cobra.Command, args []string) error {
 // ── Helpers ─────────────────────────────────────────────────────────
 
 // resolveBundleLicenseStatus returns a human-readable license status string
-// for the given bundle key. Reads the local license cache — no network call.
-func resolveBundleLicenseStatus(bundleKey string) string {
-	if bundleKey == "ntask" {
+// for the given canonical bundle slug. Reads the local license cache — no
+// network call.
+func resolveBundleLicenseStatus(bundleSlug string) string {
+	if bundleSlug == "task" {
 		return "active (free)"
 	}
 
@@ -163,7 +160,7 @@ func resolveBundleLicenseStatus(bundleKey string) string {
 	// Check if the specific bundle is in PluginsAllowed.
 	// The license server populates PluginsAllowed with all plugin names
 	// included in the licensed bundle(s).
-	b, ok := canonicalBundles[bundleKey]
+	b, ok := bundle.Get(bundleSlug)
 	if ok && len(b.Plugins) > 0 {
 		for _, allowed := range cache.PluginsAllowed {
 			for _, bp := range b.Plugins {

--- a/cmd/commands/bundle_list.go
+++ b/cmd/commands/bundle_list.go
@@ -2,7 +2,8 @@ package commands
 
 // Purpose: the bundleListRow type and runBundleList, the RunE for "nself
 // bundle list". Inputs are the cobra command/args; outputs are a printed
-// table or JSON of canonical bundles.
+// table or JSON of canonical bundles resolved from bundles.json via
+// internal/bundle (P6-E4-W3-S3-T10 — no local bundle map here).
 // Constraints: split out of bundle.go (CLI-R12) as a pure move, no behavior change.
 
 import (
@@ -10,6 +11,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nself-org/cli/internal/bundle"
 	"github.com/nself-org/cli/internal/plugin"
 
 	"github.com/spf13/cobra"
@@ -42,18 +44,11 @@ func runBundleList(cmd *cobra.Command, _ []string) error {
 		installedSet[strings.ToLower(p.Name)] = true
 	}
 
-	for _, key := range bundleDisplayOrder {
-		b, ok := canonicalBundles[key]
-		if !ok {
-			continue
-		}
-
+	for _, b := range bundle.All() {
 		status := "active"
-		switch key {
-		case "ntask":
+		switch b.Slug {
+		case "task":
 			status = "free"
-		case "nsentry", "nfamily", "clawde":
-			status = "planned"
 		}
 
 		// Count how many bundle plugins are installed.
@@ -75,7 +70,7 @@ func runBundleList(cmd *cobra.Command, _ []string) error {
 		}
 
 		rows = append(rows, bundleListRow{
-			Slug:        key,
+			Slug:        b.Slug,
 			Name:        b.Name,
 			Price:       b.Price,
 			PluginCount: len(b.Plugins),
@@ -100,7 +95,7 @@ func runBundleList(cmd *cobra.Command, _ []string) error {
 			pluginCount = fmt.Sprintf("  (%d plugins)", r.PluginCount)
 		}
 
-		b := canonicalBundles[r.Slug]
+		b, _ := bundle.Get(r.Slug)
 		desc := b.Description
 		if desc == "" && len(b.Plugins) > 0 {
 			preview := b.Plugins

--- a/cmd/commands/bundle_test.go
+++ b/cmd/commands/bundle_test.go
@@ -2,11 +2,48 @@ package commands
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/nself-org/cli/internal/bundle"
+
 	"github.com/spf13/cobra"
 )
+
+// fixtureBundlesJSON serves as the bundles.json response for every test in
+// this file. A local httptest server (not the live plugins.nself.org
+// endpoint) is pointed at via NSELF_BUNDLES_URL so bundleCmd's
+// PersistentPreRunE (bundle.Load) resolves deterministically offline,
+// exercising the real fetch path rather than mocking it away.
+const fixtureBundlesJSON = `{
+  "schema_version": "2.0.0",
+  "bundles": {
+    "task":   {"display": "ɳTask",   "tier": "free", "price_monthly": 0,    "price_yearly": 0,    "plugins": ["notifications","jobs"]},
+    "chat":   {"display": "ɳChat",   "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99, "plugins": ["bots","livekit"]},
+    "claw":   {"display": "ɳClaw",   "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99, "plugins": ["ai","claw","mux","voice","browser","google","notify","cron"]},
+    "family": {"display": "ɳFamily", "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99, "plugins": ["social","photos"]},
+    "sentry": {"display": "ɳSentry", "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99, "plugins": ["nself-uptime-monitor","nself-status-page"]},
+    "tv":     {"display": "ɳTV",     "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99, "plugins": ["streaming","epg"]},
+    "clawde": {"display": "ClawDE",  "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99, "plugins": ["auth","cms","realtime"]}
+  }
+}`
+
+func TestMain(m *testing.M) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(fixtureBundlesJSON))
+	}))
+	defer srv.Close()
+	_ = os.Setenv("NSELF_BUNDLES_URL", srv.URL)
+	// Seed once up front too, so direct RunE calls that bypass
+	// PersistentPreRunE (not routed through cobra Execute) still resolve.
+	if err := bundle.LoadBytes([]byte(fixtureBundlesJSON)); err != nil {
+		panic("seeding bundle fixture: " + err.Error())
+	}
+	os.Exit(m.Run())
+}
 
 // newBundleTestCmd returns an isolated cobra root with only the bundle
 // command tree attached — avoids touching the global RootCmd state.
@@ -43,30 +80,33 @@ func TestBundleCmd_SubcommandsRegistered(t *testing.T) {
 	}
 }
 
-// ── canonicalBundles ─────────────────────────────────────────────────
+// ── bundle membership (resolved from bundles.json via internal/bundle) ──
 
-func TestCanonicalBundles_AllPresent(t *testing.T) {
-	required := []string{"nclaw", "nchat", "nfamily", "ntv", "clawde", "nsentry", "ntask", "nself-plus"}
+func TestBundles_AllPresent(t *testing.T) {
+	required := []string{"claw", "chat", "family", "tv", "clawde", "sentry", "task", "nself-plus"}
 	for _, key := range required {
-		if _, ok := canonicalBundles[key]; !ok {
-			t.Errorf("canonicalBundles missing required bundle %q", key)
+		if _, ok := bundle.Get(key); !ok {
+			t.Errorf("bundle.Get missing required bundle %q", key)
 		}
 	}
 }
 
-func TestCanonicalBundles_NamesNotEmpty(t *testing.T) {
-	for key, b := range canonicalBundles {
+func TestBundles_NamesNotEmpty(t *testing.T) {
+	for _, b := range bundle.All() {
 		if b.Name == "" {
-			t.Errorf("bundle %q has empty Name", key)
+			t.Errorf("bundle %q has empty Name", b.Slug)
 		}
 		if b.Price == "" {
-			t.Errorf("bundle %q has empty Price", key)
+			t.Errorf("bundle %q has empty Price", b.Slug)
 		}
 	}
 }
 
-func TestCanonicalBundles_NClawPlugins(t *testing.T) {
-	b := canonicalBundles["nclaw"]
+func TestBundles_ClawPlugins(t *testing.T) {
+	b, ok := bundle.Get("claw")
+	if !ok {
+		t.Fatal("bundle.Get(claw) failed")
+	}
 	required := []string{"ai", "claw", "mux", "voice", "browser", "google", "notify", "cron"}
 	for _, p := range required {
 		found := false
@@ -77,7 +117,7 @@ func TestCanonicalBundles_NClawPlugins(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("nclaw bundle missing expected plugin %q", p)
+			t.Errorf("claw bundle missing expected plugin %q", p)
 		}
 	}
 }
@@ -97,7 +137,7 @@ func TestBundleList_ContainsAllBundles(t *testing.T) {
 	out, _ := captureStdout(t, func() error {
 		return runBundleList(nil, nil)
 	})
-	for _, key := range []string{"nclaw", "nchat", "ntv", "clawde", "nsentry", "ntask", "nself-plus"} {
+	for _, key := range []string{"claw", "chat", "tv", "clawde", "sentry", "task", "nself-plus"} {
 		if !strings.Contains(out, key) {
 			t.Errorf("bundle list output missing bundle key %q\nfull output:\n%s", key, out)
 		}
@@ -118,16 +158,16 @@ func TestBundleList_ContainsPricing(t *testing.T) {
 
 // ── bundle info ───────────────────────────────────────────────────────
 
-func TestBundleInfo_NClawHappyPath(t *testing.T) {
+func TestBundleInfo_ClawHappyPath(t *testing.T) {
 	out, err := captureStdout(t, func() error {
-		return runBundleInfo(&cobra.Command{}, []string{"nclaw"})
+		return runBundleInfo(&cobra.Command{}, []string{"claw"})
 	})
 	if err != nil {
-		t.Fatalf("bundle info nclaw returned error: %v", err)
+		t.Fatalf("bundle info claw returned error: %v", err)
 	}
 	for _, want := range []string{"ɳClaw", "$0.99", "ai", "claw", "mux"} {
 		if !strings.Contains(out, want) {
-			t.Errorf("bundle info nclaw output missing %q\nfull:\n%s", want, out)
+			t.Errorf("bundle info claw output missing %q\nfull:\n%s", want, out)
 		}
 	}
 }
@@ -147,26 +187,52 @@ func TestBundleInfo_NSelfPlus(t *testing.T) {
 	}
 }
 
-func TestBundleInfo_SentryAliasResolvesToNSentry(t *testing.T) {
-	out, err := captureStdout(t, func() error {
-		return runBundleInfo(&cobra.Command{}, []string{"sentry"})
-	})
-	if err != nil {
-		t.Fatalf("bundle info sentry (alias) returned error: %v", err)
+// TestBundleInfo_LegacyAndCanonicalSlugsMatch is the acceptance-criteria
+// check: `nself bundle info nclaw --json` and `nself bundle info claw --json`
+// must return identical output (backward-compat alias verified).
+func TestBundleInfo_LegacyAndCanonicalSlugsMatch(t *testing.T) {
+	pairs := [][2]string{
+		{"nclaw", "claw"}, {"nchat", "chat"}, {"nfamily", "family"},
+		{"ntv", "tv"}, {"nsentry", "sentry"}, {"ntask", "task"},
 	}
-	for _, want := range []string{"ɳSentry", "$0.99"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("bundle info sentry output missing %q\nfull:\n%s", want, out)
+	for _, pair := range pairs {
+		legacy, canonical := pair[0], pair[1]
+		legacyOut, err1 := captureStdout(t, func() error {
+			return runBundleInfo(&cobra.Command{}, []string{legacy})
+		})
+		canonicalOut, err2 := captureStdout(t, func() error {
+			return runBundleInfo(&cobra.Command{}, []string{canonical})
+		})
+		if err1 != nil || err2 != nil {
+			t.Errorf("pair (%q,%q): err1=%v err2=%v", legacy, canonical, err1, err2)
+			continue
+		}
+		if legacyOut != canonicalOut {
+			t.Errorf("bundle info %q and %q produced different output:\n%q\nvs\n%q", legacy, canonical, legacyOut, canonicalOut)
 		}
 	}
 }
 
-func TestBundleInfo_SentryAliasCaseAndSpaceInsensitive(t *testing.T) {
+func TestBundleInfo_SentryAliasResolvesToCanonical(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		return runBundleInfo(&cobra.Command{}, []string{"nsentry"})
+	})
+	if err != nil {
+		t.Fatalf("bundle info nsentry (alias) returned error: %v", err)
+	}
+	for _, want := range []string{"ɳSentry", "$0.99"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("bundle info nsentry output missing %q\nfull:\n%s", want, out)
+		}
+	}
+}
+
+func TestBundleInfo_SentryCaseAndSpaceInsensitive(t *testing.T) {
 	out, err := captureStdout(t, func() error {
 		return runBundleInfo(&cobra.Command{}, []string{"  SENTRY "})
 	})
 	if err != nil {
-		t.Fatalf("bundle info '  SENTRY ' (alias) returned error: %v", err)
+		t.Fatalf("bundle info '  SENTRY ' returned error: %v", err)
 	}
 	if !strings.Contains(out, "ɳSentry") {
 		t.Errorf("bundle info '  SENTRY ' output missing ɳSentry name\nfull:\n%s", out)
@@ -205,12 +271,12 @@ func TestBundleInfo_JSONFlag(t *testing.T) {
 	buf := &bytes.Buffer{}
 	root.SetOut(buf)
 	root.SetErr(buf)
-	root.SetArgs([]string{"bundle", "info", "nclaw", "--json"})
+	root.SetArgs([]string{"bundle", "info", "claw", "--json"})
 	if err := root.Execute(); err != nil {
-		t.Fatalf("bundle info nclaw --json returned error: %v", err)
+		t.Fatalf("bundle info claw --json returned error: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{`"slug"`, `"nclaw"`, `"name"`, `"price"`, `"plugins"`, `"license_status"`, `"install_hint"`} {
+	for _, want := range []string{`"slug"`, `"claw"`, `"name"`, `"price"`, `"plugins"`, `"license_status"`, `"install_hint"`} {
 		if !strings.Contains(out, want) {
 			t.Errorf("--json output missing key %q\nfull:\n%s", want, out)
 		}
@@ -225,13 +291,13 @@ func TestBundleInfo_JSON_AllFields(t *testing.T) {
 	buf := &bytes.Buffer{}
 	root.SetOut(buf)
 	root.SetErr(buf)
-	root.SetArgs([]string{"bundle", "info", "ntask", "--json"})
+	root.SetArgs([]string{"bundle", "info", "task", "--json"})
 	if err := root.Execute(); err != nil {
-		t.Fatalf("bundle info ntask --json returned error: %v", err)
+		t.Fatalf("bundle info task --json returned error: %v", err)
 	}
 	out := buf.String()
 	if !strings.Contains(out, `"FREE"`) {
-		t.Errorf("--json ntask output missing FREE price\nfull:\n%s", out)
+		t.Errorf("--json task output missing FREE price\nfull:\n%s", out)
 	}
 	if !strings.Contains(out, `"plugin_count"`) {
 		t.Errorf("--json output missing plugin_count\nfull:\n%s", out)
@@ -239,7 +305,7 @@ func TestBundleInfo_JSON_AllFields(t *testing.T) {
 }
 
 func TestBundleInfo_CaseInsensitive(t *testing.T) {
-	for _, input := range []string{"nClaw", "NCLAW", "NClaw"} {
+	for _, input := range []string{"nClaw", "NCLAW", "NClaw", "claw", "CLAW"} {
 		out, err := captureStdout(t, func() error {
 			return runBundleInfo(&cobra.Command{}, []string{input})
 		})
@@ -248,62 +314,74 @@ func TestBundleInfo_CaseInsensitive(t *testing.T) {
 			continue
 		}
 		if !strings.Contains(out, "ɳClaw") {
-			t.Errorf("bundle info %q did not resolve to nclaw\nfull:\n%s", input, out)
+			t.Errorf("bundle info %q did not resolve to claw\nfull:\n%s", input, out)
 		}
 	}
 }
 
-func TestBundleInfo_NSentry(t *testing.T) {
+func TestBundleInfo_Sentry(t *testing.T) {
 	out, err := captureStdout(t, func() error {
-		return runBundleInfo(&cobra.Command{}, []string{"nsentry"})
+		return runBundleInfo(&cobra.Command{}, []string{"sentry"})
 	})
 	if err != nil {
-		t.Fatalf("bundle info nsentry returned error: %v", err)
+		t.Fatalf("bundle info sentry returned error: %v", err)
 	}
 	if !strings.Contains(out, "ɳSentry") {
-		t.Errorf("bundle info nsentry missing ɳSentry name\nfull:\n%s", out)
+		t.Errorf("bundle info sentry missing ɳSentry name\nfull:\n%s", out)
 	}
 	for _, p := range []string{"nself-uptime-monitor", "nself-status-page"} {
 		if !strings.Contains(out, p) {
-			t.Errorf("bundle info nsentry missing plugin %q\nfull:\n%s", p, out)
+			t.Errorf("bundle info sentry missing plugin %q\nfull:\n%s", p, out)
 		}
 	}
 }
 
-func TestBundleInfo_NTask(t *testing.T) {
+func TestBundleInfo_Task(t *testing.T) {
 	out, err := captureStdout(t, func() error {
-		return runBundleInfo(&cobra.Command{}, []string{"ntask"})
+		return runBundleInfo(&cobra.Command{}, []string{"task"})
 	})
 	if err != nil {
-		t.Fatalf("bundle info ntask returned error: %v", err)
+		t.Fatalf("bundle info task returned error: %v", err)
 	}
 	if !strings.Contains(out, "ɳTask") {
-		t.Errorf("bundle info ntask missing ɳTask name\nfull:\n%s", out)
+		t.Errorf("bundle info task missing ɳTask name\nfull:\n%s", out)
 	}
 	if !strings.Contains(out, "FREE") {
-		t.Errorf("bundle info ntask missing FREE price\nfull:\n%s", out)
+		t.Errorf("bundle info task missing FREE price\nfull:\n%s", out)
+	}
+}
+
+func TestBundleInfo_ClawdeAndTaskUnprefixedOnly(t *testing.T) {
+	// clawde and task never had an n-prefixed form; both must resolve
+	// directly without error (acceptance criterion #3).
+	for _, slug := range []string{"clawde", "task"} {
+		if _, err := captureStdout(t, func() error {
+			return runBundleInfo(&cobra.Command{}, []string{slug})
+		}); err != nil {
+			t.Errorf("bundle info %q returned error: %v", slug, err)
+		}
 	}
 }
 
 // ── resolveBundleLicenseStatus ────────────────────────────────────────
 
-func TestResolveBundleLicenseStatus_NTask(t *testing.T) {
-	status := resolveBundleLicenseStatus("ntask")
+func TestResolveBundleLicenseStatus_Task(t *testing.T) {
+	status := resolveBundleLicenseStatus("task")
 	if !strings.Contains(status, "free") {
-		t.Errorf("ntask license status should mention 'free', got: %s", status)
+		t.Errorf("task license status should mention 'free', got: %s", status)
 	}
 }
 
 func TestResolveBundleLicenseStatus_NoCache(t *testing.T) {
 	// Override cache path to a guaranteed non-existent file.
 	t.Setenv("LICENSE_CACHE_PATH", "/tmp/nself-test-no-license-cache-xyz.json")
-	status := resolveBundleLicenseStatus("nclaw")
+	status := resolveBundleLicenseStatus("claw")
 	if !strings.Contains(status, "not activated") {
 		t.Errorf("expected 'not activated' when no cache, got: %s", status)
 	}
 }
 
-// ── bundleDisplayOrder ────────────────────────────────────────────────
+// ── bundle list / display order ─────────────────────────────────────────
 
 func TestBundleList_JSONFlag(t *testing.T) {
 	root := newBundleTestCmd()
@@ -318,8 +396,8 @@ func TestBundleList_JSONFlag(t *testing.T) {
 	if !strings.Contains(out, `"slug"`) {
 		t.Errorf("--json output missing 'slug' key: %s", out)
 	}
-	if !strings.Contains(out, `"nclaw"`) {
-		t.Errorf("--json output missing nclaw entry: %s", out)
+	if !strings.Contains(out, `"claw"`) {
+		t.Errorf("--json output missing claw entry: %s", out)
 	}
 }
 
@@ -336,10 +414,10 @@ func TestBundleList_InstalledFlag_NoPlugins(t *testing.T) {
 	}
 }
 
-func TestBundleDisplayOrder_AllKeysValid(t *testing.T) {
-	for _, key := range bundleDisplayOrder {
-		if _, ok := canonicalBundles[key]; !ok {
-			t.Errorf("bundleDisplayOrder references unknown bundle key %q", key)
+func TestDisplayOrder_AllKeysValid(t *testing.T) {
+	for _, key := range bundle.DisplayOrder {
+		if _, ok := bundle.Get(key); !ok {
+			t.Errorf("bundle.DisplayOrder references unknown bundle key %q", key)
 		}
 	}
 }

--- a/internal/build/manifest.go
+++ b/internal/build/manifest.go
@@ -27,8 +27,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/nself-org/cli/internal/bundle"
-	"github.com/nself-org/cli/internal/config"
-	"github.com/nself-org/cli/internal/plugin"
 )
 
 // manifestFilenames are the accepted names for the project manifest, checked
@@ -137,6 +135,24 @@ func (m *ProjectManifest) DeclaredPlugins() []string {
 	if m.Bundle != "" {
 		bundles = append(bundles, m.Bundle)
 	}
+	if len(bundles) > 0 {
+		// P6-E4-W3-S3-T10 CI regression: bundle.Load() is only wired into
+		// `nself bundle`'s PersistentPreRunE. Every OTHER command that
+		// reaches this expansion (build/start/restart/stop/ops/status, via
+		// internal/build's manifest loader) needs the resolver populated
+		// too, or a manifest's `bundles:` entries silently expand to
+		// nothing — exactly the silent-drop this file's own PCI charter
+		// forbids. EnsureLoaded is idempotent: a no-op once any caller in
+		// this process has already loaded the registry.
+		if err := bundle.EnsureLoaded(context.Background()); err != nil {
+			// Never silently drop: loudly report and continue with
+			// whatever plugins are already flat-declared. A manifest that
+			// ONLY uses bundles: with no cache and no network will end up
+			// with zero plugins here — surfaced, not hidden.
+			slog.Warn("could not resolve bundle catalog — declared bundle(s) will NOT be expanded",
+				"bundles", bundles, "err", err)
+		}
+	}
 	for _, slug := range bundles {
 		b, ok := bundle.Get(slug)
 		if !ok {
@@ -186,107 +202,3 @@ func autoInstallEnabled() bool {
 // autoInstallTimeout bounds a single best-effort plugin auto-install so an
 // unreachable registry can never hang `nself build`.
 const autoInstallTimeout = 60 * time.Second
-
-// ResolveDeclaredPlugins guarantees every plugin declared in nself.yaml is
-// wired into the build, in three steps per declared plugin:
-//
-//  1. Already installed in pluginDir → satisfied (its compose fragment, if
-//     any, is picked up by DiscoverPluginComposeFiles).
-//  2. Provided by a core compose service (auth, storage) → satisfied.
-//  3. Otherwise attempt a best-effort auto-install from the registry, then
-//     re-check. Still absent → reported in missing.
-//
-// Returns the list of declared plugins that could not be wired. Callers MUST
-// surface missing plugins to the user (build warning + BuildResult) — a
-// declared plugin is never silently dropped.
-func ResolveDeclaredPlugins(ctx context.Context, cfg *config.Config, workdir, pluginDir string, composeServices []string) (missing []string) {
-	manifest, err := LoadProjectManifest(workdir)
-	if err != nil {
-		slog.Warn("could not parse project manifest — declared plugins not resolved", "err", err)
-		return nil
-	}
-	declared := manifest.DeclaredPlugins()
-	if len(declared) == 0 {
-		return nil
-	}
-
-	serviceSet := make(map[string]bool, len(composeServices))
-	for _, s := range composeServices {
-		serviceSet[s] = true
-	}
-
-	for _, name := range declared {
-		if pluginInstalled(pluginDir, name) {
-			continue
-		}
-		if satisfiedByCoreService(name, serviceSet) {
-			continue
-		}
-		if autoInstallEnabled() {
-			installCtx, cancel := context.WithTimeout(ctx, autoInstallTimeout)
-			err := plugin.Install(installCtx, cfg, name, pluginDir)
-			cancel()
-			if err == nil && pluginInstalled(pluginDir, name) {
-				slog.Info("auto-installed declared plugin", "plugin", name, "source", "nself.yaml")
-				continue
-			}
-			slog.Warn("declared plugin auto-install failed", "plugin", name, "err", err)
-		}
-		missing = append(missing, name)
-	}
-
-	return missing
-}
-
-// pluginInstalled reports whether the named plugin has an install directory
-// (with at least a plugin.json or compose fragment) under pluginDir.
-func pluginInstalled(pluginDir, name string) bool {
-	dir := filepath.Join(pluginDir, name)
-	info, err := os.Stat(dir)
-	if err != nil || !info.IsDir() {
-		return false
-	}
-	// A directory with a manifest or compose fragment counts as installed.
-	for _, f := range []string{"plugin.json", pluginComposeFilename} {
-		if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
-			return true
-		}
-	}
-	return false
-}
-
-// satisfiedByCoreService reports whether a declared plugin name is provided
-// by a generated core compose service instead of a plugin container.
-func satisfiedByCoreService(name string, serviceSet map[string]bool) bool {
-	if serviceSet[name] {
-		return true
-	}
-	for _, alias := range coreServiceAliases[name] {
-		if serviceSet[alias] {
-			return true
-		}
-	}
-	return false
-}
-
-// expectedCoreServices returns the compose service names the generator will
-// emit for core/optional services, derived from config. Used by
-// ResolveDeclaredPlugins to recognise declared names (auth, storage) that a
-// core service satisfies — the compose YAML is generated after plugin
-// resolution, so the names are derived rather than parsed.
-func expectedCoreServices(cfg *config.Config) []string {
-	services := []string{"postgres", "hasura", "auth", "nginx"}
-	if cfg.Minio.Enabled {
-		services = append(services, "minio")
-	}
-	if cfg.Redis.Enabled {
-		services = append(services, "redis")
-	}
-	if cfg.Functions.Enabled {
-		services = append(services, "functions")
-	}
-	if cfg.Mailpit.Enabled {
-		services = append(services, "mailpit")
-	}
-	return services
-}

--- a/internal/build/manifest_resolve.go
+++ b/internal/build/manifest_resolve.go
@@ -1,0 +1,119 @@
+// manifest_resolve.go — ResolveDeclaredPlugins and its helpers: reconciling
+// a project manifest's declared plugins against what's actually installed
+// and wired into the generated stack. Split out of manifest.go to stay
+// under the 300-line/file cap (internal/repoqa).
+package build
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/plugin"
+)
+
+// ResolveDeclaredPlugins guarantees every plugin declared in nself.yaml is
+// wired into the build, in three steps per declared plugin:
+//
+//  1. Already installed in pluginDir → satisfied (its compose fragment, if
+//     any, is picked up by DiscoverPluginComposeFiles).
+//  2. Provided by a core compose service (auth, storage) → satisfied.
+//  3. Otherwise attempt a best-effort auto-install from the registry, then
+//     re-check. Still absent → reported in missing.
+//
+// Returns the list of declared plugins that could not be wired. Callers MUST
+// surface missing plugins to the user (build warning + BuildResult) — a
+// declared plugin is never silently dropped.
+func ResolveDeclaredPlugins(ctx context.Context, cfg *config.Config, workdir, pluginDir string, composeServices []string) (missing []string) {
+	manifest, err := LoadProjectManifest(workdir)
+	if err != nil {
+		slog.Warn("could not parse project manifest — declared plugins not resolved", "err", err)
+		return nil
+	}
+	declared := manifest.DeclaredPlugins()
+	if len(declared) == 0 {
+		return nil
+	}
+
+	serviceSet := make(map[string]bool, len(composeServices))
+	for _, s := range composeServices {
+		serviceSet[s] = true
+	}
+
+	for _, name := range declared {
+		if pluginInstalled(pluginDir, name) {
+			continue
+		}
+		if satisfiedByCoreService(name, serviceSet) {
+			continue
+		}
+		if autoInstallEnabled() {
+			installCtx, cancel := context.WithTimeout(ctx, autoInstallTimeout)
+			err := plugin.Install(installCtx, cfg, name, pluginDir)
+			cancel()
+			if err == nil && pluginInstalled(pluginDir, name) {
+				slog.Info("auto-installed declared plugin", "plugin", name, "source", "nself.yaml")
+				continue
+			}
+			slog.Warn("declared plugin auto-install failed", "plugin", name, "err", err)
+		}
+		missing = append(missing, name)
+	}
+
+	return missing
+}
+
+// pluginInstalled reports whether the named plugin has an install directory
+// (with at least a plugin.json or compose fragment) under pluginDir.
+func pluginInstalled(pluginDir, name string) bool {
+	dir := filepath.Join(pluginDir, name)
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	// A directory with a manifest or compose fragment counts as installed.
+	for _, f := range []string{"plugin.json", pluginComposeFilename} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// satisfiedByCoreService reports whether a declared plugin name is provided
+// by a generated core compose service instead of a plugin container.
+func satisfiedByCoreService(name string, serviceSet map[string]bool) bool {
+	if serviceSet[name] {
+		return true
+	}
+	for _, alias := range coreServiceAliases[name] {
+		if serviceSet[alias] {
+			return true
+		}
+	}
+	return false
+}
+
+// expectedCoreServices returns the compose service names the generator will
+// emit for core/optional services, derived from config. Used by
+// ResolveDeclaredPlugins to recognise declared names (auth, storage) that a
+// core service satisfies — the compose YAML is generated after plugin
+// resolution, so the names are derived rather than parsed.
+func expectedCoreServices(cfg *config.Config) []string {
+	services := []string{"postgres", "hasura", "auth", "nginx"}
+	if cfg.Minio.Enabled {
+		services = append(services, "minio")
+	}
+	if cfg.Redis.Enabled {
+		services = append(services, "redis")
+	}
+	if cfg.Functions.Enabled {
+		services = append(services, "functions")
+	}
+	if cfg.Mailpit.Enabled {
+		services = append(services, "mailpit")
+	}
+	return services
+}

--- a/internal/build/manifest_test.go
+++ b/internal/build/manifest_test.go
@@ -12,8 +12,29 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/nself-org/cli/internal/bundle"
 	"github.com/nself-org/cli/internal/config"
 )
+
+// fixtureBundlesJSON seeds internal/bundle's resolver so this package's
+// tests are deterministic and offline — no network dependency on
+// plugins.nself.org. Mirrors real bundles.json's "sentry" membership
+// exactly (14 plugins, including nself-stripe per ADR-P6-03 Ruling 2) so
+// TestLoadProjectManifest_FlatPluginsAndBundleExpansion's expected count
+// stays honest against the real source of truth, not a stale hand copy.
+const fixtureBundlesJSON = `{
+  "schema_version": "2.0.0",
+  "bundles": {
+    "sentry": {"display": "ɳSentry", "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99, "plugins": ["nself-alert-router","nself-anomaly","nself-audit","nself-crash","nself-cron-monitor","nself-errors","nself-incident-mgmt","nself-oncall","nself-rum","nself-slo-tracker","nself-status-page","nself-stripe","nself-synthetic-monitor","nself-uptime-monitor"]}
+  }
+}`
+
+func TestMain(m *testing.M) {
+	if err := bundle.LoadBytes([]byte(fixtureBundlesJSON)); err != nil {
+		panic("seeding bundle fixture: " + err.Error())
+	}
+	os.Exit(m.Run())
+}
 
 // writeTestPlugin scaffolds a fake installed plugin with a plugin.json and,
 // when withCompose is true, a docker-compose.plugin.yml fragment.
@@ -94,15 +115,16 @@ plugins:
 		t.Fatal(err)
 	}
 	got := m.DeclaredPlugins()
-	// cron + the 13 nsentry bundle plugins.
-	if len(got) != 14 {
-		t.Fatalf("expected 14 declared plugins (cron + 13 nsentry), got %d: %v", len(got), got)
+	// cron + the 14 sentry bundle plugins (bundles.json/ADR-P6-03 — includes
+	// nself-stripe, which the pre-ADR hardcoded 13-plugin list omitted).
+	if len(got) != 15 {
+		t.Fatalf("expected 15 declared plugins (cron + 14 sentry), got %d: %v", len(got), got)
 	}
 	set := make(map[string]bool, len(got))
 	for _, p := range got {
 		set[p] = true
 	}
-	for _, want := range []string{"cron", "nself-uptime-monitor", "nself-status-page", "nself-errors", "nself-audit"} {
+	for _, want := range []string{"cron", "nself-uptime-monitor", "nself-status-page", "nself-errors", "nself-audit", "nself-stripe"} {
 		if !set[want] {
 			t.Errorf("declared plugins missing %q: %v", want, got)
 		}

--- a/internal/bundle/bundles.go
+++ b/internal/bundle/bundles.go
@@ -2,9 +2,11 @@
 // plus install/remove orchestration with license validation, version pinning,
 // and atomic rollback on failure (S2.T03/T04/T22).
 //
-// Bundle membership is authoritative here — the source of truth that mirrors
-// .claude/docs/sport/F06-BUNDLE-INVENTORY.md. The cmd layer must consume this
-// package; do NOT duplicate the bundle map elsewhere.
+// Bundle membership is resolved from bundles.json (ADR-P6-03), the single
+// source of truth for bundle -> plugin membership, served at
+// plugins.nself.org/bundles.json. See registry.go for the fetch+cache loader.
+// The cmd layer must consume this package via Get/Names/All — do NOT
+// hand-maintain a second bundle map anywhere else in the CLI.
 package bundle
 
 import (
@@ -16,138 +18,81 @@ import (
 // Bundle describes a canonical nSelf plugin bundle.
 type Bundle struct {
 	Name        string   // Display name (with ɳ glyph)
-	Slug        string   // CLI-arg lowercase identifier
+	Slug        string   // CLI-arg lowercase identifier (bundles.json canonical slug)
 	Price       string   // Human-readable price string
 	Description string   // Optional one-line description
 	Plugins     []string // Plugin slugs in the bundle (nil for meta-bundle)
 }
 
-// canonicalBundles is the authoritative bundle membership map.
-// Mirrors F06-BUNDLE-INVENTORY.md verbatim. Any update here MUST update F06.
-var canonicalBundles = map[string]Bundle{
-	"nclaw": {
-		Slug:  "nclaw",
-		Name:  "ɳClaw",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			// "ai" = legacy paid/ai (3709); canonical AI suite post-E6 = "ai-gateway" (3761)
-			"ai", "ai-gateway", "ai-cc", "ai-mcp",
-			"claw", "claw-web", "mux", "voice", "browser",
-			"google", "notify", "cron", "claw-budget", "claw-news",
-			"mcp", "knowledge-base",
-		},
-	},
-	"nchat": {
-		Slug:  "nchat",
-		Name:  "ɳChat",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"chat", "livekit", "recording", "moderation", "bots", "realtime", "auth",
-			"support",
-		},
-	},
-	"nfamily": {
-		Slug:  "nfamily",
-		Name:  "ɳFamily",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"social", "photos", "activity-feed", "moderation", "realtime", "cms", "chat",
-			"geolocation", "calendar",
-		},
-	},
-	"ntv": {
-		Slug:  "ntv",
-		Name:  "ɳTV",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"media-processing", "streaming", "epg", "tmdb", "podcast", "recording",
-			"game-metadata", "file-processing", "subtitle-manager", "vpn", "stream-gateway",
-		},
-	},
-	"clawde": {
-		Slug:  "clawde",
-		Name:  "ClawDE",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"claw",
-			// "ai" = legacy paid/ai (3709); canonical AI suite post-E6 = "ai-gateway" (3761)
-			"ai", "ai-gateway", "ai-cc", "ai-mcp",
-			"realtime", "auth", "notify", "cms",
-			"mcp", "knowledge-base",
-		},
-	},
-	"nsentry": {
-		Slug:  "nsentry",
-		Name:  "ɳSentry",
-		Price: "$0.99/mo or $9.99/yr",
-		Plugins: []string{
-			"nself-uptime-monitor", "nself-status-page", "nself-incident-mgmt",
-			"nself-alert-router", "nself-slo-tracker", "nself-synthetic-monitor",
-			"nself-rum", "nself-errors", "nself-cron-monitor", "nself-oncall",
-			"nself-crash", "nself-anomaly", "nself-audit",
-		},
-	},
-	"nself-plus": {
-		Slug:        "nself-plus",
-		Name:        "ɳSelf+",
-		Price:       "$3.99/mo or $39.99/yr",
-		Description: "All 6 paid bundles + all apps + support",
-		Plugins:     nil, // meta-bundle — no individual plugin list
-	},
-	"ntask": {
-		Slug:        "ntask",
-		Name:        "ɳTask",
-		Price:       "FREE",
-		Description: "Free bundle — uses free plugins only",
-		Plugins:     []string{"(free plugins only — see: nself plugin list)"},
-	},
-}
-
-// DisplayOrder is the canonical print order for bundle listings.
+// DisplayOrder is the canonical print order for bundle listings (ADR-P6-03
+// ordering canon): task -> chat -> claw -> family -> sentry -> tv -> clawde,
+// plus the computed ɳSelf+ meta-bundle last.
 var DisplayOrder = []string{
-	"nclaw", "nchat", "nfamily", "ntv", "clawde", "nsentry", "ntask", "nself-plus",
+	"task", "chat", "claw", "family", "sentry", "tv", "clawde", "nself-plus",
 }
 
-// bundleAliases maps informal/marketing slugs to their canonical bundle slug.
-// Aliases are resolved only as a fallback in Get() after the canonical lookup
-// misses — they never appear in Names() or DisplayOrder, so listings and
-// completions stay canonical-only.
+// selfPlusSlug is the synthetic meta-bundle slug. It is NOT a bundles.json
+// entry — its Plugins are computed as the union of every paid bundle's
+// plugins (ADR-P6-03: "an ɳSelf+ license entitles the union of all paid
+// bundles"), never hand-listed. See registry.go's buildBundleMap.
+const selfPlusSlug = "nself-plus"
+
+// bundleAliases maps legacy/marketing slugs to their canonical bundles.json
+// slug. bundles.json's canonical slugs are short (claw/chat/family/tv/sentry)
+// while the CLI historically used n-prefixed forms (nclaw/nchat/nfamily/ntv/
+// nsentry) plus "ntask" for the free bundle. Both forms must keep resolving
+// for backward compatibility with existing CLI users. "task" and "clawde"
+// never had an n-prefixed form. NOTE: bundles.json's canonical slug for the
+// observability bundle is "sentry" (not "nsentry" as in the pre-ADR-P6-03
+// hardcoded map) — this alias direction was corrected here, it is not merely
+// an extension of the old single entry.
 var bundleAliases = map[string]string{
-	"sentry": "nsentry",
+	"nclaw":   "claw",
+	"nchat":   "chat",
+	"nfamily": "family",
+	"ntv":     "tv",
+	"nsentry": "sentry",
+	"ntask":   "task",
 }
 
 // Get returns the Bundle for the given slug. The slug is case-insensitive and
 // trimmed. Falls back to bundleAliases when there is no canonical match.
-// Returns ok=false when the slug is unknown; callers can call Names() to
-// render a useful error hint.
+// Returns ok=false when the slug is unknown or bundles.json has not been
+// loaded yet (see Load); callers can call Names() to render a useful hint.
 func Get(slug string) (Bundle, bool) {
 	key := strings.ToLower(strings.TrimSpace(slug))
-	if b, ok := canonicalBundles[key]; ok {
+	m := currentBundles()
+	if b, ok := m[key]; ok {
 		return b, ok
 	}
 	if canonical, ok := bundleAliases[key]; ok {
-		b, ok := canonicalBundles[canonical]
+		b, ok := m[canonical]
 		return b, ok
 	}
 	return Bundle{}, false
 }
 
 // Names returns every known bundle slug sorted alphabetically. Useful for
-// error messages and shell completion.
+// error messages and shell completion. Canonical slugs only — aliases never
+// appear here.
 func Names() []string {
-	out := make([]string, 0, len(canonicalBundles))
-	for k := range canonicalBundles {
+	m := currentBundles()
+	out := make([]string, 0, len(m))
+	for k := range m {
 		out = append(out, k)
 	}
 	sort.Strings(out)
 	return out
 }
 
-// All returns every Bundle in canonical display order.
+// All returns every Bundle in canonical display order. Bundles not present
+// in the loaded set (e.g. a future bundles.json omitting one) are silently
+// skipped rather than panicking.
 func All() []Bundle {
-	out := make([]Bundle, 0, len(canonicalBundles))
+	m := currentBundles()
+	out := make([]Bundle, 0, len(DisplayOrder))
 	for _, slug := range DisplayOrder {
-		if b, ok := canonicalBundles[slug]; ok {
+		if b, ok := m[slug]; ok {
 			out = append(out, b)
 		}
 	}
@@ -155,16 +100,19 @@ func All() []Bundle {
 }
 
 // IsInstallable reports whether the bundle can be installed via
-// `nself bundle install`. Meta-bundles (nself-plus) and free bundles (ntask)
-// are not installable as a unit — operators install their constituent plugins
-// directly via `nself plugin install`.
+// `nself bundle install`. The ɳSelf+ meta-bundle and the free Task Bundle
+// are not installable as a unit — operators install their constituent
+// plugins directly via `nself plugin install` (free plugins need no license;
+// ɳSelf+ has no single SKU to install, only its union of entitlements).
+//
+// Per Ruling 2, this is the ONLY bundle-membership rule the CLI hand-codes:
+// which two of the eight display slugs are non-installable structural
+// categories, not plugin data. IsInstallable's plugin SET for every other
+// bundle, including "sentry", is exactly bundles.json's plugins[] array —
+// no cli-side subsetting and no special case for nself-stripe or any other
+// plugin.
 func (b Bundle) IsInstallable() bool {
-	if b.Slug == "nself-plus" {
-		return false
-	}
-	if b.Slug == "ntask" {
-		// ntask is free and its plugin list is a placeholder — users install
-		// free plugins individually.
+	if b.Slug == selfPlusSlug || b.Slug == "task" {
 		return false
 	}
 	if len(b.Plugins) == 0 {

--- a/internal/bundle/bundles_test.go
+++ b/internal/bundle/bundles_test.go
@@ -1,23 +1,49 @@
 package bundle
 
 import (
+	"os"
 	"testing"
 )
+
+// fixtureBundlesJSON is a representative bundles.json payload (ADR-P6-03
+// shape) used to seed the resolver in tests without a network round trip.
+// Mirrors real bundles.json: short canonical slugs, "sentry" includes
+// nself-stripe (Ruling 2: IsInstallable never special-cases any plugin).
+const fixtureBundlesJSON = `{
+  "schema_version": "2.0.0",
+  "bundles": {
+    "task":   {"display": "Task Bundle",   "tier": "free", "price_monthly": 0,    "price_yearly": 0,     "plugins": ["notifications","jobs"]},
+    "chat":   {"display": "Chat Bundle",   "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99,  "plugins": ["bots","livekit"]},
+    "claw":   {"display": "ɳClaw",         "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99,  "plugins": ["ai","claw","claw-web"]},
+    "family": {"display": "ɳFamily",       "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99,  "plugins": ["social","photos"]},
+    "sentry": {"display": "ɳSentry",       "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99,  "plugins": ["nself-uptime-monitor","nself-status-page","nself-incident-mgmt","nself-alert-router","nself-slo-tracker","nself-synthetic-monitor","nself-rum","nself-errors","nself-cron-monitor","nself-oncall","nself-crash","nself-anomaly","nself-audit","nself-stripe"]},
+    "tv":     {"display": "ɳTV",           "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99,  "plugins": ["streaming","epg"]},
+    "clawde": {"display": "ClawDE",        "tier": "paid", "price_monthly": 0.99, "price_yearly": 9.99,  "plugins": ["auth","cms","realtime"]}
+  }
+}`
+
+func TestMain(m *testing.M) {
+	if err := LoadBytes([]byte(fixtureBundlesJSON)); err != nil {
+		panic("seeding bundle fixture: " + err.Error())
+	}
+	os.Exit(m.Run())
+}
 
 func TestGet_KnownBundles(t *testing.T) {
 	cases := []struct {
 		slug        string
 		wantOK      bool
-		wantName    string
+		wantSlug    string
 		installable bool
 	}{
-		{"nclaw", true, "ɳClaw", true},
-		{"NCLAW", true, "ɳClaw", true},
-		{"  nchat  ", true, "ɳChat", true},
-		{"nself-plus", true, "ɳSelf+", false}, // meta, not installable
-		{"ntask", true, "ɳTask", false},       // free, not installable as a unit
-		{"sentry", true, "ɳSentry", true},     // alias -> nsentry
-		{"SENTRY ", true, "ɳSentry", true},    // alias case-insensitive + trimmed
+		{"claw", true, "claw", true},
+		{"CLAW", true, "claw", true},
+		{"  chat  ", true, "chat", true},
+		{"nself-plus", true, "nself-plus", false}, // meta, not installable
+		{"task", true, "task", false},             // free, not installable as a unit
+		{"nclaw", true, "claw", true},             // legacy n-prefixed alias
+		{"NSENTRY ", true, "sentry", true},        // alias case-insensitive + trimmed
+		{"ntv", true, "tv", true},
 		{"bogus", false, "", false},
 	}
 	for _, tc := range cases {
@@ -29,12 +55,59 @@ func TestGet_KnownBundles(t *testing.T) {
 		if !ok {
 			continue
 		}
-		if b.Name != tc.wantName {
-			t.Errorf("Get(%q).Name = %q; want %q", tc.slug, b.Name, tc.wantName)
+		if b.Slug != tc.wantSlug {
+			t.Errorf("Get(%q).Slug = %q; want %q", tc.slug, b.Slug, tc.wantSlug)
 		}
 		if b.IsInstallable() != tc.installable {
 			t.Errorf("Get(%q).IsInstallable() = %v; want %v", tc.slug, b.IsInstallable(), tc.installable)
 		}
+	}
+}
+
+// TestGet_AliasAndCanonicalMatch verifies both the legacy n-prefixed form and
+// the bundles.json-canonical short form resolve to the identical Bundle
+// (backward-compat requirement, ticket acceptance criterion #2).
+func TestGet_AliasAndCanonicalMatch(t *testing.T) {
+	pairs := map[string]string{
+		"nclaw":   "claw",
+		"nchat":   "chat",
+		"nfamily": "family",
+		"ntv":     "tv",
+		"nsentry": "sentry",
+		"ntask":   "task",
+	}
+	for legacy, canonical := range pairs {
+		legacyB, ok1 := Get(legacy)
+		canonicalB, ok2 := Get(canonical)
+		if !ok1 || !ok2 {
+			t.Errorf("alias pair (%q,%q): ok1=%v ok2=%v", legacy, canonical, ok1, ok2)
+			continue
+		}
+		if legacyB.Slug != canonicalB.Slug || legacyB.Name != canonicalB.Name {
+			t.Errorf("Get(%q) = %+v; Get(%q) = %+v — must match", legacy, legacyB, canonical, canonicalB)
+		}
+	}
+}
+
+// TestIsInstallable_SentryIncludesStripe proves Ruling 2: IsInstallable's
+// plugin set for sentry is exactly bundles.json's array, including
+// nself-stripe, with no cli-side subsetting.
+func TestIsInstallable_SentryIncludesStripe(t *testing.T) {
+	b, ok := Get("sentry")
+	if !ok {
+		t.Fatal("Get(sentry) failed")
+	}
+	found := false
+	for _, p := range b.Plugins {
+		if p == "nself-stripe" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("sentry bundle plugins %v missing nself-stripe (Ruling 2 violation)", b.Plugins)
+	}
+	if !b.IsInstallable() {
+		t.Error("sentry bundle should be installable")
 	}
 }
 
@@ -43,14 +116,12 @@ func TestNames_SortedAndComplete(t *testing.T) {
 	if len(names) < 6 {
 		t.Errorf("Names() returned %d entries; want at least 6", len(names))
 	}
-	// Sorted check
 	for i := 1; i < len(names); i++ {
 		if names[i-1] > names[i] {
 			t.Errorf("Names() not sorted at %d: %q > %q", i, names[i-1], names[i])
 		}
 	}
-	// Must include all six paid bundles
-	required := []string{"nclaw", "nchat", "nfamily", "ntv", "clawde", "nsentry"}
+	required := []string{"claw", "chat", "family", "tv", "clawde", "sentry", "task"}
 	have := make(map[string]bool, len(names))
 	for _, n := range names {
 		have[n] = true
@@ -60,16 +131,10 @@ func TestNames_SortedAndComplete(t *testing.T) {
 			t.Errorf("Names() missing required bundle %q", r)
 		}
 	}
-	// Aliases must never leak into Names()
-	if have["sentry"] {
-		t.Errorf("Names() must not include alias %q", "sentry")
-	}
-}
-
-func TestAliases_NotInDisplayOrder(t *testing.T) {
-	for _, slug := range DisplayOrder {
-		if slug == "sentry" {
-			t.Errorf("DisplayOrder must not include alias %q", "sentry")
+	// Legacy aliases must never leak into Names().
+	for _, alias := range []string{"nclaw", "nchat", "nfamily", "ntv", "nsentry", "ntask"} {
+		if have[alias] {
+			t.Errorf("Names() must not include alias %q", alias)
 		}
 	}
 }
@@ -86,13 +151,41 @@ func TestAll_DisplayOrder(t *testing.T) {
 	}
 }
 
+// TestSelfPlus_UnionIsComputed proves the ɳSelf+ meta-bundle's plugin list is
+// the deduped union of every paid bundle's plugins, never a hand-listed set.
+func TestSelfPlus_UnionIsComputed(t *testing.T) {
+	plus, ok := Get("nself-plus")
+	if !ok {
+		t.Fatal("Get(nself-plus) failed")
+	}
+	plusSet := make(map[string]bool, len(plus.Plugins))
+	for _, p := range plus.Plugins {
+		plusSet[p] = true
+	}
+	for _, slug := range []string{"chat", "claw", "family", "sentry", "tv", "clawde"} {
+		b, _ := Get(slug)
+		for _, p := range b.Plugins {
+			if !plusSet[p] {
+				t.Errorf("nself-plus union missing %q from paid bundle %q", p, slug)
+			}
+		}
+	}
+	// task is free — its plugins must NOT be pulled into the paid union.
+	task, _ := Get("task")
+	for _, p := range task.Plugins {
+		if plusSet[p] {
+			t.Errorf("nself-plus union unexpectedly includes free-tier plugin %q from task", p)
+		}
+	}
+}
+
 func TestUnknownBundleError_ContainsHints(t *testing.T) {
 	err := UnknownBundleError("bogus")
 	if err == nil {
 		t.Fatal("UnknownBundleError returned nil")
 	}
 	msg := err.Error()
-	for _, want := range []string{"bogus", "nclaw", "nsentry"} {
+	for _, want := range []string{"bogus", "claw", "sentry"} {
 		if !contains(msg, want) {
 			t.Errorf("error message missing %q: %s", want, msg)
 		}

--- a/internal/bundle/registry.go
+++ b/internal/bundle/registry.go
@@ -1,0 +1,279 @@
+// registry.go — fetch+cache loader for bundles.json (ADR-P6-03).
+//
+// Load is called once, eagerly, at command start (bundleCmd's
+// PersistentPreRunE) — never lazily on first Get/All access. It fetches the
+// live document from plugins.nself.org/bundles.json, validates it, and
+// populates the in-memory bundle map every invocation. On fetch failure it
+// falls back to the last-known-good local cache (mirrors
+// internal/license/validate.go's RefreshCache/ExportCache/ImportCache
+// cache-then-fall-back convention); if no cache exists either, Load returns
+// a clear network error rather than silently serving an empty bundle set.
+//
+// There is no go:embed fallback — the loader always fetches live, cache
+// fallback only on fetch failure (per ticket P6-E4-W3-S3-T10).
+package bundle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultBundlesURL is the canonical bundles.json endpoint (T8's CF
+	// worker). Override with NSELF_BUNDLES_URL for staging/tests.
+	DefaultBundlesURL = "https://plugins.nself.org/bundles.json"
+
+	bundlesHTTPTimeout   = 15 * time.Second
+	bundlesCacheFileName = "bundles.json"
+
+	// bundlesStaleWarnAfter is the age beyond which a served-from-cache
+	// bundle set gets a one-time stderr warning (mirrors the license
+	// validator's warn-on-stale pattern in defaultWarnOnce).
+	bundlesStaleWarnAfter = 24 * time.Hour
+)
+
+// jsonBundle mirrors one entry of bundles.json's "bundles" map
+// (bundles/bundles-schema.json in the plugins-pro repo).
+type jsonBundle struct {
+	Display      string   `json:"display"`
+	Tier         string   `json:"tier"` // "free" | "paid"
+	PriceMonthly float64  `json:"price_monthly"`
+	PriceYearly  float64  `json:"price_yearly"`
+	Plugins      []string `json:"plugins"`
+}
+
+// bundlesDoc is the top-level bundles.json shape.
+type bundlesDoc struct {
+	SchemaVersion string                `json:"schema_version"`
+	Bundles       map[string]jsonBundle `json:"bundles"`
+}
+
+// cachedBundlesDoc wraps bundlesDoc with the timestamp of the fetch that
+// produced it, so a served-from-cache response can report its own staleness.
+type cachedBundlesDoc struct {
+	FetchedAt int64      `json:"fetched_at"`
+	Doc       bundlesDoc `json:"doc"`
+}
+
+var (
+	stateMu       sync.RWMutex
+	state         map[string]Bundle // nil until Load/LoadBytes succeeds
+	staleWarnOnce sync.Once
+)
+
+// bundlesURL returns the configured bundles.json source, honoring
+// NSELF_BUNDLES_URL for staging/offline-mirror overrides.
+func bundlesURL() string {
+	if u := os.Getenv("NSELF_BUNDLES_URL"); u != "" {
+		return u
+	}
+	return DefaultBundlesURL
+}
+
+// Load eager-fetches and validates bundles.json, populating the resolver
+// used by Get/Names/All/IsInstallable. Call once at command start. On fetch
+// failure, falls back to the local cache (with a staleness warning past
+// bundlesStaleWarnAfter); with no fetch and no cache, returns an error
+// naming the network issue rather than leaving the resolver empty.
+func Load(ctx context.Context) error {
+	data, fetchErr := fetchBundlesJSON(ctx, bundlesURL())
+	if fetchErr == nil {
+		if err := LoadBytes(data); err != nil {
+			return fmt.Errorf("validating bundles.json: %w", err)
+		}
+		_ = writeBundlesCache(data)
+		return nil
+	}
+
+	cached, cacheErr := readBundlesCache()
+	if cacheErr != nil || cached == nil {
+		return fmt.Errorf("fetching bundles.json from %s: %w (no local cache available)", bundlesURL(), fetchErr)
+	}
+	age := time.Since(time.Unix(cached.FetchedAt, 0))
+	if age > bundlesStaleWarnAfter {
+		staleWarnOnce.Do(func() {
+			fmt.Fprintf(os.Stderr,
+				"warning: bundles.json cache is %s stale (last fetch failed: %v); bundle membership may be outdated. Reconnect and retry.\n",
+				age.Round(time.Hour), fetchErr)
+		})
+	}
+	setState(buildBundleMap(cached.Doc))
+	return nil
+}
+
+// LoadBytes parses and validates a raw bundles.json payload and installs it
+// as the current bundle set. Exported so tests (and any future offline
+// import path) can seed a fixture document without a network round trip.
+func LoadBytes(data []byte) error {
+	var doc bundlesDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("invalid bundles.json: %w", err)
+	}
+	if !strings.HasPrefix(doc.SchemaVersion, "2.") {
+		return fmt.Errorf("unsupported bundles.json schema_version %q (expected 2.x)", doc.SchemaVersion)
+	}
+	if len(doc.Bundles) == 0 {
+		return fmt.Errorf("bundles.json has no bundles")
+	}
+	setState(buildBundleMap(doc))
+	return nil
+}
+
+// currentBundles returns the loaded bundle map, or an empty map if Load has
+// not run yet (Get/Names/All degrade to "unknown bundle" rather than panic).
+func currentBundles() map[string]Bundle {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return state
+}
+
+func setState(m map[string]Bundle) {
+	stateMu.Lock()
+	state = m
+	stateMu.Unlock()
+}
+
+// buildBundleMap converts the raw JSON document into the resolver's Bundle
+// map, computing the ɳSelf+ meta-bundle as the union of every tier=="paid"
+// bundle's plugins — never a hand-listed set (ADR-P6-03).
+func buildBundleMap(doc bundlesDoc) map[string]Bundle {
+	out := make(map[string]Bundle, len(doc.Bundles)+1)
+	unionSet := make(map[string]struct{})
+	for slug, jb := range doc.Bundles {
+		out[slug] = Bundle{
+			Name:    jb.Display,
+			Slug:    slug,
+			Price:   formatPrice(jb.Tier, jb.PriceMonthly, jb.PriceYearly),
+			Plugins: jb.Plugins,
+		}
+		if jb.Tier == "paid" {
+			for _, p := range jb.Plugins {
+				unionSet[p] = struct{}{}
+			}
+		}
+	}
+	union := make([]string, 0, len(unionSet))
+	for p := range unionSet {
+		union = append(union, p)
+	}
+	sort.Strings(union)
+	out[selfPlusSlug] = Bundle{
+		Name:        "ɳSelf+",
+		Slug:        selfPlusSlug,
+		Price:       "$3.99/mo or $39.99/yr",
+		Description: "All paid bundles + all apps + support",
+		Plugins:     union,
+	}
+	return out
+}
+
+func formatPrice(tier string, monthly, yearly float64) string {
+	if tier == "free" || (monthly == 0 && yearly == 0) {
+		return "FREE"
+	}
+	return fmt.Sprintf("$%.2f/mo or $%.2f/yr", monthly, yearly)
+}
+
+// fetchBundlesJSON performs the HTTP GET against url and returns the raw
+// response body (capped at 1MiB — bundles.json is a few KB).
+func fetchBundlesJSON(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building bundles.json request: %w", err)
+	}
+	client := &http.Client{Timeout: bundlesHTTPTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("network error: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+}
+
+// bundlesCachePath returns the on-disk cache location, honoring
+// NSELF_BUNDLES_CACHE_PATH (mirrors license.CachePath's LICENSE_CACHE_PATH
+// override convention).
+func bundlesCachePath() (string, error) {
+	if p := os.Getenv("NSELF_BUNDLES_CACHE_PATH"); p != "" {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determining home directory: %w", err)
+	}
+	return filepath.Join(home, ".cache", "nself", bundlesCacheFileName), nil
+}
+
+// writeBundlesCache atomically writes a freshly fetched bundles.json payload
+// to the local cache (tmpfile + rename, matching license.WriteCache).
+func writeBundlesCache(rawDoc []byte) error {
+	var doc bundlesDoc
+	if err := json.Unmarshal(rawDoc, &doc); err != nil {
+		return err
+	}
+	entry := cachedBundlesDoc{FetchedAt: time.Now().Unix(), Doc: doc}
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+	path, err := bundlesCachePath()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating bundles cache directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".bundles.json.tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// readBundlesCache reads the last-known-good cached bundles.json. Returns
+// nil, nil if no cache file exists.
+func readBundlesCache() (*cachedBundlesDoc, error) {
+	path, err := bundlesCachePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading bundles cache: %w", err)
+	}
+	var entry cachedBundlesDoc
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, fmt.Errorf("parsing bundles cache: %w", err)
+	}
+	return &entry, nil
+}

--- a/internal/bundle/registry.go
+++ b/internal/bundle/registry.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -108,6 +107,29 @@ func Load(ctx context.Context) error {
 	}
 	setState(buildBundleMap(cached.Doc))
 	return nil
+}
+
+// EnsureLoaded populates the resolver if it has not been loaded yet in this
+// process — a no-op once Load/LoadBytes has already succeeded once. This is
+// the safety net for callers OUTSIDE the `nself bundle` command family
+// (which eagerly calls Load in its PersistentPreRunE): `nself build`,
+// `start`, `restart`, `stop`, `ops`, and `status` all reach bundle expansion
+// via internal/build's manifest loader without ever running through that
+// PreRunE, so without this, a manifest's `bundles:` entries would silently
+// expand to nothing in every one of those commands (P6-E4-W3-S3-T10 CI
+// regression: TestLoadProjectManifest_FlatPluginsAndBundleExpansion).
+// Deliberately NOT a refresh-on-every-call: once state is non-nil, this
+// returns immediately, matching Load's own "eager once, not lazy-per-Get"
+// design intent, just anchored at the first real caller in a process
+// instead of assuming that caller is always the bundle subcommand tree.
+func EnsureLoaded(ctx context.Context) error {
+	stateMu.RLock()
+	loaded := state != nil
+	stateMu.RUnlock()
+	if loaded {
+		return nil
+	}
+	return Load(ctx)
 }
 
 // LoadBytes parses and validates a raw bundles.json payload and installs it
@@ -200,80 +222,4 @@ func fetchBundlesJSON(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-}
-
-// bundlesCachePath returns the on-disk cache location, honoring
-// NSELF_BUNDLES_CACHE_PATH (mirrors license.CachePath's LICENSE_CACHE_PATH
-// override convention).
-func bundlesCachePath() (string, error) {
-	if p := os.Getenv("NSELF_BUNDLES_CACHE_PATH"); p != "" {
-		return p, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("determining home directory: %w", err)
-	}
-	return filepath.Join(home, ".cache", "nself", bundlesCacheFileName), nil
-}
-
-// writeBundlesCache atomically writes a freshly fetched bundles.json payload
-// to the local cache (tmpfile + rename, matching license.WriteCache).
-func writeBundlesCache(rawDoc []byte) error {
-	var doc bundlesDoc
-	if err := json.Unmarshal(rawDoc, &doc); err != nil {
-		return err
-	}
-	entry := cachedBundlesDoc{FetchedAt: time.Now().Unix(), Doc: doc}
-	data, err := json.MarshalIndent(entry, "", "  ")
-	if err != nil {
-		return err
-	}
-	path, err := bundlesCachePath()
-	if err != nil {
-		return err
-	}
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("creating bundles cache directory: %w", err)
-	}
-	tmp, err := os.CreateTemp(dir, ".bundles.json.tmp.*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return err
-	}
-	if err := os.Chmod(tmpPath, 0o600); err != nil {
-		_ = os.Remove(tmpPath)
-		return err
-	}
-	return os.Rename(tmpPath, path)
-}
-
-// readBundlesCache reads the last-known-good cached bundles.json. Returns
-// nil, nil if no cache file exists.
-func readBundlesCache() (*cachedBundlesDoc, error) {
-	path, err := bundlesCachePath()
-	if err != nil {
-		return nil, err
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("reading bundles cache: %w", err)
-	}
-	var entry cachedBundlesDoc
-	if err := json.Unmarshal(data, &entry); err != nil {
-		return nil, fmt.Errorf("parsing bundles cache: %w", err)
-	}
-	return &entry, nil
 }

--- a/internal/bundle/registry_cache.go
+++ b/internal/bundle/registry_cache.go
@@ -1,0 +1,88 @@
+// registry_cache.go — local on-disk cache for the last-known-good
+// bundles.json (P6-E4-W3-S3-T10). Split out of registry.go to stay under the
+// 300-line/file cap (internal/repoqa).
+package bundle
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// bundlesCachePath returns the on-disk cache location, honoring
+// NSELF_BUNDLES_CACHE_PATH (mirrors license.CachePath's LICENSE_CACHE_PATH
+// override convention).
+func bundlesCachePath() (string, error) {
+	if p := os.Getenv("NSELF_BUNDLES_CACHE_PATH"); p != "" {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determining home directory: %w", err)
+	}
+	return filepath.Join(home, ".cache", "nself", bundlesCacheFileName), nil
+}
+
+// writeBundlesCache atomically writes a freshly fetched bundles.json payload
+// to the local cache (tmpfile + rename, matching license.WriteCache).
+func writeBundlesCache(rawDoc []byte) error {
+	var doc bundlesDoc
+	if err := json.Unmarshal(rawDoc, &doc); err != nil {
+		return err
+	}
+	entry := cachedBundlesDoc{FetchedAt: time.Now().Unix(), Doc: doc}
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+	path, err := bundlesCachePath()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating bundles cache directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".bundles.json.tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// readBundlesCache reads the last-known-good cached bundles.json. Returns
+// nil, nil if no cache file exists.
+func readBundlesCache() (*cachedBundlesDoc, error) {
+	path, err := bundlesCachePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading bundles cache: %w", err)
+	}
+	var entry cachedBundlesDoc
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, fmt.Errorf("parsing bundles cache: %w", err)
+	}
+	return &entry, nil
+}

--- a/internal/bundle/registry_test.go
+++ b/internal/bundle/registry_test.go
@@ -1,0 +1,117 @@
+package bundle
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestLoad_FetchSuccess_PopulatesFromLiveServer proves Load performs an
+// eager, real HTTP fetch (not a lazy/no-op) and populates the resolver from
+// the response body.
+func TestLoad_FetchSuccess_PopulatesFromLiveServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(fixtureBundlesJSON))
+	}))
+	defer srv.Close()
+	t.Setenv("NSELF_BUNDLES_URL", srv.URL)
+	t.Setenv("NSELF_BUNDLES_CACHE_PATH", t.TempDir()+"/bundles-cache.json")
+
+	if err := Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := Get("claw"); !ok {
+		t.Error("Load did not populate the resolver from the live server response")
+	}
+	// Re-seed the package-wide fixture for tests that run after this one.
+	if err := LoadBytes([]byte(fixtureBundlesJSON)); err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+}
+
+// TestLoad_FetchFailure_FallsBackToCache proves the offline-cache fallback:
+// with a prior successful fetch cached on disk, a subsequent failed fetch
+// still returns the last-known-good bundle set rather than erroring
+// (ticket acceptance criterion #4).
+func TestLoad_FetchFailure_FallsBackToCache(t *testing.T) {
+	cachePath := t.TempDir() + "/bundles-cache.json"
+	t.Setenv("NSELF_BUNDLES_CACHE_PATH", cachePath)
+
+	// First: a successful fetch populates the cache.
+	okSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(fixtureBundlesJSON))
+	}))
+	t.Setenv("NSELF_BUNDLES_URL", okSrv.URL)
+	if err := Load(context.Background()); err != nil {
+		t.Fatalf("priming Load: %v", err)
+	}
+	okSrv.Close()
+
+	// Second: point at a dead server (connection refused) — fetch fails,
+	// must degrade to the cache written above rather than erroring.
+	deadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := deadSrv.URL
+	deadSrv.Close() // now guaranteed connection-refused
+
+	t.Setenv("NSELF_BUNDLES_URL", deadURL)
+	if err := Load(context.Background()); err != nil {
+		t.Fatalf("Load should fall back to cache on fetch failure, got error: %v", err)
+	}
+	if _, ok := Get("claw"); !ok {
+		t.Error("Load did not serve the cached bundle set on fetch failure")
+	}
+
+	// Re-seed for subsequent tests in this package.
+	if err := LoadBytes([]byte(fixtureBundlesJSON)); err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+}
+
+// TestLoad_FetchFailure_NoCache_ReturnsError proves Load does NOT silently
+// serve an empty bundle set when there is neither a successful fetch nor a
+// cache — it must name the network issue (ticket guide step 3).
+func TestLoad_FetchFailure_NoCache_ReturnsError(t *testing.T) {
+	deadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := deadSrv.URL
+	deadSrv.Close()
+
+	t.Setenv("NSELF_BUNDLES_URL", deadURL)
+	t.Setenv("NSELF_BUNDLES_CACHE_PATH", t.TempDir()+"/never-written.json")
+
+	err := Load(context.Background())
+	if err == nil {
+		t.Fatal("expected error when fetch fails and no cache exists")
+	}
+	if !strings.Contains(err.Error(), "fetching bundles.json") {
+		t.Errorf("error should name the network issue, got: %v", err)
+	}
+
+	// Re-seed for subsequent tests in this package.
+	if err := LoadBytes([]byte(fixtureBundlesJSON)); err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+}
+
+func TestLoadBytes_RejectsBadSchemaVersion(t *testing.T) {
+	err := LoadBytes([]byte(`{"schema_version":"1.0.0","bundles":{"task":{"display":"x","tier":"free","plugins":[]}}}`))
+	if err == nil {
+		t.Fatal("expected schema_version rejection")
+	}
+	// Re-seed: LoadBytes must not have clobbered state on validation failure
+	// in a way that breaks other tests.
+	if err := LoadBytes([]byte(fixtureBundlesJSON)); err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+}
+
+func TestLoadBytes_RejectsEmptyBundles(t *testing.T) {
+	err := LoadBytes([]byte(`{"schema_version":"2.0.0","bundles":{}}`))
+	if err == nil {
+		t.Fatal("expected empty-bundles rejection")
+	}
+	if err := LoadBytes([]byte(fixtureBundlesJSON)); err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Ticket P6-E4-W3-S3-T10. `internal/bundle` now resolves bundle membership from `bundles.json` (plugins-pro branch `p6-e4-w2-s1-bundles-json`, PR #85) instead of a hardcoded `canonicalBundles` Go map — eager fetch+cache loader (`internal/bundle/registry.go`), offline cache fallback, clear error when neither fetch nor cache succeeds.
- Canonical slugs are now bundles.json's short form (`claw/chat/family/tv/sentry/clawde/task`); legacy n-prefixed slugs (`nclaw/nchat/nfamily/ntv/nsentry/ntask`) resolve via an extended/corrected alias table (the old `"sentry"->"nsentry"` alias was backwards vs. bundles.json's canonical `"sentry"` slug — corrected, not just extended).
- `nself-plus` (ɳSelf+) is computed as the deduped union of every paid bundle's plugins from bundles.json — never hand-listed (ADR-P6-03).
- Found and fixed a second, independently-drifted hardcoded bundle map in `cmd/commands/bundle.go` that `bundle list`/`bundle info` were actually reading from (not `internal/bundle` at all) — same drift shape as the `isPaidPlugin` allowlist gap that caused cli#318's 404s. Both commands now delegate to `internal/bundle`.

## Test plan
- [x] `go build ./...`
- [x] `GOOS=linux go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/bundle/... ./cmd/commands/...` (all green, including new offline-cache-fallback, bad-schema-rejection, alias-backward-compat, and ɳSelf+-union tests)
- [x] `go test ./internal/repoqa/...` (300-line/file gate)

Depends on plugins-pro PR #85 (bundles.json) merging first; the CF worker endpoint (T8) and ping_api entitlements (T9) land in parallel PRs.