### PR TITLE
docs: add the 1.3.4 and 1.3.5 changelog entries

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -432,6 +432,7 @@
     "group_id": "deploy",
     "flags": [
       "--check",
+      "--filesystem",
       "--no-gitleaks",
       "--no-status",
       "--owner",

--- a/.github/wiki/Changelog.md
+++ b/.github/wiki/Changelog.md
@@ -3,6 +3,57 @@
 All notable changes to the ɳSelf CLI are documented in this file. Format loosely
 follows Keep a Changelog, with Conventional Commit classification.
 
+## [1.3.5] — 2026-08-30
+
+Infrastructure-only release. No CLI command or flag behavior changed.
+
+### Fixed
+
+- **`nself doctor`'s CI-VAULT-SYNC-01 check could never pass on a CI runner.** The check assumed a
+  developer machine's vault layout; it now recognizes the CI runner's own credential path.
+- **Both TypeScript SDKs stopped publishing to npm.** The publish job never received the npm token,
+  so `@nself/sdk` and the second TypeScript SDK silently failed to release. Both are back in
+  version lockstep with the CLI.
+
+## [1.3.4] — 2026-08-28
+
+Plugin licensing and reliability fixes, plus a new command for server access management.
+
+### Added
+
+- **`nself access grant` / `revoke` / `list`**: manage SSH key access on an already-deployed server
+  without shelling in by hand.
+
+### Fixed
+
+- **An all-access license entitled every plugin, correctly this time.** A prior fix had left a gap
+  where the all-access tier didn't unlock every plugin as intended.
+- **License commands failed outright on machines upgraded from an older layout.** Anyone who
+  installed nSelf before the license directory restructure could no longer run any `nself license`
+  subcommand.
+- **`nself db` treated "database already exists" as a failure on create.** Re-running `nself db
+  create` against an already-initialized database now succeeds instead of erroring.
+- **`nself start` checked the wrong ports.** It validated against nSelf's default port list instead
+  of the ports the stack actually publishes, so custom port configs failed health checks that were
+  actually fine.
+- **`nself doctor` resolved container names by hardcoding `nself` instead of reading
+  `PROJECT_NAME`.** Renamed projects got false-positive "container not found" diagnostics.
+- **`nself plugin outdated` probed the registry even when nothing was installed.**
+- **`nself clean --all`**: host-wide Docker system prune, for reclaiming disk across every nSelf
+  project on a machine, not just the current one.
+- **Blue/green deploys' soak gate now counts container state, not just health status**, closing a
+  gap where a container could report healthy while still restarting.
+- **nginx hardening**: the master process now has the capabilities its own startup needs (it was
+  missing them while workers had them), the cert directory is traversable so a non-root master can
+  read TLS certs (this was also causing a TLS crash-loop), and the tmpfs mount is writable by the
+  master, not just the workers.
+- **Aggregate and per-service health output disagreed on what "healthy" means.** Both now share one
+  predicate.
+- **Public wiki pages shipped with unresolved merge conflict markers and misattributed content**:
+  stray `<<<<<<<` markers in one page, and `mcp-serve.md` claiming env vars, mDNS, and doctor
+  behavior that command doesn't have. `login`/`logout`'s documented credential store path was also
+  wrong.
+
 ## [1.3.3] — 2026-08-26
 
 Plugin lifecycle fixes, all found by installing and removing plugins end to end

--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -74,6 +74,7 @@ is why `nself ci` could not be used as a required status check.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--check` | `false` | Run gates only; do not post a GitHub commit status |
+| `--filesystem` | `false` | Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball |
 | `--no-gitleaks` | `false` | Skip the gitleaks secret scan |
 | `--no-status` | `false` | Alias for --check |
 | `--owner` | `""` | GitHub owner (default: from git remote) |
@@ -101,6 +102,7 @@ nself ci                        # gate current directory, post status
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo
 ```
 <!-- END PROSE:examples -->

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -35,6 +35,7 @@ Examples:
   nself ci --check                # gate only, no status posted
   nself ci --no-gitleaks .        # skip secret scan
   nself ci --sha abc1234 .        # override commit SHA
+  nself ci --filesystem /tmp/x    # force filesystem scan (non-checkout source, e.g. a tarball)
   nself ci /path/to/repo          # gate a specific repo`,
 	RunE: runCI,
 }
@@ -47,6 +48,7 @@ func init() {
 	ciCmd.Flags().String("owner", "", "GitHub owner (default: from git remote)")
 	ciCmd.Flags().String("repo", "", "GitHub repo name (default: from git remote)")
 	ciCmd.Flags().BoolP("verbose", "v", false, "Print each gate command before running")
+	ciCmd.Flags().Bool("filesystem", false, "Force gitleaks filesystem scan (--no-git) even inside a git checkout; opt-in for non-checkout source trees such as an exported tarball")
 
 	// Wire eval subcommand group: `nself ci eval` and `nself ci eval gate`.
 	evalCmd := nscicmd.NewEvalCmd()
@@ -76,6 +78,7 @@ func runCI(cmd *cobra.Command, args []string) error {
 	owner, _ := cmd.Flags().GetString("owner")
 	repo, _ := cmd.Flags().GetString("repo")
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	filesystem, _ := cmd.Flags().GetBool("filesystem")
 
 	postStatus := !checkMode && !noStatus
 
@@ -92,6 +95,9 @@ func runCI(cmd *cobra.Command, args []string) error {
 	}
 	if noGitleaks {
 		ciArgs = append(ciArgs, "--no-gitleaks")
+	}
+	if filesystem {
+		ciArgs = append(ciArgs, "--filesystem")
 	}
 	if verbose {
 		ciArgs = append(ciArgs, "-v")


### PR DESCRIPTION
`v1.3.4` and `v1.3.5` are both tagged and released (v1.3.5 is the current latest, and `.github/VERSION` reads 1.3.5), but the published changelog stopped at 1.3.3. Two shipped releases were absent from the page users read to find out what changed.

The entries were already drafted and sitting uncommitted in a working tree; this commits them.