### PR TITLE
P6-E11 T5/T8: WASI host-memory shim for embedded PG + Hetzner key mismatch warning

### DIFF
--- a/.github/wiki/Config-Env-Vars.md
+++ b/.github/wiki/Config-Env-Vars.md
@@ -243,6 +243,7 @@ This registers a Node.js service named `ping_api` accessible at `ping.{BASE_DOMA
 | Variable | Type | Default | Required | Description |
 |---|---|---|---|---|
 | `NSELF_DEPLOY_KEY_PATH` | string | *(empty)* | No | Path to the SSH private key used for remote deploys. Overrides `NSELF_DEPLOY_SSH_KEY` when set. Example: `~/.ssh/nself_deploy_ed25519`. |
+| `HETZNER_NSELF_TOKEN` | string | *(empty)* | No | Hetzner Cloud API token. When set, `nself access grant` calls the Hetzner Cloud API after a successful grant and warns about any SSH key registered at the Hetzner project level that is absent from the target server's `authorized_keys` — a key added to the project believing it grants access everywhere does nothing for an already-running server. Unset skips the check entirely; it is never required for `nself access` itself to work. |
 
 ---
 

--- a/cmd/commands/access_grant.go
+++ b/cmd/commands/access_grant.go
@@ -10,6 +10,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/nself-org/cli/internal/access"
 	"github.com/nself-org/cli/internal/ui"
@@ -61,6 +62,8 @@ func runAccessGrant(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	warnHetznerMismatch(cmd, t)
+
 	if result.AlreadyGranted {
 		ui.Success(fmt.Sprintf("%s already has this exact key granted (%s)", user, result.Fingerprint))
 		return nil
@@ -81,4 +84,23 @@ func runAccessGrant(cmd *cobra.Command, args []string) error {
 		ui.Info("Expires: " + expires.Format("2006-01-02"))
 	}
 	return nil
+}
+
+// warnHetznerMismatch runs the best-effort Hetzner-project-vs-running-server
+// key check (issue #238) after a grant and prints one ui.Warn per mismatch.
+// It is silent (not a command failure) when HETZNER_NSELF_TOKEN is unset or
+// the API call fails — this is an advisory check, never a gate on grant.
+func warnHetznerMismatch(cmd *cobra.Command, t access.Transport) {
+	token := os.Getenv("HETZNER_NSELF_TOKEN")
+	if token == "" {
+		return
+	}
+	warnings, err := access.HetznerMismatchWarnings(cmd.Context(), token, t)
+	if err != nil {
+		ui.Info("Hetzner project-key mismatch check skipped: " + err.Error())
+		return
+	}
+	for _, w := range warnings {
+		ui.Warn(w)
+	}
 }

--- a/internal/access/hetzner_mismatch.go
+++ b/internal/access/hetzner_mismatch.go
@@ -1,0 +1,152 @@
+package access
+
+// Purpose: the Hetzner-project-vs-running-server key mismatch check —
+// issue #238's remaining sub-item. `nself access grant/revoke/list` manage
+// one host's authorized_keys directly; this file answers a different
+// question: is there a key registered at the Hetzner Cloud project level
+// that operators believe (incorrectly) already grants access to this
+// already-running server? hcloud only injects project-level keys at
+// server-creation time, so a project key with no matching entry on the
+// host is silently inert — this is issue #238's "actual footgun".
+// Inputs: a Hetzner Cloud API token and a Transport for the target host.
+// Outputs: one warning string per project-level key absent from the host.
+// Constraints: compares fingerprints computed locally by PublicKey.
+// Fingerprint (SHA256) on both sides — never Hetzner's own "fingerprint"
+// field, which is legacy MD5 colon-hex and would never match. Best-effort
+// only: an empty token or any network/API failure returns an error the
+// caller is expected to log and otherwise ignore, never one that fails the
+// grant/revoke this check is attached to.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// hetznerAPIBaseURL and hetznerHTTPClient are var indirections so tests can
+// point the mismatch check at a local httptest.Server instead of the real
+// Hetzner Cloud API, mirroring the injectable explicit-timeout http.Client
+// pattern used by internal/license/validate.go (never http.DefaultClient).
+var (
+	hetznerAPIBaseURL = "https://api.hetzner.cloud/v1"
+	hetznerHTTPClient = &http.Client{Timeout: 10 * time.Second}
+)
+
+// hetznerSSHKey is the subset of a Hetzner Cloud API ssh_keys entry this
+// check needs. Its own "fingerprint" field is deliberately unused: Hetzner
+// reports the legacy MD5 colon-hex format, not the SHA256 format
+// PublicKey.Fingerprint produces, so a direct string comparison would never
+// match. Instead PublicKey is re-parsed from public_key and fingerprinted
+// locally, comparing apples to apples against the host side.
+type hetznerSSHKey struct {
+	Name      string `json:"name"`
+	PublicKey string `json:"public_key"`
+}
+
+// HetznerMismatchWarnings compares the SSH keys registered at the Hetzner
+// Cloud project level (identified by token) against the keys actually
+// present in t's authorized_keys, and returns one warning string per
+// project-level key absent from the host.
+//
+// The reverse case is deliberately NOT a mismatch and never produces a
+// warning: a key present in authorized_keys but never registered at the
+// Hetzner project level (e.g. anything granted via `nself access grant`
+// itself) is a normal, legitimate state.
+//
+// An empty token, or any network/API failure, returns (nil, err) so callers
+// can treat this as a best-effort check — see access_grant.go's caller,
+// which logs at most and never fails the grant/revoke this check is
+// attached to.
+func HetznerMismatchWarnings(ctx context.Context, token string, t Transport) ([]string, error) {
+	if token == "" {
+		return nil, nil
+	}
+
+	hostFPs, err := hostFingerprints(ctx, t)
+	if err != nil {
+		return nil, fmt.Errorf("read host keys for mismatch check: %w", err)
+	}
+
+	projectKeys, err := fetchHetznerSSHKeys(ctx, token)
+	if err != nil {
+		return nil, fmt.Errorf("fetch Hetzner project SSH keys: %w", err)
+	}
+
+	var warnings []string
+	for _, pk := range projectKeys {
+		key, err := ParsePublicKey(pk.PublicKey)
+		if err != nil {
+			continue // not a key format we understand; skip rather than false-positive
+		}
+		fp, err := key.Fingerprint()
+		if err != nil || hostFPs[fp] {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"Hetzner project key %q (%s) is registered at the project level but NOT present in %s's authorized_keys — it will not grant access to this already-running server",
+			pk.Name, fp, t.Describe()))
+	}
+	return warnings, nil
+}
+
+// hostFingerprints returns the fingerprint of every key line in t's
+// authorized_keys — managed AND foreign — since the mismatch check must
+// compare against everything that can actually authenticate a login, not
+// just nself-managed entries.
+func hostFingerprints(ctx context.Context, t Transport) (map[string]bool, error) {
+	content, err := t.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]bool{}
+	for _, line := range strings.Split(strings.TrimRight(string(content), "\n"), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) < 2 {
+			continue
+		}
+		key, err := ParsePublicKey(fields[0] + " " + fields[1])
+		if err != nil {
+			continue
+		}
+		fp, err := key.Fingerprint()
+		if err != nil {
+			continue
+		}
+		out[fp] = true
+	}
+	return out, nil
+}
+
+// fetchHetznerSSHKeys calls GET /ssh_keys against the Hetzner Cloud API.
+func fetchHetznerSSHKeys(ctx context.Context, token string) ([]hetznerSSHKey, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hetznerAPIBaseURL+"/ssh_keys", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := hetznerHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("network error: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hetzner API returned %d", resp.StatusCode)
+	}
+
+	var parsed struct {
+		SSHKeys []hetznerSSHKey `json:"ssh_keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return parsed.SSHKeys, nil
+}

--- a/internal/access/hetzner_mismatch_test.go
+++ b/internal/access/hetzner_mismatch_test.go
@@ -1,0 +1,140 @@
+package access
+
+// Tests drive HetznerMismatchWarnings against a local httptest.Server
+// standing in for the Hetzner Cloud API (hetznerAPIBaseURL is redirected for
+// the duration of each test) and a LocalFileTransport fixture standing in
+// for the target host — no network call ever reaches the real Hetzner API
+// or any real host, staging or production included.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// withHetznerServer starts a test server returning body for GET /ssh_keys,
+// points hetznerAPIBaseURL at it for the duration of the test, and restores
+// the original value on cleanup.
+func withHetznerServer(t *testing.T, keys []hetznerSSHKey) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ssh_keys" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization header = %q, want %q", got, "Bearer test-token")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			SSHKeys []hetznerSSHKey `json:"ssh_keys"`
+		}{SSHKeys: keys})
+	}))
+	t.Cleanup(srv.Close)
+
+	oldURL := hetznerAPIBaseURL
+	hetznerAPIBaseURL = srv.URL
+	t.Cleanup(func() { hetznerAPIBaseURL = oldURL })
+}
+
+func TestHetznerMismatchWarnings_EmptyToken_NoOp(t *testing.T) {
+	tp, _ := newFixture(t)
+	warnings, err := HetznerMismatchWarnings(context.Background(), "", tp)
+	if err != nil {
+		t.Fatalf("HetznerMismatchWarnings: %v", err)
+	}
+	if warnings != nil {
+		t.Errorf("warnings = %v, want nil for empty token", warnings)
+	}
+}
+
+// TestHetznerMismatchWarnings_ProjectKeyMissingFromHost proves the
+// true-positive case: a key registered at the Hetzner project level but
+// absent from the host's authorized_keys produces exactly one warning
+// naming that key.
+func TestHetznerMismatchWarnings_ProjectKeyMissingFromHost(t *testing.T) {
+	tp, _ := newFixture(t)
+	ctx := context.Background()
+
+	// alice is granted on the host; bob exists only at the project level.
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+
+	withHetznerServer(t, []hetznerSSHKey{
+		{Name: "alice-project-key", PublicKey: aliceKeyLine},
+		{Name: "bob-project-key", PublicKey: bobKeyLine},
+	})
+
+	warnings, err := HetznerMismatchWarnings(ctx, "test-token", tp)
+	if err != nil {
+		t.Fatalf("HetznerMismatchWarnings: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly 1", warnings)
+	}
+	if got := warnings[0]; !containsAll(got, "bob-project-key", bobFP) {
+		t.Errorf("warning = %q, want it to name bob-project-key and %s", got, bobFP)
+	}
+}
+
+// TestHetznerMismatchWarnings_HostOnlyKey_NoWarning proves the
+// true-negative case required by CR-B: a key present on the host but never
+// registered at the Hetzner project level (the normal `nself access grant`
+// case) must never produce a warning.
+func TestHetznerMismatchWarnings_HostOnlyKey_NoWarning(t *testing.T) {
+	tp, _ := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+
+	// The Hetzner project has no keys registered at all — alice's host key
+	// has no project-level counterpart, which is fine and not a mismatch.
+	withHetznerServer(t, nil)
+
+	warnings, err := HetznerMismatchWarnings(ctx, "test-token", tp)
+	if err != nil {
+		t.Fatalf("HetznerMismatchWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none (host-only key is not a mismatch)", warnings)
+	}
+}
+
+// TestHetznerMismatchWarnings_AllMatch_NoWarning proves that when every
+// project-level key is also present on the host (managed or foreign), no
+// warnings fire.
+func TestHetznerMismatchWarnings_AllMatch_NoWarning(t *testing.T) {
+	tp, _ := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := Grant(ctx, tp, GrantRequest{User: "alice", Key: aliceKey(t)}); err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+
+	withHetznerServer(t, []hetznerSSHKey{
+		{Name: "alice-project-key", PublicKey: aliceKeyLine},
+	})
+
+	warnings, err := HetznerMismatchWarnings(ctx, "test-token", tp)
+	if err != nil {
+		t.Fatalf("HetznerMismatchWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none (project key matches host key)", warnings)
+	}
+}
+
+func containsAll(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/embedded/emscripten_abi.go
+++ b/internal/embedded/emscripten_abi.go
@@ -55,24 +55,30 @@ const enosys = int32(-38)
 //	4d-4f. defineEmscriptenTimeEventNetFuncs (time, event loop, network stubs)
 //	4g. defineEmscriptenSyscallStubs (__syscall_* stubs)
 //	4h. defineEmscriptenInvokeTrampolines (invoke_* trampolines)
-func defineEmscriptenABI(linker *wasmtime.Linker, store *wasmtime.Store) error {
+//
+// It returns the created env::memory object so the caller can also bind
+// definePGWasi's wasi_snapshot_preview1 shim (pg_wasi.go) to the same
+// linear memory — pglite has exactly one memory in the whole instantiation,
+// and the WASI functions must read/write through the identical object the
+// guest code addresses.
+func defineEmscriptenABI(linker *wasmtime.Linker, store *wasmtime.Store) (*wasmtime.Memory, error) {
 	mem, err := defineEmscriptenGlobalsMemoryTable(linker, store)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := defineEmscriptenRuntimeFuncs(linker, store, mem); err != nil {
-		return err
+		return nil, err
 	}
 	if err := defineEmscriptenTimeEventNetFuncs(linker, store); err != nil {
-		return err
+		return nil, err
 	}
 	if err := defineEmscriptenSyscallStubs(linker, store); err != nil {
-		return err
+		return nil, err
 	}
 	if err := defineEmscriptenInvokeTrampolines(linker, store); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return mem, nil
 }
 
 // defineGOTNamespaces registers all imports from the GOT.mem and GOT.func

--- a/internal/embedded/emscripten_abi_test.go
+++ b/internal/embedded/emscripten_abi_test.go
@@ -43,7 +43,7 @@ func newTestLinkerWithABI(t *testing.T) (*wasmtime.Linker, *wasmtime.Store, *was
 	if err := linker.DefineWasi(); err != nil {
 		t.Fatalf("DefineWasi: %v", err)
 	}
-	if err := defineEmscriptenABI(linker, store); err != nil {
+	if _, err := defineEmscriptenABI(linker, store); err != nil {
 		t.Fatalf("defineEmscriptenABI: %v", err)
 	}
 
@@ -62,7 +62,7 @@ func TestDefineEmscriptenABI_NoError(t *testing.T) {
 	if err := linker.DefineWasi(); err != nil {
 		t.Fatalf("DefineWasi: %v", err)
 	}
-	if err := defineEmscriptenABI(linker, store); err != nil {
+	if _, err := defineEmscriptenABI(linker, store); err != nil {
 		t.Errorf("defineEmscriptenABI returned unexpected error: %v", err)
 	}
 }

--- a/internal/embedded/integration_test.go
+++ b/internal/embedded/integration_test.go
@@ -34,9 +34,26 @@ func shortIntegTempDir(t *testing.T) string {
 }
 
 // quarantined reports whether the embedded-PG integration tests should be
-// skipped. pglite v0.2.17 is an Emscripten SIDE_MODULE whose GOT.mem/GOT.func
-// relocations are never applied host-side, so it traps with an out-of-bounds
-// access before Postgres starts. These tests have never passed on main.
+// skipped. These tests have never passed on main.
+//
+// Status as of P6-E11-W2-S1-T5 (2026-08-31): the originally diagnosed
+// SIDE_MODULE relocation gap (GOT.mem/GOT.func never relocated, then
+// wasmtime's linker.DefineWasi() failing with "missing required memory
+// export" because pglite imports env::memory instead of exporting it) is
+// FIXED — dylink.go + emscripten_abi.go + pg_wasi.go now relocate GOT.mem
+// and bind a from-scratch WASI preview1 shim directly to the host-owned
+// memory. Boot now proceeds substantially further before trapping.
+//
+// The current blocker is different and deeper: pglite/Postgres's own
+// startup calls __syscall_pipe (Postgres's latch.c self-pipe trick), which
+// emscripten_abi_syscalls.go permanently stubs to ENOSYS along with every
+// other __syscall_* import. Postgres's init treats that failure as fatal
+// and aborts (wasm `unreachable`). Fixing this requires real syscall
+// emulation (pipe/fcntl/dup/poll at minimum, likely more downstream for
+// real file I/O against the data directory) — a materially larger, separate
+// body of work from the WASI-memory-export fix this ticket closed. See the
+// completion note on issue #231 for the full repro and function-index
+// evidence.
 //
 // Tracked in https://github.com/nself-org/cli/issues/231. Removing this skip is
 // part of closing that issue. Set EMBEDDED_PG_WASM_FIXED=1 to run them while

--- a/internal/embedded/pg_wasi.go
+++ b/internal/embedded/pg_wasi.go
@@ -1,0 +1,255 @@
+//go:build cgo
+
+package embedded
+
+// pg_wasi.go — a from-scratch WASI preview1 shim bound to the host-owned
+// env::memory extern (defineEmscriptenGlobalsMemoryTable's mem), replacing
+// wasmtime's built-in linker.DefineWasi().
+//
+// Why: wasmtime's linker.DefineWasi() resolves guest memory by looking up
+// the INSTANCE's exported memory named "memory" the first time any WASI
+// function actually runs. pglite v0.2.17 is an Emscripten SIDE_MODULE: it
+// IMPORTS env::memory (created host-side, see emscripten_abi_globals.go)
+// and exports nothing named "memory" at all. The first WASI call then fails
+// with "missing required memory export" — the exact next blocker documented
+// in project_ci_findings_2026_08_17.md and reproduced live in
+// P6-E11-W2-S1-T5 (2026-08-31): `linker.DefineWasi()` + Instantiate()
+// succeed, but the first call into a WASI-provided function during
+// __main_argc_argv traps with that message.
+//
+// pglite v0.2.17 imports only 12 wasi_snapshot_preview1 functions (confirmed
+// via wasmtime.Module.Imports() against the cached pglite.wasm, 2026-08-31 —
+// NOT the ~40-function preview1 surface DefineWasi() provides): clock_time_get,
+// environ_get, environ_sizes_get, fd_close, fd_fdstat_get, fd_pread,
+// fd_pwrite, fd_read, fd_seek, fd_sync, fd_write, proc_exit. Notably absent:
+// path_open, fd_prestat_get, fd_prestat_dir_name, args_get/args_sizes_get,
+// random_get. This matches emscripten_abi_syscalls.go's __syscall_openat
+// (and every other path-taking syscall) being permanently stubbed to
+// ENOSYS: real file-path I/O never reaches WASI at all in this build —
+// pglite's own in-WASM VFS keeps Postgres's data purely in linear memory.
+// The only fds actually exercised are 0 (stdin, unused), 1 (stdout), and 2
+// (stderr); every other fd returns EBADF, matching the no-path-open reality
+// rather than pretending general file I/O works.
+//
+// Inputs: *wasmtime.Linker, *wasmtime.Store, the host-owned *wasmtime.Memory
+// from defineEmscriptenABI, and the stdout/stderr writers boot() opens
+// (replacing the WasiConfig-based file redirection this shim makes
+// unreachable — WasiConfig only feeds wasmtime's own DefineWasi()).
+// Outputs: error — first definition failure aborts, matching
+// defineEmscriptenABI's convention.
+// Constraints: never calls linker.DefineWasi(); every function below is a
+// full replacement, not a wrapper around it.
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/bytecodealliance/wasmtime-go/v25"
+)
+
+// WASI preview1 errno values this shim returns. Full table:
+// https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md
+const (
+	wasiErrnoSuccess = int32(0)
+	wasiErrnoBadf    = int32(8)  // EBADF — fd is not 0/1/2
+	wasiErrnoSpipe   = int32(29) // ESPIPE — seek on a non-seekable fd (stdio)
+)
+
+// definePGWasi registers the 12 wasi_snapshot_preview1 imports pglite
+// v0.2.17 actually declares, bound to mem instead of an instance export.
+// stdout and stderr receive fd_write output for fds 1 and 2 respectively;
+// every other fd is treated as absent (EBADF) since pglite never opens one
+// through WASI (see file header).
+func definePGWasi(linker *wasmtime.Linker, store *wasmtime.Store, mem *wasmtime.Memory, stdout, stderr io.Writer) error {
+	const mod = "wasi_snapshot_preview1"
+
+	writerFor := func(fd int32) io.Writer {
+		switch fd {
+		case 1:
+			return stdout
+		case 2:
+			return stderr
+		default:
+			return nil
+		}
+	}
+
+	// fd_write(fd, iovs_ptr, iovs_len, nwritten_ptr) -> errno. Gathers each
+	// iovec (8 bytes: buf_ptr u32, buf_len u32) and writes it to the fd's
+	// backing writer, matching the WASI scatter/gather contract.
+	if err := linker.DefineFunc(store, mod, "fd_write",
+		func(fd, iovsPtr, iovsLen, nwrittenPtr int32) int32 {
+			w := writerFor(fd)
+			if w == nil {
+				return wasiErrnoBadf
+			}
+			data := mem.UnsafeData(store)
+			var total uint32
+			for i := int32(0); i < iovsLen; i++ {
+				base := int(iovsPtr) + int(i)*8
+				if base < 0 || base+8 > len(data) {
+					return wasiErrnoBadf
+				}
+				bufPtr := binary.LittleEndian.Uint32(data[base : base+4])
+				bufLen := binary.LittleEndian.Uint32(data[base+4 : base+8])
+				if int(bufPtr+bufLen) > len(data) {
+					return wasiErrnoBadf
+				}
+				n, err := w.Write(data[bufPtr : bufPtr+bufLen])
+				total += uint32(n) //nolint:gosec // n <= bufLen, a WASM-address-range value
+				if err != nil {
+					return wasiErrnoBadf
+				}
+			}
+			if int(nwrittenPtr)+4 > len(data) {
+				return wasiErrnoBadf
+			}
+			binary.LittleEndian.PutUint32(data[nwrittenPtr:nwrittenPtr+4], total)
+			return wasiErrnoSuccess
+		}); err != nil {
+		return fmt.Errorf("embedded/wasi: fd_write: %w", err)
+	}
+
+	// fd_read(fd, iovs_ptr, iovs_len, nread_ptr) -> errno. Only fd 0 (stdin)
+	// is a valid target and always reports EOF (0 bytes) — the embedded
+	// runtime has no interactive stdin to serve reads from.
+	if err := linker.DefineFunc(store, mod, "fd_read",
+		func(fd, iovsPtr, iovsLen, nreadPtr int32) int32 {
+			if fd != 0 {
+				return wasiErrnoBadf
+			}
+			data := mem.UnsafeData(store)
+			if int(nreadPtr)+4 > len(data) {
+				return wasiErrnoBadf
+			}
+			binary.LittleEndian.PutUint32(data[nreadPtr:nreadPtr+4], 0)
+			return wasiErrnoSuccess
+		}); err != nil {
+		return fmt.Errorf("embedded/wasi: fd_read: %w", err)
+	}
+
+	// fd_pread / fd_pwrite: no fd this runtime exposes supports positional
+	// I/O — no real file is ever opened through WASI (see file header) — so
+	// both always report EBADF.
+	if err := linker.DefineFunc(store, mod, "fd_pread",
+		func(fd, iovsPtr, iovsLen int32, offset int64, nreadPtr int32) int32 {
+			return wasiErrnoBadf
+		}); err != nil {
+		return fmt.Errorf("embedded/wasi: fd_pread: %w", err)
+	}
+	if err := linker.DefineFunc(store, mod, "fd_pwrite",
+		func(fd, iovsPtr, iovsLen int32, offset int64, nwrittenPtr int32) int32 {
+			return wasiErrnoBadf
+		}); err != nil {
+		return fmt.Errorf("embedded/wasi: fd_pwrite: %w", err)
+	}
+
+	// fd_seek(fd, offset, whence, newoffset_ptr) -> errno. stdio fds are
+	// non-seekable (ESPIPE); anything else is EBADF.
+	if err := linker.DefineFunc(store, mod, "fd_seek",
+		func(fd int32, offset int64, whence int32, newoffsetPtr int32) int32 {
+			if fd >= 0 && fd <= 2 {
+				return wasiErrnoSpipe
+			}
+			return wasiErrnoBadf
+		}); err != nil {
+		return fmt.Errorf("embedded/wasi: fd_seek: %w", err)
+	}
+
+	// fd_close / fd_sync: stdio fds no-op successfully (this runtime does
+	// not actually own fds 0-2 to close/flush); anything else is EBADF.
+	if err := linker.DefineFunc(store, mod, "fd_close", func(fd int32) int32 {
+		if fd >= 0 && fd <= 2 {
+			return wasiErrnoSuccess
+		}
+		return wasiErrnoBadf
+	}); err != nil {
+		return fmt.Errorf("embedded/wasi: fd_close: %w", err)
+	}
+	if err := linker.DefineFunc(store, mod, "fd_sync", func(fd int32) int32 {
+		if fd >= 0 && fd <= 2 {
+			return wasiErrnoSuccess
+		}
+		return wasiErrnoBadf
+	}); err != nil {
+		return fmt.Errorf("embedded/wasi: fd_sync: %w", err)
+	}
+
+	// fd_fdstat_get(fd, stat_ptr) -> errno. Writes a 24-byte __wasi_fdstat_t:
+	// fs_filetype(u8) + 3 pad + fs_flags(u16) + 2 pad + fs_rights_base(u64) +
+	// fs_rights_inheriting(u64). filetype 2 = character_device, matching a
+	// terminal/log stream; rights are set to all bits since nothing in this
+	// shim enforces rights checks on a call.
+	if err := linker.DefineFunc(store, mod, "fd_fdstat_get",
+		func(fd, statPtr int32) int32 {
+			if fd < 0 || fd > 2 {
+				return wasiErrnoBadf
+			}
+			data := mem.UnsafeData(store)
+			if statPtr < 0 || int(statPtr)+24 > len(data) {
+				return wasiErrnoBadf
+			}
+			buf := data[statPtr : statPtr+24]
+			for i := range buf {
+				buf[i] = 0
+			}
+			buf[0] = 2                                            // fs_filetype = character_device
+			binary.LittleEndian.PutUint64(buf[8:16], ^uint64(0))  // fs_rights_base
+			binary.LittleEndian.PutUint64(buf[16:24], ^uint64(0)) // fs_rights_inheriting
+			return wasiErrnoSuccess
+		}); err != nil {
+		return fmt.Errorf("embedded/wasi: fd_fdstat_get: %w", err)
+	}
+
+	// clock_time_get(clock_id, precision, result_ptr) -> errno. clock_id is
+	// ignored — realtime and monotonic both collapse to the host wall
+	// clock, which is all pglite needs for internal timestamps here.
+	if err := linker.DefineFunc(store, mod, "clock_time_get",
+		func(clockID int32, precision int64, resultPtr int32) int32 {
+			data := mem.UnsafeData(store)
+			if resultPtr < 0 || int(resultPtr)+8 > len(data) {
+				return wasiErrnoBadf
+			}
+			binary.LittleEndian.PutUint64(data[resultPtr:resultPtr+8], uint64(time.Now().UnixNano())) //nolint:gosec // wall-clock value, not security sensitive
+			return wasiErrnoSuccess
+		}); err != nil {
+		return fmt.Errorf("embedded/wasi: clock_time_get: %w", err)
+	}
+
+	// environ_sizes_get / environ_get: the embedded runtime passes no
+	// environment to pglite (matching __main_argc_argv(0, 0) — no argv
+	// either), so both report zero entries.
+	if err := linker.DefineFunc(store, mod, "environ_sizes_get",
+		func(countPtr, bufSizePtr int32) int32 {
+			data := mem.UnsafeData(store)
+			if countPtr < 0 || int(countPtr)+4 > len(data) || bufSizePtr < 0 || int(bufSizePtr)+4 > len(data) {
+				return wasiErrnoBadf
+			}
+			binary.LittleEndian.PutUint32(data[countPtr:countPtr+4], 0)
+			binary.LittleEndian.PutUint32(data[bufSizePtr:bufSizePtr+4], 0)
+			return wasiErrnoSuccess
+		}); err != nil {
+		return fmt.Errorf("embedded/wasi: environ_sizes_get: %w", err)
+	}
+	if err := linker.DefineFunc(store, mod, "environ_get",
+		func(environPtr, environBufPtr int32) int32 {
+			return wasiErrnoSuccess // nothing to write; sizes_get already reported 0
+		}); err != nil {
+		return fmt.Errorf("embedded/wasi: environ_get: %w", err)
+	}
+
+	// proc_exit(code) never returns to its caller per spec. code 0 is a
+	// graceful shutdown (mirrors env::exit's convention in
+	// emscripten_abi_runtime.go); any code panics so wasmtime surfaces it as
+	// a trap the boot goroutine reports through exitCh instead of silently
+	// discarding it.
+	if err := linker.DefineFunc(store, mod, "proc_exit", func(code int32) {
+		panic(fmt.Sprintf("pglite: proc_exit(%d)", code))
+	}); err != nil {
+		return fmt.Errorf("embedded/wasi: proc_exit: %w", err)
+	}
+
+	return nil
+}

--- a/internal/embedded/wasmtime_runtime.go
+++ b/internal/embedded/wasmtime_runtime.go
@@ -61,6 +61,13 @@ type EmbeddedPGRuntime struct {
 	wasmPath   string // absolute path to pglite.wasm
 	sockPath   string // AF_UNIX socket path exposed to containers
 
+	// stdoutLog and stderrLog back definePGWasi's fd_write (pg_wasi.go) for
+	// fds 1 and 2. They must stay open for the runtime's whole lifetime —
+	// __main_argc_argv keeps running in a goroutine after boot() returns —
+	// so Stop closes them rather than boot deferring the close.
+	stdoutLog *os.File
+	stderrLog *os.File
+
 	started bool
 	stopped bool
 	err     error // sticky error from a failed Start

--- a/internal/embedded/wasmtime_runtime_boot.go
+++ b/internal/embedded/wasmtime_runtime_boot.go
@@ -58,16 +58,16 @@ func (r *EmbeddedPGRuntime) boot(ctx context.Context) error {
 	r.store = store
 
 	linker := wasmtime.NewLinker(r.engine)
-	if err := linker.DefineWasi(); err != nil {
-		return fmt.Errorf("embedded/runtime: define WASI: %w", err)
-	}
 
 	// pglite v0.2.17 is compiled with Emscripten and requires all 113 env::
-	// host imports to be defined before instantiation. DefineWasi() only covers
-	// WASI preview-1; defineEmscriptenABI defines the remaining Emscripten
-	// symbols (env::exit, invoke_* trampolines, __syscall_* stubs, globals,
-	// memory, and the indirect function table).
-	if err := defineEmscriptenABI(linker, store); err != nil {
+	// host imports to be defined before instantiation, PLUS 12
+	// wasi_snapshot_preview1 imports (defined below by definePGWasi, not
+	// wasmtime's own linker.DefineWasi()). defineEmscriptenABI defines
+	// env::exit, invoke_* trampolines, __syscall_* stubs, globals, memory,
+	// and the indirect function table, and returns the created env::memory
+	// object so definePGWasi can bind to the exact same linear memory.
+	mem, err := defineEmscriptenABI(linker, store)
+	if err != nil {
 		return fmt.Errorf("embedded/runtime: Emscripten ABI: %w", err)
 	}
 
@@ -86,15 +86,29 @@ func (r *EmbeddedPGRuntime) boot(ctx context.Context) error {
 		return fmt.Errorf("embedded/runtime: GOT namespaces: %w", err)
 	}
 
+	// wasmtime's linker.DefineWasi() resolves guest memory via the
+	// INSTANCE's exported "memory" — pglite is a SIDE_MODULE that imports
+	// env::memory and exports nothing named "memory", so DefineWasi()'s
+	// functions trap with "missing required memory export" on first call
+	// (see pg_wasi.go header for the full diagnosis). definePGWasi replaces
+	// it entirely, binding the 12 wasi_snapshot_preview1 functions pglite
+	// actually imports directly to mem.
+	stdoutLog, err := os.OpenFile(filepath.Join(r.runtimeDir, "pglite-stdout.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("embedded/runtime: open stdout log: %w", err)
+	}
+	r.stdoutLog = stdoutLog
+	stderrLog, err := os.OpenFile(filepath.Join(r.runtimeDir, "pglite-stderr.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("embedded/runtime: open stderr log: %w", err)
+	}
+	r.stderrLog = stderrLog
+
+	if err := definePGWasi(linker, store, mem, stdoutLog, stderrLog); err != nil {
+		return fmt.Errorf("embedded/runtime: WASI: %w", err)
+	}
+
 	r.linker = linker
-
-	// Configure WASI: preopened filesystem, environment.
-	wasiCfg := wasmtime.NewWasiConfig()
-	_ = wasiCfg.SetStdoutFile(filepath.Join(r.runtimeDir, "pglite-stdout.log"))
-	_ = wasiCfg.SetStderrFile(filepath.Join(r.runtimeDir, "pglite-stderr.log"))
-	_ = wasiCfg.PreopenDir(filepath.Join(r.runtimeDir, wasmPreopenDir), "/data")
-
-	store.SetWasi(wasiCfg)
 
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("embedded/runtime: context expired before instantiate: %w", err)
@@ -243,6 +257,13 @@ func (r *EmbeddedPGRuntime) Stop() error {
 	r.stopped = true
 
 	_ = os.Remove(r.sockPath)
+
+	if r.stdoutLog != nil {
+		_ = r.stdoutLog.Close()
+	}
+	if r.stderrLog != nil {
+		_ = r.stderrLog.Close()
+	}
 
 	// wasmtime does not have a graceful shutdown path for an instantiated WASM
 	// module. The goroutine running _start will be abandoned; the process will


### PR DESCRIPTION
## Summary

**P6-E11-W2-S1-T5 — embedded PG pglite WASM boot**
- Fixes the diagnosed relocation/memory-export gap (issue #231): wasmtime's `linker.DefineWasi()` requires an *exported* `memory`, but pglite v0.2.17 (an Emscripten SIDE_MODULE) *imports* `env::memory` instead. Replaced with a from-scratch WASI preview1 shim (`internal/embedded/pg_wasi.go`) bound to the host-owned memory object, covering exactly the 12 `wasi_snapshot_preview1` functions pglite imports (confirmed via `wasmtime.Module.Imports()`).
- Boot now proceeds substantially further (trap moved from `missing required memory export` to a later, deeper trap).
- Full boot is NOT reached: Postgres's own startup calls `__syscall_pipe` (latch.c self-pipe trick), which is permanently ENOSYS-stubbed, and Postgres aborts. This is a separate, larger syscall-emulation gap — disposition recorded as **CLOSED-QUARANTINE-HARDENED**, `t.Skip` left in place, issue #231 updated with full diagnosis and kept open.

**P6-E11-W2-S1-T8 — nself access Hetzner mismatch warning**
- Verified all 5 items of issue #238's original ask against the real implementation (idempotent grant, timestamped backup, fingerprint echo, audit log, `--expires`) — all present and correct, no gaps.
- Implemented the one confirmed-missing item: warn when an SSH key is registered at the Hetzner Cloud project level but absent from the target server's `authorized_keys` (`internal/access/hetzner_mismatch.go`), gated behind `HETZNER_NSELF_TOKEN` (empty = silently skipped).
- Documented the new env var in `.github/wiki/Config-Env-Vars.md` (surface-parity gate caught it as newly-undocumented).
- Issue #238 to be closed with evidence comment referencing this PR.

## Test plan
- [x] `gofmt -l cmd internal` — clean
- [x] `go build ./...` (darwin) and `GOOS=linux go build ./...` — both succeed
- [x] `go vet ./...` (darwin + linux) — no issues
- [x] `go test ./... -count=1` — all pass (including `internal/repoqa` file-size and surface-parity gates)
- [x] `golangci-lint run ./... --max-issues-per-linter=0 --max-same-issues=0` (darwin + linux) — 0 issues
- [x] Fresh integration repro: `CGO_ENABLED=1 EMBEDDED_PG_WASM_FIXED=1 PGLITE_WASM_PATH=... go test -tags integration ./internal/embedded/... -run TestEmbeddedPGBootCycle -v` — trap point moved as described, all 4 embedded integration tests fail identically/deterministically at the new (not the old) trap
- [x] `internal/access` + `cmd/commands` full suite green, new `hetzner_mismatch_test.go` covers true-positive and true-negative mismatch cases