### PR TITLE
fix(scripts): plugin-counts double-counted the dual-registry slugs

### DIFF
--- a/scripts/plugin-counts.sh
+++ b/scripts/plugin-counts.sh
@@ -49,9 +49,33 @@ fi
 free_n="$(count "$free_reg")"
 pro_n="$(count "$pro_reg")"
 
+# Six slugs are registered in BOTH registries, and they are not all the same
+# case, so a plain free+pro sum is wrong.
+#
+#   search, webhooks            genuinely different free and paid
+#                               implementations that happen to share a name.
+#                               Two plugins. Count both.
+#   cron, notify,               the same plugin listed twice while a rename
+#   subtitle-manager, vpn       decision is pending. One plugin. Count once.
+#
+# This script is what the PPI, SPORT, the website and marketing copy all cite,
+# so the naive sum published a number that was too high by the size of the
+# second group. The web build had the identical bug independently.
+overlap_dupes="$(python3 -c '
+import json, sys
+free = set(json.load(open(sys.argv[1]))["plugins"])
+pro  = set(json.load(open(sys.argv[2]))["plugins"])
+# Slugs shared by both registries that are ONE plugin, not two.
+distinct_by_design = {"search", "webhooks"}
+print(len((free & pro) - distinct_by_design))
+' "$free_reg" "$pro_reg")"
+
 printf 'free   %s\n' "$free_n"
 printf 'pro    %s\n' "$pro_n"
-printf 'total  %s\n' "$((free_n + pro_n))"
+printf 'total  %s\n' "$((free_n + pro_n - overlap_dupes))"
+if [ "$overlap_dupes" -gt 0 ]; then
+  printf '       (%s dual-registry duplicate(s) deducted; search/webhooks counted twice by design)\n' "$overlap_dupes"
+fi
 
 # The pro directory count is deliberately higher than the registry count: some
 # directories under paid/ are shared code, not plugins. Print the gap with its


### PR DESCRIPTION
`cli/scripts/plugin-counts.sh` is the generator the PPI, SPORT, the website and marketing copy all cite as authoritative. It printed `free + pro` with **no deduplication**.

Six slugs are registered in BOTH registries, and they are not the same case:

| Slugs | Reality | Count as |
|---|---|---|
| `search`, `webhooks` | Genuinely different free and paid implementations sharing a name | **two** |
| `cron`, `notify`, `subtitle-manager`, `vpn` | The same plugin listed twice, pending a rename decision | **one** |

So the naive sum overstated by four. Against `origin/main` it now reports **177**, not 181, and prints the deduction with its reason so the figure can be argued with rather than just trusted.

## Why this matters beyond four plugins
The web build had this **identical bug independently**, fixed in web#153 — which computes the same 177. Two generators, same wrong arithmetic, neither checked against the other.

That is the real lesson: *"the number is generated"* is not the same as *"the number is right"*. Both satisfied the counts-are-generated rule while publishing a wrong figure, and a generated number reads as more authoritative than a hand-typed one, so nobody questions it.

## Operational note recorded in the commit
The script reads the registries as **sibling working directories**, so its output depends on which branch those repos are checked out on. During a multi-agent session they are routinely parked on feature branches, and reading one as live already produced a wrong published figure today. For anything describing what ships, point it at `origin/main` content.