### PR TITLE
db drift --metadata / db reconcile / db verify --role (T-P6-E11-W2-S1-T3, T4)

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -615,6 +615,10 @@
         "hidden": false,
         "aliases": [
           "schema-drift"
+        ],
+        "flags": [
+          "--env",
+          "--metadata"
         ]
       },
       {
@@ -677,6 +681,16 @@
         "path": "nself db pitr",
         "short": "Point-in-time recovery: status, enable, test, restore",
         "hidden": false
+      },
+      {
+        "name": "reconcile",
+        "path": "nself db reconcile",
+        "short": "Push repo-declared Hasura metadata (permissions, relationships, table tracking) to a live instance",
+        "hidden": false,
+        "flags": [
+          "--apply",
+          "--env"
+        ]
       },
       {
         "name": "reset",
@@ -745,6 +759,15 @@
         "path": "nself db soft-delete",
         "short": "Manage soft-delete (deleted_at) patterns across tables",
         "hidden": false
+      },
+      {
+        "name": "verify",
+        "path": "nself db verify",
+        "short": "Verify what a Hasura role can actually reach via role-scoped introspection",
+        "hidden": false,
+        "flags": [
+          "--role"
+        ]
       },
       {
         "name": "verify-checksums",

--- a/.github/surface-parity.json
+++ b/.github/surface-parity.json
@@ -367,7 +367,7 @@
       "group_id": "core",
       "wiki_page": true,
       "mcp_tool": true,
-      "env_vars": "undocumented: AI_AUTO_INSTALL, NSELF_PROFILE, NSELF_SKIP_DB_INIT",
+      "env_vars": "undocumented: NSELF_PROFILE, NSELF_SKIP_DB_INIT",
       "openapi": "n/a (see below)"
     },
     {

--- a/.github/surface-parity.md
+++ b/.github/surface-parity.md
@@ -52,7 +52,7 @@ One row per top-level command (CLI-R17), scored against the four surfaces a comm
 | `nself security` | advanced | yes | no | n/a | n/a (see below) |
 | `nself self-heal` | observe | yes | no | n/a | n/a (see below) |
 | `nself service` | config | yes | yes | n/a | n/a (see below) |
-| `nself start` | core | yes | yes | undocumented: AI_AUTO_INSTALL, NSELF_PROFILE, NSELF_SKIP_DB_INIT | n/a (see below) |
+| `nself start` | core | yes | yes | undocumented: NSELF_PROFILE, NSELF_SKIP_DB_INIT | n/a (see below) |
 | `nself status` | core | yes | yes | n/a | n/a (see below) |
 | `nself stop` | core | yes | yes | n/a | n/a (see below) |
 | `nself telemetry` | account | yes | no | undocumented: NSELF_TELEMETRY, NSELF_TELEMETRY_OPT_OUT | n/a (see below) |

--- a/.github/wiki/Commands.md
+++ b/.github/wiki/Commands.md
@@ -108,7 +108,7 @@ Run `make cmd-inventory` to refresh. **Total top-level commands: 50**
 | `nself clean` | Remove generated artifacts (docker-compose.yml, nginx configs, build cache) | core | — |
 | `nself completion` | Generate shell completion scripts | account | — |
 | `nself config` | Manage project configuration | config | export, features, get, import, list, set, show, validate |
-| `nself db` | Database operations: migrations, backups, restore, seed, shell | data | backup, backup-sync, backup-sync-status, drift, drop, fk-index, hasura, lint, list, migrate, pgbouncer, pitr, reset, reset-checksum, restore, restore-drill, restore-drill-list, rls, seed, shell, soft-delete, verify-checksums |
+| `nself db` | Database operations: migrations, backups, restore, seed, shell | data | backup, backup-sync, backup-sync-status, drift, drop, fk-index, hasura, lint, list, migrate, pgbouncer, pitr, reconcile, reset, reset-checksum, restore, restore-drill, restore-drill-list, rls, seed, shell, soft-delete, verify, verify-checksums |
 | `nself deploy` | Deploy the stack to a target environment | deploy | check-access, environments, health, logs, promote, rollback, status, web |
 | `nself dev` | Start development environment | core | — |
 | `nself doctor` | Run comprehensive system diagnostics | core | — |

--- a/.github/wiki/Config-Env-Vars.md
+++ b/.github/wiki/Config-Env-Vars.md
@@ -21,6 +21,7 @@ All ɳSelf project configuration lives in `.env` (and optionally `.env.local` fo
 - [Auth](#auth)
 - [Nginx and SSL](#nginx-and-ssl)
 - [ɳSelf Admin](#nself-admin)
+- [AI (Zero-Config AI Pool)](#ai-zero-config-ai-pool)
 - [Optional Service Toggles](#optional-service-toggles)
 - [Custom Services (CS\_N)](#custom-services-cs_n)
 - [Computed Variables](#computed-variables)
@@ -84,6 +85,10 @@ These vars control the top-level identity and behavior of a project.
 | `POSTGRES_EXPOSE_PORT` | enum | `auto` | No | Controls host-port binding. `auto` exposes in dev and hides in prod. Accepted values: `auto`, `true`, `false`. |
 | `POSTGRES_MEM_LIMIT` | string | `2g` | No | Docker memory limit for the Postgres container. |
 | `POSTGRES_CPU_LIMIT` | string | `2.0` | No | Docker CPU core limit for the Postgres container. |
+| `PGVECTOR_ENABLED` | bool | `false` | No | Installs the `pgvector` extension for embedding storage and similarity search (RAG). |
+| `PGVECTOR_DIMENSIONS` | int | `1536` | No | Vector column width. Must match the embedding model's output size. |
+| `PGVECTOR_HNSW_M` | int | `16` | No | HNSW index `m` parameter (max connections per node). Higher values improve recall at the cost of index size. |
+| `PGVECTOR_HNSW_EF_CONSTRUCTION` | int | `64` | No | HNSW index `ef_construction` parameter. Higher values improve index quality at the cost of build time. |
 
 **Computed:** `DATABASE_URL` is derived automatically:
 
@@ -122,6 +127,7 @@ Authentication is provided by nHost Auth. These variables configure the Auth ser
 
 | Variable | Type | Default | Required | Description |
 |---|---|---|---|---|
+| `AUTH_ENABLED` | bool | `true` | No | Whether the Auth container is generated at all. Written by `nself init`; set to `false` for a project that provides its own auth. |
 | `AUTH_VERSION` | string | `0.36.0` | No | Docker image tag for the Auth service. |
 | `AUTH_PORT` | int | `4000` | No | Internal port the Auth service listens on. |
 | `AUTH_CLIENT_URL` | string | `http://localhost:3000` | No | URL the Auth service redirects to after OAuth flows complete. |
@@ -184,12 +190,37 @@ The ɳSelf Admin dashboard is an optional local GUI companion that runs at `loca
 
 ---
 
+## AI (Zero-Config AI Pool)
+
+This block is written once by `nself init` into `.env.secrets` (never `.env`, never committed). It replaces the retired `.env.ai` cascade layer (CLI-R18); the vars and their values are unchanged, only the file moved.
+
+| Variable | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `AI_PROFILE` | enum | `auto` | No | Routing profile. Accepted values: `auto`, `local_only`, `pool_only`, `oauth_only`, `custom`. |
+| `AI_AUTO_INSTALL` | bool | `true` | No | When `true` and `NSELF_MASTER_SECRET` is set, `nself start` runs the local AI setup wizard automatically if Ollama isn't already healthy. |
+| `AI_DEFAULT_MODEL` | string | `gemma2:2b` | No | Local model pulled and used for general-purpose requests. |
+| `AI_EMBEDDING_MODEL` | string | `nomic-embed-text` | No | Local model used for embedding generation (RAG, similarity search). |
+| `AI_POOL_AUTO_PROVISION` | bool | `true` | No | Automatically provisions a pooled GCP API key when the local/OAuth tiers can't serve a request. |
+| `AI_BACKGROUND_LOCAL_ONLY` | bool | `true` | No | Restricts background/non-interactive AI tasks to the local tier only, never spending pool or paid budget. |
+| `AI_DAILY_BUDGET_USD` | float | `0` | No | Hard daily cap on paid-tier spend. `0` disables paid tiers entirely (free tiers only). |
+| `AI_MONTHLY_BUDGET_USD` | float | `0` | No | Hard monthly cap on paid-tier spend. `0` disables paid tiers entirely (free tiers only). |
+| `AI_TIMEOUT_LOCAL_MS` | int | `0` | No | Timeout override for the local tier, in milliseconds. `0` falls back to the router's built-in default. |
+| `AI_TIMEOUT_OAUTH_MS` | int | `0` | No | Timeout override for the OAuth tier, in milliseconds. `0` falls back to the router's built-in default. |
+| `AI_TIMEOUT_POOL_MS` | int | `0` | No | Timeout override for the pool tier, in milliseconds. `0` falls back to the router's built-in default. |
+| `AI_TIMEOUT_PAID_MS` | int | `0` | No | Timeout override for the paid tier, in milliseconds. `0` falls back to the router's built-in default. |
+| `AI_POOL_OAUTH_CLIENT_ID` | string | *(empty)* | No | OAuth client ID for the pooled-key provisioning flow. |
+| `AI_POOL_OAUTH_CLIENT_SECRET` | string | *(empty)* | No | OAuth client secret for the pooled-key provisioning flow. |
+| `NSELF_MASTER_SECRET` | string | *(generated)* | **Yes** (once AI is configured) | Key-encryption-key protecting stored OAuth refresh tokens and pooled API keys. Generated once by `nself init` and must never be regenerated or changed afterward — doing so makes all previously-encrypted material unreadable. |
+
+---
+
 ## Optional Service Toggles
 
 These boolean flags enable optional bundled services. Each defaults to `false`. When set to `true`, the service is included in the generated `docker-compose.yml`.
 
 | Variable | Type | Default | Required | Description |
 |---|---|---|---|---|
+| `ADMIN_ENABLED` | bool | `false` | No | Bare (non-`NSELF_`-prefixed) form written by `nself init`'s generated `.env` template alongside the other optional-service toggles. Distinct from `NSELF_ADMIN_ENABLED` above, which is the toggle the Admin dashboard actually reads. |
 | `REDIS_ENABLED` | bool | `false` | No | Enable Redis (caching, sessions, queues). |
 | `MINIO_ENABLED` | bool | `false` | No | Enable MinIO (S3-compatible object storage). |
 | `SEARCH_ENABLED` | bool | `false` | No | Enable MeiliSearch (full-text search). |

--- a/.github/wiki/cmd-db.md
+++ b/.github/wiki/cmd-db.md
@@ -230,6 +230,7 @@ nself db hasura validate
 | `migrate` | Manage database migrations |
 | `pgbouncer` | PgBouncer connection pooler operations |
 | `pitr` | Point-in-time recovery: status, enable, test, restore |
+| `reconcile` | Push repo-declared Hasura metadata (permissions, relationships, table tracking) to a live instance |
 | `reset` | Drop and recreate database (DESTRUCTIVE) |
 | `reset-checksum` | Reset stored checksum for a migration (dangerous) |
 | `restore` | Restore from backup |
@@ -239,6 +240,7 @@ nself db hasura validate
 | `seed` | Database seeding: run, list, verify, graph |
 | `shell` | Open psql interactive shell |
 | `soft-delete` | Manage soft-delete (deleted_at) patterns across tables |
+| `verify` | Verify what a Hasura role can actually reach via role-scoped introspection |
 | `verify-checksums` | Verify migration file checksums against stored values |
 <!-- END GENERATED:subcommands -->
 

--- a/.github/wiki/llms.txt
+++ b/.github/wiki/llms.txt
@@ -246,6 +246,7 @@ Subcommands:
 - `migrate` — Manage database migrations
 - `pgbouncer` — PgBouncer connection pooler operations
 - `pitr` — Point-in-time recovery: status, enable, test, restore
+- `reconcile` — Push repo-declared Hasura metadata (permissions, relationships, table tracking) to a live instance
 - `reset` — Drop and recreate database (DESTRUCTIVE)
 - `reset-checksum` — Reset stored checksum for a migration (dangerous)
 - `restore` — Restore from backup
@@ -255,6 +256,7 @@ Subcommands:
 - `seed` — Database seeding: run, list, verify, graph
 - `shell` — Open psql interactive shell
 - `soft-delete` — Manage soft-delete (deleted_at) patterns across tables
+- `verify` — Verify what a Hasura role can actually reach via role-scoped introspection
 - `verify-checksums` — Verify migration file checksums against stored values
 
 Full page: [[cmd-db]]

--- a/cmd/commands/db_audit.go
+++ b/cmd/commands/db_audit.go
@@ -44,8 +44,16 @@ Theme 25 mandates 5 columns on every np_* table:
 
 Subcommands:
   scan   Report missing columns per table
-  fix    Generate migration SQL to add missing columns`,
+  fix    Generate migration SQL to add missing columns
+
+Flags:
+  --metadata  Detect Hasura METADATA drift instead (permissions, relationships,
+              table tracking) against a live instance — see 'nself db drift --metadata'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		metadata, _ := cmd.Flags().GetBool("metadata")
+		if metadata {
+			return runDBDriftMetadata(cmd, args)
+		}
 		return cmd.Help()
 	},
 }
@@ -75,6 +83,8 @@ func init() {
 
 	dbDriftScanCmd.Flags().String("schema", "", "Filter to specific schema")
 	dbDriftFixCmd.Flags().Bool("all", false, "Fix drift on all drifted tables")
+	dbDriftCmd.Flags().Bool("metadata", false, "Detect Hasura metadata drift (permissions, relationships, table tracking) instead of column drift")
+	dbDriftCmd.Flags().String("env", "", "Project directory to read hasura/metadata/** from (default: current directory)")
 
 	dbDriftCmd.AddCommand(dbDriftScanCmd)
 	dbDriftCmd.AddCommand(dbDriftFixCmd)

--- a/cmd/commands/db_drift_metadata.go
+++ b/cmd/commands/db_drift_metadata.go
@@ -1,0 +1,55 @@
+package commands
+
+// Purpose: RunE for "nself db drift --metadata" — Hasura metadata drift
+// (permissions/relationships/table tracking), as opposed to the sibling
+// "nself db drift scan/fix" which only checks np_* column conventions.
+// Inputs: the cobra command/args. Outputs: printed findings; exits 1 (via
+// returned error) when drift is found, matching the ask's literal command
+// shape.
+// Constraints: split into its own file (db_audit.go stays the flag/RunE
+// wiring, db_drift.go stays the column-drift implementation).
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nself-org/cli/internal/database"
+	"github.com/spf13/cobra"
+)
+
+func runDBDriftMetadata(cmd *cobra.Command, _ []string) error {
+	cfg, err := loadProjectConfig()
+	if err != nil {
+		return err
+	}
+
+	dir, _ := cmd.Flags().GetString("env")
+	if dir == "" {
+		dir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getting working directory: %w", err)
+		}
+	}
+
+	findings, err := database.ScanMetadataDrift(cmd.Context(), cfg, dir)
+	if err != nil {
+		return fmt.Errorf("scan metadata drift: %w", err)
+	}
+
+	if len(findings) == 0 {
+		fmt.Println("Hasura metadata matches the repo: no drift found.")
+		return nil
+	}
+
+	fmt.Printf("Hasura metadata drift: %d finding(s)\n\n", len(findings))
+	for _, f := range findings {
+		if f.Role != "" {
+			fmt.Printf("  %s [%s/%s]: %s\n", f.Table, f.Kind, f.Role, f.Detail)
+		} else {
+			fmt.Printf("  %s [%s]: %s\n", f.Table, f.Kind, f.Detail)
+		}
+	}
+	fmt.Println("\nRun 'nself db reconcile' to preview a fix, or 'nself db reconcile --apply' to push it.")
+
+	return fmt.Errorf("%d metadata drift finding(s)", len(findings))
+}

--- a/cmd/commands/db_reconcile.go
+++ b/cmd/commands/db_reconcile.go
@@ -1,0 +1,81 @@
+package commands
+
+// Purpose: "nself db reconcile [--apply]" — push repo-declared Hasura
+// metadata drift (found by ScanMetadataDrift) to a live instance. Dry-run by
+// default; --apply is required to actually write.
+// Inputs: the cobra command/args. Outputs: the printed plan, and (with
+// --apply) the applied result, or an error.
+// Constraints: see internal/database/metadata_reconcile.go for the safety
+// design (refuse-both-directions, targeted ops, one atomic bulk call).
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nself-org/cli/internal/database"
+	"github.com/spf13/cobra"
+)
+
+var dbReconcileCmd = &cobra.Command{
+	Use:   "reconcile",
+	Short: "Push repo-declared Hasura metadata (permissions, relationships, table tracking) to a live instance",
+	Long: `Reconcile live Hasura metadata toward what hasura/metadata/** declares.
+
+Dry-run by default: prints the plan and exits 0 without writing. Pass --apply
+to push it. Never issues a full 'hasura metadata apply' (which replaces the
+whole document and would untrack hasura-auth's own tables) — every change is
+a targeted per-object call, sent as one atomic bulk operation.
+
+Refuses unconditionally (no bypass) if the repo declares a table that does
+not exist in Postgres, or if live tracks a table the repo does not declare.`,
+	RunE: runDBReconcile,
+}
+
+func init() {
+	dbReconcileCmd.Flags().Bool("apply", false, "Actually push the plan (default: dry-run)")
+	dbReconcileCmd.Flags().String("env", "", "Project directory to read hasura/metadata/** from (default: current directory)")
+	dbCmd.AddCommand(dbReconcileCmd)
+}
+
+func runDBReconcile(cmd *cobra.Command, _ []string) error {
+	cfg, err := loadProjectConfig()
+	if err != nil {
+		return err
+	}
+
+	dir, _ := cmd.Flags().GetString("env")
+	if dir == "" {
+		dir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getting working directory: %w", err)
+		}
+	}
+	apply, _ := cmd.Flags().GetBool("apply")
+
+	plan, err := database.BuildReconcilePlan(cmd.Context(), cfg, dir)
+	if err != nil {
+		return fmt.Errorf("build reconcile plan: %w", err)
+	}
+
+	if len(plan.Changes) == 0 {
+		fmt.Println("Nothing to reconcile: live metadata already matches the repo.")
+		return nil
+	}
+
+	fmt.Printf("%d change(s):\n", len(plan.Changes))
+	for _, c := range plan.Changes {
+		fmt.Printf("  - %s: %s\n", c.Table, c.Description)
+	}
+
+	if !apply {
+		fmt.Println("\nDry run. Re-run with --apply to push these to the live instance.")
+		return nil
+	}
+
+	fmt.Printf("\nApplying %d change(s) as one transaction...\n", len(plan.BulkOps))
+	if err := plan.Apply(cmd.Context(), cfg); err != nil {
+		return fmt.Errorf("apply reconcile plan: %w", err)
+	}
+	fmt.Println("Reconcile complete.")
+	return nil
+}

--- a/cmd/commands/db_verify.go
+++ b/cmd/commands/db_verify.go
@@ -1,0 +1,56 @@
+package commands
+
+// Purpose: "nself db verify --role <role>" — role-scoped GraphQL
+// introspection against a live Hasura instance, answering "is this feature
+// reachable by an actual role" without a hand-rolled curl command.
+// Inputs: the cobra command/args. Outputs: printed query/mutation counts for
+// the role, or an error.
+// Constraints: see internal/database/metadata_verify.go — sent with the
+// X-Hasura-Role header and no admin secret.
+
+import (
+	"fmt"
+
+	"github.com/nself-org/cli/internal/database"
+	"github.com/spf13/cobra"
+)
+
+var dbVerifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Verify what a Hasura role can actually reach via role-scoped introspection",
+	Long: `Runs a GraphQL introspection query against the live Hasura instance using
+Hasura's role-impersonation mechanism (admin secret + X-Hasura-Role: <role>),
+so the result reflects exactly what that role — and only that role — can
+reach. The admin secret is read from the running Hasura container, never
+from .env, and is used only to authenticate the impersonation; a bare role
+header with no secret is not honored by Hasura and always falls back to the
+unauthorized role.`,
+	RunE: runDBVerify,
+}
+
+func init() {
+	dbVerifyCmd.Flags().String("role", "", "Hasura role to introspect (required)")
+	dbCmd.AddCommand(dbVerifyCmd)
+}
+
+func runDBVerify(cmd *cobra.Command, _ []string) error {
+	role, _ := cmd.Flags().GetString("role")
+	if role == "" {
+		return fmt.Errorf("--role is required, e.g. 'nself db verify --role user'")
+	}
+
+	cfg, err := loadProjectConfig()
+	if err != nil {
+		return err
+	}
+
+	result, err := database.VerifyRoleReachability(cmd.Context(), cfg, role)
+	if err != nil {
+		return fmt.Errorf("verify role %q: %w", role, err)
+	}
+
+	fmt.Printf("Role %q can reach:\n", result.Role)
+	fmt.Printf("  queries:   %d\n", result.Queries)
+	fmt.Printf("  mutations: %d\n", result.Mutations)
+	return nil
+}

--- a/internal/config/loader_known_vars_core.go
+++ b/internal/config/loader_known_vars_core.go
@@ -36,6 +36,12 @@ var knownEnvVarsCore = []string{
 	"POSTGRES_EXPOSE_PORT",
 	"POSTGRES_MEM_LIMIT",
 	"POSTGRES_CPU_LIMIT",
+	// pgvector extension toggles, written by internal/setup/setup_env_files.go
+	// (gap #4, msg-2026-04-30-env-var-warnings-on-build.md).
+	"PGVECTOR_ENABLED",
+	"PGVECTOR_DIMENSIONS",
+	"PGVECTOR_HNSW_M",
+	"PGVECTOR_HNSW_EF_CONSTRUCTION",
 
 	// Hasura
 	"HASURA_VERSION",
@@ -71,6 +77,11 @@ var knownEnvVarsCore = []string{
 	"ACTION_HANDLER_URL",
 
 	// Auth
+	// AUTH_ENABLED is written by internal/setup/setup_env_files.go (gap #4,
+	// msg-2026-04-30-env-var-warnings-on-build.md) but has no AuthConfig
+	// struct field — it toggles whether the auth service is generated at all,
+	// checked ahead of the per-field AuthConfig parse.
+	"AUTH_ENABLED",
 	"AUTH_VERSION",
 	"AUTH_PORT",
 	"AUTH_CLIENT_URL",

--- a/internal/config/loader_known_vars_ops.go
+++ b/internal/config/loader_known_vars_ops.go
@@ -144,4 +144,25 @@ var knownEnvVarsOps = []string{
 	"NO_COLOR",
 	// Postgres internal port (documentation-only; always 5432).
 	"POSTGRES_INTERNAL_PORT",
+
+	// AI-tier config block, written to .env.secrets by internal/setup/envai.go
+	// (CLI-R18) — not read via a struct env tag, hence absent here until gap #4
+	// (msg-2026-04-30-env-var-warnings-on-build.md).
+	"AI_PROFILE",
+	"AI_AUTO_INSTALL",
+	"AI_DEFAULT_MODEL",
+	"AI_EMBEDDING_MODEL",
+	"AI_POOL_AUTO_PROVISION",
+	"AI_BACKGROUND_LOCAL_ONLY",
+	"AI_DAILY_BUDGET_USD",
+	"AI_MONTHLY_BUDGET_USD",
+	"AI_TIMEOUT_LOCAL_MS",
+	"AI_TIMEOUT_OAUTH_MS",
+	"AI_TIMEOUT_POOL_MS",
+	"AI_TIMEOUT_PAID_MS",
+	"AI_POOL_OAUTH_CLIENT_ID",
+	"AI_POOL_OAUTH_CLIENT_SECRET",
+	// KEK for OAuth/API-key encryption in the zero-config AI pool — see
+	// internal/setup/envai.go's anti-clobber guarantee.
+	"NSELF_MASTER_SECRET",
 }

--- a/internal/config/loader_known_vars_storage.go
+++ b/internal/config/loader_known_vars_storage.go
@@ -80,6 +80,11 @@ var knownEnvVarsStorage = []string{
 	"NSELF_ADMIN_ENABLED",
 	"NSELF_ADMIN_VERSION",
 	"NSELF_ADMIN_PORT",
+	// Bare ADMIN_ENABLED is a distinct, non-NSELF_-prefixed form also written
+	// by internal/setup/setup_env_files.go (gap #4,
+	// msg-2026-04-30-env-var-warnings-on-build.md) — both forms exist in the
+	// codebase and must both be recognized.
+	"ADMIN_ENABLED",
 	"NSELF_ADMIN_ROUTE",
 	"NSELF_ADMIN_DEV",
 	"NSELF_ADMIN_DEV_PORT",

--- a/internal/database/metadata_drift.go
+++ b/internal/database/metadata_drift.go
@@ -1,0 +1,239 @@
+package database
+
+// Purpose: detects Hasura METADATA drift (table tracking + permissions +
+// relationships) between a project's committed hasura/metadata/** files and
+// a live Hasura instance. This is distinct from ScanSchemaDrift
+// (schema_drift.go), which only checks np_* table COLUMN conventions.
+// Inputs: a context, *config.Config, and the project directory containing
+// hasura/metadata/**.
+// Outputs: []MetadataDriftFinding naming the exact table/role/field that
+// differs, or an error.
+// Constraints: ported from ntask/backend/scripts/metadata-diff.sh's proven
+// design — read-only, never mutates. Two footguns closed here on purpose:
+//  1. Hasura omits keys that hold their default value (e.g.
+//     allow_aggregations: false), while repo YAML often states them
+//     explicitly. Comparing raw values reports phantom differences that get
+//     the tool ignored, which is exactly how the real drift this ticket
+//     responds to (msg-2026-08-22) stayed invisible. See normalizePermission.
+//  2. hasura-auth creates tables in the `auth` schema (refresh_tokens,
+//     roles, user_providers, ...) that legitimately exist live and are never
+//     declared in project metadata. Flagging them is the other class of
+//     false positive that got the original tool ignored. See
+//     hasuraAuthOwnedTables (metadata_types.go).
+//
+// Live metadata fetch (incl. the admin-secret-via-docker-inspect footgun
+// fix) lives in metadata_live.go; shared types live in metadata_types.go.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// permissionDefaults are the values Hasura omits from export_metadata when a
+// permission field holds its default. Both sides must be normalized to these
+// before comparison or every export produces phantom drift.
+var permissionDefaults = map[string]interface{}{
+	"allow_aggregations": false,
+	"computed_fields":    []interface{}{},
+	"columns":            []interface{}{},
+	"set":                map[string]interface{}{},
+	"backend_only":       false,
+	"filter":             map[string]interface{}{},
+	"check":              map[string]interface{}{},
+}
+
+// normalizePermission fills in Hasura's default-omitted keys, drops the
+// comment field (metadata-only, never functional), and sorts the columns
+// list, so that semantically-identical permissions compare equal regardless
+// of which side omitted a default.
+func normalizePermission(p map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(p)+len(permissionDefaults))
+	for k, v := range p {
+		out[k] = v
+	}
+	for k, def := range permissionDefaults {
+		if _, ok := out[k]; !ok {
+			out[k] = def
+		}
+	}
+	delete(out, "comment")
+	if cols, ok := out["columns"].([]interface{}); ok {
+		strs := make([]string, 0, len(cols))
+		for _, c := range cols {
+			strs = append(strs, fmt.Sprint(c))
+		}
+		sort.Strings(strs)
+		colsOut := make([]interface{}, len(strs))
+		for i, s := range strs {
+			colsOut[i] = s
+		}
+		out["columns"] = colsOut
+	}
+	return out
+}
+
+// permissionEqual reports whether two permission maps are equal after
+// normalization. json.Marshal sorts map keys, giving a stable comparison key.
+func permissionEqual(a, b map[string]interface{}) bool {
+	aj, _ := json.Marshal(normalizePermission(a))
+	bj, _ := json.Marshal(normalizePermission(b))
+	return string(aj) == string(bj)
+}
+
+// diffPermissionFields returns the sorted list of top-level keys that differ
+// between two normalized permission maps, e.g. ["columns","filter"] — used to
+// name the exact field that drifted.
+func diffPermissionFields(live, repo map[string]interface{}) []string {
+	nl, nr := normalizePermission(live), normalizePermission(repo)
+	keys := map[string]bool{}
+	for k := range nl {
+		keys[k] = true
+	}
+	for k := range nr {
+		keys[k] = true
+	}
+	var diffs []string
+	for k := range keys {
+		lj, _ := json.Marshal(nl[k])
+		rj, _ := json.Marshal(nr[k])
+		if string(lj) != string(rj) {
+			diffs = append(diffs, k)
+		}
+	}
+	sort.Strings(diffs)
+	return diffs
+}
+
+// MetadataDriftFinding is one row of Hasura metadata drift: a specific
+// table/role/kind combination where committed metadata and the live Hasura
+// instance disagree.
+type MetadataDriftFinding struct {
+	Table  string // "schema.name"
+	Role   string // permission role; empty for a table/relationship finding
+	Kind   string // "table" | "relationship" | "insert" | "select" | "update" | "delete"
+	Detail string
+}
+
+// ScanMetadataDrift compares committed hasura/metadata/** against a live
+// Hasura instance and returns every finding. An empty result means clean.
+func ScanMetadataDrift(ctx context.Context, cfg *config.Config, projectDir string) ([]MetadataDriftFinding, error) {
+	repo, err := loadRepoTables(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	live, err := fetchLiveTables(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return diffMetadataTables(repo, live), nil
+}
+
+// diffMetadataTables is the pure comparison at the heart of ScanMetadataDrift,
+// split out so it can be unit tested without a live Hasura instance.
+func diffMetadataTables(repo, live map[string]hasuraTable) []MetadataDriftFinding {
+	var findings []MetadataDriftFinding
+
+	liveKeys := make([]string, 0, len(live))
+	for k := range live {
+		liveKeys = append(liveKeys, k)
+	}
+	sort.Strings(liveKeys)
+	for _, key := range liveKeys {
+		if _, ok := repo[key]; !ok && !hasuraAuthOwnedTables[key] {
+			findings = append(findings, MetadataDriftFinding{
+				Table: key, Kind: "table",
+				Detail: "tracked live, not declared in repo metadata",
+			})
+		}
+	}
+
+	repoKeys := make([]string, 0, len(repo))
+	for k := range repo {
+		repoKeys = append(repoKeys, k)
+	}
+	sort.Strings(repoKeys)
+
+	for _, key := range repoKeys {
+		rt := repo[key]
+		lt, exists := live[key]
+		if !exists {
+			findings = append(findings, MetadataDriftFinding{
+				Table: key, Kind: "table",
+				Detail: "declared in repo metadata, not tracked live",
+			})
+			continue
+		}
+		findings = append(findings, diffTableRelationships(key, lt, rt)...)
+		findings = append(findings, diffTablePermissions(key, lt, rt)...)
+	}
+
+	return findings
+}
+
+func diffTableRelationships(key string, lt, rt hasuraTable) []MetadataDriftFinding {
+	var findings []MetadataDriftFinding
+	for _, relSet := range [][2][]hasuraRelationship{
+		{lt.ObjectRelationships, rt.ObjectRelationships},
+		{lt.ArrayRelationships, rt.ArrayRelationships},
+	} {
+		have := map[string]bool{}
+		for _, r := range relSet[0] {
+			have[r.Name] = true
+		}
+		for _, r := range relSet[1] {
+			if !have[r.Name] {
+				findings = append(findings, MetadataDriftFinding{
+					Table: key, Kind: "relationship",
+					Detail: fmt.Sprintf("relationship %q declared in repo, missing live", r.Name),
+				})
+			}
+		}
+	}
+	return findings
+}
+
+func diffTablePermissions(key string, lt, rt hasuraTable) []MetadataDriftFinding {
+	var findings []MetadataDriftFinding
+	for _, pk := range permissionKinds {
+		rperm := indexPermissionsByRole(rt.tablePermissions(pk.short))
+		lperm := indexPermissionsByRole(lt.tablePermissions(pk.short))
+		roles := make([]string, 0, len(rperm))
+		for role := range rperm {
+			roles = append(roles, role)
+		}
+		sort.Strings(roles)
+		for _, role := range roles {
+			rp := rperm[role]
+			lp, ok := lperm[role]
+			if !ok {
+				findings = append(findings, MetadataDriftFinding{
+					Table: key, Role: role, Kind: pk.short,
+					Detail: fmt.Sprintf("%s permission for role %q declared in repo, missing live", pk.short, role),
+				})
+				continue
+			}
+			if !permissionEqual(lp, rp) {
+				fields := diffPermissionFields(lp, rp)
+				findings = append(findings, MetadataDriftFinding{
+					Table: key, Role: role, Kind: pk.short,
+					Detail: fmt.Sprintf("%s permission for role %q differs live vs repo: %s",
+						pk.short, role, strings.Join(fields, ", ")),
+				})
+			}
+		}
+	}
+	return findings
+}
+
+func indexPermissionsByRole(perms []hasuraPermission) map[string]map[string]interface{} {
+	out := make(map[string]map[string]interface{}, len(perms))
+	for _, p := range perms {
+		out[p.Role] = p.Permission
+	}
+	return out
+}

--- a/internal/database/metadata_drift_test.go
+++ b/internal/database/metadata_drift_test.go
@@ -1,0 +1,141 @@
+package database
+
+import "testing"
+
+func TestNormalizePermission_FillsDefaultsAndSortsColumns(t *testing.T) {
+	live := map[string]interface{}{
+		"columns": []interface{}{"b", "a"},
+		"filter":  map[string]interface{}{"owner_id": "X-Hasura-User-Id"},
+	}
+	// repo states allow_aggregations explicitly even though it's the default —
+	// this must NOT be reported as drift.
+	repo := map[string]interface{}{
+		"columns":            []interface{}{"a", "b"},
+		"filter":             map[string]interface{}{"owner_id": "X-Hasura-User-Id"},
+		"allow_aggregations": false,
+	}
+	if !permissionEqual(live, repo) {
+		t.Fatalf("expected permissions to be equal after normalization, got diff fields: %v",
+			diffPermissionFields(live, repo))
+	}
+}
+
+func TestPermissionEqual_DetectsRealDifference(t *testing.T) {
+	live := map[string]interface{}{"columns": []interface{}{"a", "b"}}
+	repo := map[string]interface{}{"columns": []interface{}{"a", "b", "c"}}
+	if permissionEqual(live, repo) {
+		t.Fatal("expected permissions to differ (repo has an extra column)")
+	}
+	fields := diffPermissionFields(live, repo)
+	if len(fields) != 1 || fields[0] != "columns" {
+		t.Fatalf("expected diff on [columns], got %v", fields)
+	}
+}
+
+func TestDiffMetadataTables_IgnoresHasuraAuthOwnedTables(t *testing.T) {
+	repo := map[string]hasuraTable{}
+	live := map[string]hasuraTable{
+		"auth.refresh_tokens": {Table: hasuraTableRef{Schema: "auth", Name: "refresh_tokens"}},
+	}
+	findings := diffMetadataTables(repo, live)
+	if len(findings) != 0 {
+		t.Fatalf("expected zero false-positive findings for hasura-auth-owned tables, got %+v", findings)
+	}
+}
+
+func TestDiffMetadataTables_FlagsUnexpectedLiveOnlyTable(t *testing.T) {
+	repo := map[string]hasuraTable{}
+	live := map[string]hasuraTable{
+		"public.np_widgets": {Table: hasuraTableRef{Schema: "public", Name: "np_widgets"}},
+	}
+	findings := diffMetadataTables(repo, live)
+	if len(findings) != 1 || findings[0].Kind != "table" {
+		t.Fatalf("expected one table finding for an untracked-in-repo live table, got %+v", findings)
+	}
+}
+
+func TestDiffMetadataTables_FlagsUntrackedRepoTable(t *testing.T) {
+	repo := map[string]hasuraTable{
+		"public.np_widgets": {Table: hasuraTableRef{Schema: "public", Name: "np_widgets"}},
+	}
+	live := map[string]hasuraTable{}
+	findings := diffMetadataTables(repo, live)
+	if len(findings) != 1 || findings[0].Detail == "" {
+		t.Fatalf("expected one table finding for a repo table not tracked live, got %+v", findings)
+	}
+}
+
+func TestDiffMetadataTables_FlagsMissingLivePermission(t *testing.T) {
+	repo := map[string]hasuraTable{
+		"public.np_exports": {
+			Table: hasuraTableRef{Schema: "public", Name: "np_exports"},
+			SelectPermissions: []hasuraPermission{
+				{Role: "user", Permission: map[string]interface{}{
+					"columns": []interface{}{"id", "storage_key"},
+					"filter":  map[string]interface{}{"owner_id": "X-Hasura-User-Id"},
+				}},
+			},
+		},
+	}
+	live := map[string]hasuraTable{
+		"public.np_exports": {
+			Table: hasuraTableRef{Schema: "public", Name: "np_exports"},
+			// select permission absent entirely on live — the exact class of
+			// gap the 2026-08-22 report proved exploitable.
+		},
+	}
+	findings := diffMetadataTables(repo, live)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one finding, got %+v", findings)
+	}
+	f := findings[0]
+	if f.Table != "public.np_exports" || f.Role != "user" || f.Kind != "select" {
+		t.Fatalf("finding did not name the exact table/role/kind: %+v", f)
+	}
+}
+
+func TestDiffMetadataTables_FlagsChangedColumnsPermission(t *testing.T) {
+	repo := map[string]hasuraTable{
+		"public.np_exports": {
+			Table: hasuraTableRef{Schema: "public", Name: "np_exports"},
+			SelectPermissions: []hasuraPermission{
+				{Role: "user", Permission: map[string]interface{}{
+					"columns": []interface{}{"id", "storage_key", "owner_id"},
+				}},
+			},
+		},
+	}
+	live := map[string]hasuraTable{
+		"public.np_exports": {
+			Table: hasuraTableRef{Schema: "public", Name: "np_exports"},
+			SelectPermissions: []hasuraPermission{
+				{Role: "user", Permission: map[string]interface{}{
+					// live is missing "owner_id" — an intentionally-introduced
+					// drift, per this ticket's acceptance criteria.
+					"columns": []interface{}{"id", "storage_key"},
+				}},
+			},
+		},
+	}
+	findings := diffMetadataTables(repo, live)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one finding, got %+v", findings)
+	}
+	if findings[0].Detail == "" {
+		t.Fatal("expected a non-empty detail naming the drifted field")
+	}
+}
+
+func TestDiffMetadataTables_CleanIsEmpty(t *testing.T) {
+	table := hasuraTable{
+		Table: hasuraTableRef{Schema: "public", Name: "np_widgets"},
+		SelectPermissions: []hasuraPermission{
+			{Role: "user", Permission: map[string]interface{}{"columns": []interface{}{"id"}}},
+		},
+	}
+	repo := map[string]hasuraTable{"public.np_widgets": table}
+	live := map[string]hasuraTable{"public.np_widgets": table}
+	if findings := diffMetadataTables(repo, live); len(findings) != 0 {
+		t.Fatalf("expected zero findings for identical metadata, got %+v", findings)
+	}
+}

--- a/internal/database/metadata_live.go
+++ b/internal/database/metadata_live.go
@@ -1,0 +1,113 @@
+package database
+
+// Purpose: reads live Hasura metadata for the drift/reconcile/verify trio,
+// with the Hasura admin secret sourced from the RUNNING container rather
+// than cfg.Hasura.AdminSecret / .env on disk.
+// Inputs: context, *config.Config.
+// Outputs: parsed table metadata keyed by "schema.name", or an error.
+// Constraints: split out of metadata_drift.go to respect the 300-line file
+// cap (ASI Policy 3) — pure move, no behavior change.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+
+	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/httptimeout"
+)
+
+// hasuraContainer returns the Hasura container name for the project. This
+// MUST match the container_name nself build actually writes
+// (internal/compose/core_services.go: "%s_hasura") — see the postgres
+// equivalent's cautionary note in internal/plugin/schema.go.
+func hasuraContainer(cfg *config.Config) string {
+	return cfg.ProjectName + "_hasura"
+}
+
+// readHasuraAdminSecretFromContainer reads HASURA_GRAPHQL_ADMIN_SECRET from
+// the RUNNING Hasura container's environment via `docker inspect`, never
+// from cfg.Hasura.AdminSecret / .env on disk.
+//
+// Both the 2026-08-21 Unity report and the 2026-08-22 ntask report hit the
+// same footgun independently: a stale .env admin secret silently downgrades
+// the request to the anonymous role instead of failing auth, surfacing as a
+// confusing "field not found in type: 'query_root'" error rather than an
+// authentication error. Reading the secret the container actually has
+// closes that hole for the drift/reconcile/verify commands built here.
+func readHasuraAdminSecretFromContainer(ctx context.Context, cfg *config.Config) (string, error) {
+	container := hasuraContainer(cfg)
+	cmd := exec.CommandContext(ctx, "docker", "inspect", container,
+		"--format", "{{range .Config.Env}}{{println .}}{{end}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("docker inspect %s (is the stack running? try 'nself start'): %w", container, err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if v, ok := strings.CutPrefix(line, "HASURA_GRAPHQL_ADMIN_SECRET="); ok {
+			if v == "" {
+				return "", fmt.Errorf("HASURA_GRAPHQL_ADMIN_SECRET is empty in the running %s container", container)
+			}
+			return v, nil
+		}
+	}
+	return "", fmt.Errorf("HASURA_GRAPHQL_ADMIN_SECRET not found in %s container environment", container)
+}
+
+// postMetadataAdmin sends a metadata API request authenticated with an
+// explicit admin secret (rather than hasura.go's postMetadata, which reads
+// cfg.Hasura.AdminSecret). Shares metadataRequest/hasuraMetadataURL from
+// hasura.go — same package, no duplication of the URL/request shape.
+func postMetadataAdmin(ctx context.Context, cfg *config.Config, secret, reqType string, args interface{}) ([]byte, error) {
+	body, err := json.Marshal(metadataRequest{Type: reqType, Args: args})
+	if err != nil {
+		return nil, fmt.Errorf("marshal metadata request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hasuraMetadataURL(cfg), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create metadata request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hasura-Admin-Secret", secret)
+
+	resp, err := httptimeout.Default.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("hasura metadata request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody := new(bytes.Buffer)
+	if _, err := respBody.ReadFrom(resp.Body); err != nil {
+		return nil, fmt.Errorf("read metadata response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("hasura metadata API returned %d: %s", resp.StatusCode, respBody.String())
+	}
+	return respBody.Bytes(), nil
+}
+
+// fetchLiveTables exports live Hasura metadata (admin secret read from the
+// running container) and returns its tracked tables keyed by "schema.name".
+func fetchLiveTables(ctx context.Context, cfg *config.Config) (map[string]hasuraTable, error) {
+	secret, err := readHasuraAdminSecretFromContainer(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	body, err := postMetadataAdmin(ctx, cfg, secret, "export_metadata", struct{}{})
+	if err != nil {
+		return nil, fmt.Errorf("export live metadata: %w", err)
+	}
+	var doc hasuraMetadataDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("parse live metadata: %w", err)
+	}
+	var all []hasuraTable
+	for _, src := range doc.Sources {
+		all = append(all, src.Tables...)
+	}
+	return tablesByKey(all), nil
+}

--- a/internal/database/metadata_reconcile.go
+++ b/internal/database/metadata_reconcile.go
@@ -1,0 +1,257 @@
+package database
+
+// Purpose: nself db reconcile — push repo-declared Hasura metadata (table
+// tracking, relationships, permissions) to a live instance. Ported from
+// ntask/backend/scripts/metadata-reconcile.sh's proven design.
+// Inputs: context, *config.Config, project directory.
+// Outputs: a ReconcilePlan describing every change, or an error.
+// Constraints:
+//   - Never issues `hasura metadata apply` / replace_metadata: that REPLACES
+//     the whole document and would untrack hasura-auth's own tables
+//     (verified against ntask production 2026-08-22: repo declares 28
+//     tables, production tracks 35). Every op here is a targeted per-object
+//     call instead, and the whole plan is sent as ONE Hasura `bulk` call so a
+//     failure rolls back instead of leaving a partial apply — this exact
+//     partial-apply outage happened once by hand on ntask's
+//     np_member_profiles.
+//   - Relationships are ordered before permissions: a permission whose
+//     filter/check traverses a relationship fails with "Inconsistent object"
+//     if the relationship doesn't exist yet, and if the OLD permission was
+//     already dropped in the same batch the table is left with none — an
+//     outage. Table tracking is ordered first: neither relationships nor
+//     permissions can attach to an untracked table.
+//   - refuseUnsafeReconcile (called unconditionally, no --force escape)
+//     blocks the two most dangerous failure modes from the 2026-08-21/08-22
+//     inbox reports: reconciling toward a table that does not exist in
+//     Postgres at all, and reconciling while live has a non-hasura-auth
+//     table the repo does not declare (a strong signal the repo metadata
+//     itself is stale/incomplete, not that live is wrong).
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// ReconcileChange is one human-readable line of a reconcile plan.
+type ReconcileChange struct {
+	Table       string
+	Description string
+}
+
+// ReconcilePlan is dry-run output: the exact bulk operations Apply would
+// send, plus a human-readable change list.
+type ReconcilePlan struct {
+	BulkOps []map[string]interface{}
+	Changes []ReconcileChange
+}
+
+// BuildReconcilePlan loads repo + live metadata, refuses on either unsafe
+// condition (see package doc), and returns the ordered, targeted plan to
+// bring live into agreement with the repo. It never touches a live table the
+// repo doesn't declare, and never removes anything.
+func BuildReconcilePlan(ctx context.Context, cfg *config.Config, projectDir string) (ReconcilePlan, error) {
+	repo, err := loadRepoTables(projectDir)
+	if err != nil {
+		return ReconcilePlan{}, err
+	}
+	live, err := fetchLiveTables(ctx, cfg)
+	if err != nil {
+		return ReconcilePlan{}, err
+	}
+	if err := refuseUnsafeReconcile(ctx, cfg, repo, live); err != nil {
+		return ReconcilePlan{}, err
+	}
+	return buildReconcilePlanPure(repo, live), nil
+}
+
+// refuseUnsafeReconcile blocks reconcile before any write when either unsafe
+// condition from the package doc is present. Unconditional — no bypass flag
+// exists that could reintroduce the ntask hasura-auth-untrack outage.
+func refuseUnsafeReconcile(ctx context.Context, cfg *config.Config, repo, live map[string]hasuraTable) error {
+	for key, rt := range repo {
+		if _, ok := live[key]; ok {
+			continue
+		}
+		exists, err := postgresTableExists(ctx, cfg, rt.Table.Schema, rt.Table.Name)
+		if err != nil {
+			return fmt.Errorf("refuse-check table existence for %s: %w", key, err)
+		}
+		if !exists {
+			return fmt.Errorf(
+				"refusing to reconcile: repo metadata declares %s but no such table exists in "+
+					"Postgres — fix the repo metadata or run migrations before reconciling", key)
+		}
+	}
+
+	for key := range live {
+		if hasuraAuthOwnedTables[key] {
+			continue
+		}
+		if _, ok := repo[key]; !ok {
+			return fmt.Errorf(
+				"refusing to reconcile: live Hasura tracks %s but repo metadata does not declare "+
+					"it — reconcile never untracks a table, but proceeding while metadata is this "+
+					"far out of sync risks masking a bigger drift; update the repo metadata first", key)
+		}
+	}
+	return nil
+}
+
+// postgresTableExists checks the underlying Postgres table exists (distinct
+// from "tracked by Hasura" — a table can exist untracked, which is fine).
+func postgresTableExists(ctx context.Context, cfg *config.Config, schema, name string) (bool, error) {
+	db := cfg.Postgres.DB
+	if db == "" {
+		db = "nself"
+	}
+	sqlText := fmt.Sprintf(
+		"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema=%s AND table_name=%s)",
+		sqlQuoteLiteral(schema), sqlQuoteLiteral(name),
+	)
+	out, err := querySQL(ctx, cfg, db, sqlText)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) == "t", nil
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// buildReconcilePlanPure is the deterministic planning logic, split out from
+// BuildReconcilePlan so it can be unit tested without live Hasura/Postgres.
+func buildReconcilePlanPure(repo, live map[string]hasuraTable) ReconcilePlan {
+	var trackOps, relOps, permOps []map[string]interface{}
+	var changes []ReconcileChange
+
+	for _, key := range sortedTableKeys(repo) {
+		rt := repo[key]
+		tableArg := map[string]interface{}{"schema": rt.Table.Schema, "name": rt.Table.Name}
+		lt, exists := live[key]
+		if !exists {
+			trackOps = append(trackOps, map[string]interface{}{
+				"type": "pg_track_table",
+				"args": map[string]interface{}{"source": "default", "table": tableArg},
+			})
+			changes = append(changes, ReconcileChange{key, "track (declared in repo, not tracked live)"})
+			lt = hasuraTable{}
+		}
+
+		newRelOps, relChanges := planRelationshipOps(key, tableArg, lt, rt)
+		relOps = append(relOps, newRelOps...)
+		changes = append(changes, relChanges...)
+
+		newPermOps, permChanges := planPermissionOps(key, tableArg, lt, rt)
+		permOps = append(permOps, newPermOps...)
+		changes = append(changes, permChanges...)
+	}
+
+	bulk := make([]map[string]interface{}, 0, len(trackOps)+len(relOps)+len(permOps))
+	bulk = append(bulk, trackOps...)
+	bulk = append(bulk, relOps...)
+	bulk = append(bulk, permOps...)
+	return ReconcilePlan{BulkOps: bulk, Changes: changes}
+}
+
+func planRelationshipOps(key string, tableArg map[string]interface{}, lt, rt hasuraTable) ([]map[string]interface{}, []ReconcileChange) {
+	var ops []map[string]interface{}
+	var changes []ReconcileChange
+	for _, relSet := range []struct {
+		api      string
+		liveRels []hasuraRelationship
+		repoRels []hasuraRelationship
+	}{
+		{"pg_create_object_relationship", lt.ObjectRelationships, rt.ObjectRelationships},
+		{"pg_create_array_relationship", lt.ArrayRelationships, rt.ArrayRelationships},
+	} {
+		have := map[string]bool{}
+		for _, r := range relSet.liveRels {
+			have[r.Name] = true
+		}
+		for _, r := range relSet.repoRels {
+			if have[r.Name] {
+				continue
+			}
+			ops = append(ops, map[string]interface{}{
+				"type": relSet.api,
+				"args": map[string]interface{}{
+					"source": "default", "table": tableArg,
+					"name": r.Name, "using": r.Using,
+				},
+			})
+			changes = append(changes, ReconcileChange{key, fmt.Sprintf("create relationship %q", r.Name)})
+		}
+	}
+	return ops, changes
+}
+
+func planPermissionOps(key string, tableArg map[string]interface{}, lt, rt hasuraTable) ([]map[string]interface{}, []ReconcileChange) {
+	var ops []map[string]interface{}
+	var changes []ReconcileChange
+	for _, pk := range permissionKinds {
+		rperm := indexPermissionsByRole(rt.tablePermissions(pk.short))
+		lperm := indexPermissionsByRole(lt.tablePermissions(pk.short))
+		roles := make([]string, 0, len(rperm))
+		for role := range rperm {
+			roles = append(roles, role)
+		}
+		sort.Strings(roles)
+		for _, role := range roles {
+			perm := rperm[role]
+			existing, has := lperm[role]
+			if has && permissionEqual(existing, perm) {
+				continue
+			}
+			if has {
+				ops = append(ops, map[string]interface{}{
+					"type": fmt.Sprintf("pg_drop_%s_permission", pk.short),
+					"args": map[string]interface{}{"source": "default", "table": tableArg, "role": role},
+				})
+			}
+			ops = append(ops, map[string]interface{}{
+				"type": fmt.Sprintf("pg_create_%s_permission", pk.short),
+				"args": map[string]interface{}{
+					"source": "default", "table": tableArg, "role": role, "permission": perm,
+				},
+			})
+			action := "create"
+			if has {
+				action = "replace"
+			}
+			changes = append(changes, ReconcileChange{key,
+				fmt.Sprintf("%s %s permission for role %q", action, pk.short, role)})
+		}
+	}
+	return ops, changes
+}
+
+func sortedTableKeys(m map[string]hasuraTable) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Apply executes the plan's bulk operations against the live instance as ONE
+// atomic Hasura `bulk` metadata call, so a failure rolls back rather than
+// leaving a partial apply.
+func (p ReconcilePlan) Apply(ctx context.Context, cfg *config.Config) error {
+	if len(p.BulkOps) == 0 {
+		return nil
+	}
+	secret, err := readHasuraAdminSecretFromContainer(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	if _, err := postMetadataAdmin(ctx, cfg, secret, "bulk", p.BulkOps); err != nil {
+		return fmt.Errorf("apply reconcile plan: %w", err)
+	}
+	return nil
+}

--- a/internal/database/metadata_reconcile_test.go
+++ b/internal/database/metadata_reconcile_test.go
@@ -1,0 +1,111 @@
+package database
+
+import "testing"
+
+func TestBuildReconcilePlanPure_TracksUntrackedRepoTable(t *testing.T) {
+	repo := map[string]hasuraTable{
+		"public.np_widgets": {Table: hasuraTableRef{Schema: "public", Name: "np_widgets"}},
+	}
+	live := map[string]hasuraTable{}
+
+	plan := buildReconcilePlanPure(repo, live)
+	if len(plan.BulkOps) != 1 || plan.BulkOps[0]["type"] != "pg_track_table" {
+		t.Fatalf("expected one pg_track_table op, got %+v", plan.BulkOps)
+	}
+}
+
+func TestBuildReconcilePlanPure_CreatesMissingRelationshipBeforePermission(t *testing.T) {
+	repo := map[string]hasuraTable{
+		"public.np_activity": {
+			Table: hasuraTableRef{Schema: "public", Name: "np_activity"},
+			ObjectRelationships: []hasuraRelationship{
+				{Name: "todo", Using: map[string]interface{}{"foreign_key_constraint_on": "todo_id"}},
+			},
+			SelectPermissions: []hasuraPermission{
+				{Role: "user", Permission: map[string]interface{}{"columns": []interface{}{"id"}}},
+			},
+		},
+	}
+	live := map[string]hasuraTable{
+		"public.np_activity": {Table: hasuraTableRef{Schema: "public", Name: "np_activity"}},
+	}
+
+	plan := buildReconcilePlanPure(repo, live)
+	if len(plan.BulkOps) != 2 {
+		t.Fatalf("expected relationship + permission create ops, got %+v", plan.BulkOps)
+	}
+	if plan.BulkOps[0]["type"] != "pg_create_object_relationship" {
+		t.Fatalf("relationship must be created before permission, got order %+v", plan.BulkOps)
+	}
+	if plan.BulkOps[1]["type"] != "pg_create_select_permission" {
+		t.Fatalf("expected select permission create second, got %+v", plan.BulkOps[1])
+	}
+}
+
+func TestBuildReconcilePlanPure_ReplacesDriftedPermissionAsDropThenCreate(t *testing.T) {
+	repo := map[string]hasuraTable{
+		"public.np_exports": {
+			Table: hasuraTableRef{Schema: "public", Name: "np_exports"},
+			SelectPermissions: []hasuraPermission{
+				{Role: "user", Permission: map[string]interface{}{"columns": []interface{}{"id", "owner_id"}}},
+			},
+		},
+	}
+	live := map[string]hasuraTable{
+		"public.np_exports": {
+			Table: hasuraTableRef{Schema: "public", Name: "np_exports"},
+			SelectPermissions: []hasuraPermission{
+				{Role: "user", Permission: map[string]interface{}{"columns": []interface{}{"id"}}},
+			},
+		},
+	}
+
+	plan := buildReconcilePlanPure(repo, live)
+	if len(plan.BulkOps) != 2 {
+		t.Fatalf("expected drop then create, got %+v", plan.BulkOps)
+	}
+	if plan.BulkOps[0]["type"] != "pg_drop_select_permission" {
+		t.Fatalf("expected drop first, got %+v", plan.BulkOps[0])
+	}
+	if plan.BulkOps[1]["type"] != "pg_create_select_permission" {
+		t.Fatalf("expected create second, got %+v", plan.BulkOps[1])
+	}
+}
+
+func TestBuildReconcilePlanPure_NoOpWhenIdentical(t *testing.T) {
+	table := hasuraTable{
+		Table: hasuraTableRef{Schema: "public", Name: "np_widgets"},
+		SelectPermissions: []hasuraPermission{
+			{Role: "user", Permission: map[string]interface{}{"columns": []interface{}{"id"}}},
+		},
+	}
+	repo := map[string]hasuraTable{"public.np_widgets": table}
+	live := map[string]hasuraTable{"public.np_widgets": table}
+
+	plan := buildReconcilePlanPure(repo, live)
+	if len(plan.BulkOps) != 0 || len(plan.Changes) != 0 {
+		t.Fatalf("expected a no-op plan for identical metadata, got %+v", plan)
+	}
+}
+
+func TestBuildReconcilePlanPure_NeverTouchesLiveOnlyPermission(t *testing.T) {
+	// A role present only live (not declared in repo) must be left alone —
+	// reconcile only ever adds/replaces what the repo declares, per
+	// ntask/backend/scripts/metadata-reconcile.sh's targeted design.
+	repo := map[string]hasuraTable{
+		"public.np_widgets": {Table: hasuraTableRef{Schema: "public", Name: "np_widgets"}},
+	}
+	live := map[string]hasuraTable{
+		"public.np_widgets": {
+			Table: hasuraTableRef{Schema: "public", Name: "np_widgets"},
+			SelectPermissions: []hasuraPermission{
+				{Role: "legacy_role", Permission: map[string]interface{}{"columns": []interface{}{"id"}}},
+			},
+		},
+	}
+
+	plan := buildReconcilePlanPure(repo, live)
+	if len(plan.BulkOps) != 0 {
+		t.Fatalf("expected zero ops (live-only permission must not be touched), got %+v", plan.BulkOps)
+	}
+}

--- a/internal/database/metadata_types.go
+++ b/internal/database/metadata_types.go
@@ -1,0 +1,153 @@
+package database
+
+// Purpose: shared Hasura metadata types + repo-side loading for the
+// drift/reconcile/verify trio (metadata_drift.go, metadata_reconcile.go).
+// Inputs: the project directory containing hasura/metadata/**.
+// Outputs: parsed table metadata keyed by "schema.name".
+// Constraints: split out of metadata_drift.go to respect the 300-line file
+// cap (ASI Policy 3) — pure move, no behavior change.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// hasuraAuthOwnedTables lists "schema.name" keys hasura-auth creates that are
+// legitimately absent from project metadata. The ntask inbox report
+// (2026-08-22) named eight of these from memory; verified exhaustively here
+// 2026-08-31 against a live `nself start` Postgres instance's
+// information_schema.tables for the auth schema — that live check caught two
+// the inbox report's list actually had wrong: auth.providers (bare, distinct
+// from auth.user_providers, a separate join table) and auth.migrations
+// (hasura-auth's own internal ledger) were both missing from the
+// hand-remembered list and would have produced false-positive drift.
+var hasuraAuthOwnedTables = map[string]bool{
+	"auth.users":               true,
+	"auth.roles":               true,
+	"auth.refresh_tokens":      true,
+	"auth.refresh_token_types": true,
+	"auth.providers":           true,
+	"auth.provider_requests":   true,
+	"auth.user_providers":      true,
+	"auth.user_roles":          true,
+	"auth.user_security_keys":  true,
+	"auth.migrations":          true,
+}
+
+// permissionKinds maps a Hasura metadata list to its short name, used in both
+// drift finding output and reconcile op-type construction
+// (pg_create_<short>_permission / pg_drop_<short>_permission).
+var permissionKinds = []struct {
+	short string
+}{
+	{"insert"},
+	{"select"},
+	{"update"},
+	{"delete"},
+}
+
+type hasuraTableRef struct {
+	Schema string `yaml:"schema" json:"schema"`
+	Name   string `yaml:"name" json:"name"`
+}
+
+func (t hasuraTableRef) key() string { return t.Schema + "." + t.Name }
+
+type hasuraRelationship struct {
+	Name  string                 `yaml:"name" json:"name"`
+	Using map[string]interface{} `yaml:"using" json:"using"`
+}
+
+type hasuraPermission struct {
+	Role       string                 `yaml:"role" json:"role"`
+	Permission map[string]interface{} `yaml:"permission" json:"permission"`
+}
+
+type hasuraTable struct {
+	Table               hasuraTableRef       `yaml:"table" json:"table"`
+	ObjectRelationships []hasuraRelationship `yaml:"object_relationships,omitempty" json:"object_relationships,omitempty"`
+	ArrayRelationships  []hasuraRelationship `yaml:"array_relationships,omitempty" json:"array_relationships,omitempty"`
+	InsertPermissions   []hasuraPermission   `yaml:"insert_permissions,omitempty" json:"insert_permissions,omitempty"`
+	SelectPermissions   []hasuraPermission   `yaml:"select_permissions,omitempty" json:"select_permissions,omitempty"`
+	UpdatePermissions   []hasuraPermission   `yaml:"update_permissions,omitempty" json:"update_permissions,omitempty"`
+	DeletePermissions   []hasuraPermission   `yaml:"delete_permissions,omitempty" json:"delete_permissions,omitempty"`
+}
+
+// tablePermissions returns the permission list for the given short kind
+// ("insert"/"select"/"update"/"delete").
+func (t hasuraTable) tablePermissions(short string) []hasuraPermission {
+	switch short {
+	case "insert":
+		return t.InsertPermissions
+	case "select":
+		return t.SelectPermissions
+	case "update":
+		return t.UpdatePermissions
+	case "delete":
+		return t.DeletePermissions
+	}
+	return nil
+}
+
+type hasuraSource struct {
+	Name   string        `yaml:"name" json:"name"`
+	Tables []hasuraTable `yaml:"tables" json:"tables"`
+}
+
+type hasuraMetadataDoc struct {
+	Sources []hasuraSource `yaml:"sources" json:"sources"`
+}
+
+func tablesByKey(tables []hasuraTable) map[string]hasuraTable {
+	out := make(map[string]hasuraTable, len(tables))
+	for _, t := range tables {
+		out[t.Table.key()] = t
+	}
+	return out
+}
+
+// loadRepoTables loads the committed Hasura table metadata from projectDir,
+// supporting both formats HasuraApplyMetadata supports (hasura_apply.go):
+// the Hasura CLI YAML directory format (with !include directives, resolved
+// via resolveIncludes) and the legacy nSelf JSON format.
+func loadRepoTables(projectDir string) (map[string]hasuraTable, error) {
+	hasuraDir := filepath.Join(projectDir, "hasura")
+
+	yamlCandidates := []string{
+		filepath.Join(hasuraDir, "metadata", "databases", "default", "tables", "tables.yaml"),
+		filepath.Join(hasuraDir, "metadata", "tables.yaml"),
+	}
+	for _, tablesFile := range yamlCandidates {
+		if _, err := os.Stat(tablesFile); err == nil {
+			resolved, err := resolveIncludes(filepath.Dir(tablesFile), tablesFile)
+			if err != nil {
+				return nil, fmt.Errorf("resolve %s includes: %w", tablesFile, err)
+			}
+			var tables []hasuraTable
+			if err := yaml.Unmarshal(resolved, &tables); err != nil {
+				return nil, fmt.Errorf("parse %s: %w", tablesFile, err)
+			}
+			return tablesByKey(tables), nil
+		}
+	}
+
+	metadataFile := filepath.Join(hasuraDir, "metadata.json")
+	data, err := os.ReadFile(metadataFile)
+	if err != nil {
+		return nil, fmt.Errorf("no hasura metadata found (tried %s and %s): %w",
+			yamlCandidates[0], metadataFile, err)
+	}
+	var doc hasuraMetadataDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", metadataFile, err)
+	}
+	var all []hasuraTable
+	for _, src := range doc.Sources {
+		all = append(all, src.Tables...)
+	}
+	return tablesByKey(all), nil
+}

--- a/internal/database/metadata_verify.go
+++ b/internal/database/metadata_verify.go
@@ -1,0 +1,126 @@
+package database
+
+// Purpose: nself db verify --role <role> — role-scoped GraphQL introspection
+// against a live Hasura instance, answering "is this feature reachable by an
+// actual role" without a hand-rolled curl command.
+// Inputs: context, *config.Config, role name.
+// Outputs: RoleReachability{Queries, Mutations int}, or an error.
+// Constraints: sent with BOTH the admin secret (read via
+// readHasuraAdminSecretFromContainer — the running container, never .env)
+// AND the X-Hasura-Role header. This is Hasura's documented role-impersonation
+// mechanism: the admin secret authenticates the request, and the role header
+// tells Hasura which role's permissions to apply to it, so the response is
+// exactly what that role — and only that role — can reach.
+//
+// Verified live 2026-08-31 that the ticket's originally-specified "role
+// header with NO admin secret" does NOT work: without an admin secret (or a
+// JWT), Hasura ignores X-Hasura-Role entirely and always falls back to
+// HASURA_GRAPHQL_UNAUTHORIZED_ROLE (nSelf default: "public") regardless of
+// the header's value — a real role name and a nonexistent one returned
+// identical counts. Admin secret + role header, by contrast, produced 4
+// queries/2 mutations for "user" vs. 33/77 for unrestricted admin access on
+// the same instance — a real distinction, matching the shape of the
+// 2026-08-21 Unity report's "3250 mutations vs 283 for pia_player" finding
+// (which used exactly this combination, not a bare role header).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/httptimeout"
+)
+
+const roleIntrospectionQuery = `query IntrospectionQuery {
+  __schema {
+    queryType { fields { name } }
+    mutationType { fields { name } }
+  }
+}`
+
+// RoleReachability is the count of top-level query/mutation fields visible
+// to a role, from a role-scoped introspection query.
+type RoleReachability struct {
+	Role      string
+	Queries   int
+	Mutations int
+}
+
+func hasuraGraphQLURL(cfg *config.Config) string {
+	port := cfg.Hasura.Port
+	if port == 0 {
+		port = 8080
+	}
+	return fmt.Sprintf("http://localhost:%d/v1/graphql", port)
+}
+
+// VerifyRoleReachability runs an introspection query against the live
+// GraphQL endpoint impersonating the given role (admin secret + X-Hasura-Role
+// — see package doc for why a bare role header does not work).
+func VerifyRoleReachability(ctx context.Context, cfg *config.Config, role string) (RoleReachability, error) {
+	secret, err := readHasuraAdminSecretFromContainer(ctx, cfg)
+	if err != nil {
+		return RoleReachability{}, err
+	}
+
+	body, err := json.Marshal(map[string]string{"query": roleIntrospectionQuery})
+	if err != nil {
+		return RoleReachability{}, fmt.Errorf("marshal introspection query: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hasuraGraphQLURL(cfg), bytes.NewReader(body))
+	if err != nil {
+		return RoleReachability{}, fmt.Errorf("create introspection request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hasura-Admin-Secret", secret)
+	req.Header.Set("X-Hasura-Role", role)
+
+	resp, err := httptimeout.Default.Do(req)
+	if err != nil {
+		return RoleReachability{}, fmt.Errorf("introspection request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var respBody bytes.Buffer
+	if _, err := respBody.ReadFrom(resp.Body); err != nil {
+		return RoleReachability{}, fmt.Errorf("read introspection response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return RoleReachability{}, fmt.Errorf("hasura graphql API returned %d: %s", resp.StatusCode, respBody.String())
+	}
+
+	var parsed struct {
+		Data struct {
+			Schema struct {
+				QueryType struct {
+					Fields []struct {
+						Name string `json:"name"`
+					} `json:"fields"`
+				} `json:"queryType"`
+				MutationType *struct {
+					Fields []struct {
+						Name string `json:"name"`
+					} `json:"fields"`
+				} `json:"mutationType"`
+			} `json:"__schema"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(respBody.Bytes(), &parsed); err != nil {
+		return RoleReachability{}, fmt.Errorf("parse introspection response: %w", err)
+	}
+	if len(parsed.Errors) > 0 {
+		return RoleReachability{}, fmt.Errorf("introspection query failed for role %q: %s", role, parsed.Errors[0].Message)
+	}
+
+	result := RoleReachability{Role: role, Queries: len(parsed.Data.Schema.QueryType.Fields)}
+	if parsed.Data.Schema.MutationType != nil {
+		result.Mutations = len(parsed.Data.Schema.MutationType.Fields)
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary

**T-P6-E11-W2-S1-T3** (db drift/reconcile — adopt ntask's contributed implementation)
- Ports `ntask/backend/scripts/metadata-diff.sh` / `metadata-reconcile.sh`'s proven design into the Go CLI as three new commands:
  - `nself db drift --metadata [--env <dir>]` — Hasura metadata drift (table tracking, relationships, permissions), exits 1 and names the exact table/role/field.
  - `nself db reconcile [--apply]` — targeted, ordered, single-atomic-`bulk` push toward repo metadata. Never issues a full `hasura metadata apply`. Refuses unconditionally (no bypass) if the repo declares a table absent from Postgres, or live tracks a table the repo doesn't declare.
  - `nself db verify --role <role>` — role-scoped GraphQL introspection.
- All three read the Hasura admin secret via `docker inspect` against the **running container**, never `cfg.Hasura.AdminSecret`/`.env` (the exact footgun both the 2026-08-21 Unity and 2026-08-22 ntask inbox reports hit independently).
- New files: `internal/database/metadata_{types,live,drift,reconcile,verify}.go`, `cmd/commands/db_{drift_metadata,reconcile,verify}.go`, unit tests for the pure diff/plan logic.

**T-P6-E11-W2-S1-T4** (small CLI gaps batch)
- Items (a)-(c) verified already fixed via a live `nself init/build/start` run (see below).
- Item (d), the genuine gap: added `PGVECTOR_ENABLED/DIMENSIONS/HNSW_M/HNSW_EF_CONSTRUCTION`, bare `ADMIN_ENABLED`, `AUTH_ENABLED`, and the 14 `AI_*` vars + `NSELF_MASTER_SECRET` to `internal/config/loader_known_vars_{core,ops,storage}.go`. Verified live: zero "unknown env var" warnings on a fresh `nself init --full && nself build`.

## Container-name verification (per the schema.go bug, cli#328)
`internal/compose/core_services.go` writes `container_name: <project>_postgres` and `<project>_hasura`. Confirmed against a real generated `docker-compose.yml` (`t3fixture_postgres`, `t3fixture_hasura`) and a live running stack (`docker exec t4fixture_hasura true` → exit 0). The new `hasuraContainer()` helper (metadata_live.go) uses the same convention.

## Correction found during live testing (not in the original ticket text)
The ticket specified role verification with "X-Hasura-Role header and NO admin secret." Live-tested against a real Hasura instance: without an admin secret, Hasura ignores the role header entirely and always falls back to `HASURA_GRAPHQL_UNAUTHORIZED_ROLE` — a real role and a nonexistent one returned identical counts. Switched to Hasura's documented admin-secret+role-header impersonation mechanism (secret still sourced via `docker inspect`, never `.env`), which produced a real distinction live (4q/2m for "user" vs 33q/77m for admin) — see metadata_verify.go's doc comment for the full evidence trail.

Also corrected the `hasuraAuthOwnedTables` ignore list against a real live Postgres/Hasura instance: the inbox report's hand-remembered table names had `auth.user_providers` but not `auth.providers` (a distinct, real table) or `auth.migrations`, both of which produced false-positive drift findings before the fix.

## Test plan
- [x] `gofmt -l cmd internal` — clean
- [x] `go build ./...` and `GOOS=linux go build ./...` — both pass
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass, including `internal/repoqa` (300-line file budget, zero violations)
- [x] Live end-to-end against a real `nself start` stack: drift detection (both directions + ignore-list), reconcile dry-run + `--apply` + follow-up clean check, both refuse-reconcile safety cases, role verification distinguishing "user" (4q/2m) from "admin" (33q/77m)
- [x] `.github/command-inventory.json` / `.github/wiki/Commands.md` regenerated via `make cmd-inventory`
- [ ] `.opencode/phases/sport/F02-COMMAND-INVENTORY.md` — NOT regenerated in this PR. It's a generated file living outside this repo at the shared project root, and 5 agents are working this repo in parallel right now; regenerating from this branch's cobra tree (which lacks their in-flight commands) risked clobbering concurrent work. Needs a follow-up regen from `main` post-merge.