### PR TITLE
fix(security): validate Server.RemotePath and make nself ci serve fail closed

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -478,7 +478,10 @@
         "hidden": false,
         "flags": [
           "--addr",
+          "--allow-unsandboxed",
+          "--allowed-repos",
           "--concurrency",
+          "--insecure",
           "--secret",
           "--timeout",
           "--verbose",

--- a/.github/surface-parity.json
+++ b/.github/surface-parity.json
@@ -61,7 +61,7 @@
       "group_id": "deploy",
       "wiki_page": true,
       "mcp_tool": false,
-      "env_vars": "undocumented: NSELF_FORGEJO_ADMIN_PASSWORD, NSELF_FORGEJO_ADMIN_USER",
+      "env_vars": "undocumented: NSELF_CI_ALLOWED_REPOS, NSELF_CI_ALLOW_UNSANDBOXED, NSELF_FORGEJO_ADMIN_PASSWORD, NSELF_FORGEJO_ADMIN_USER",
       "openapi": "n/a (see below)"
     },
     {

--- a/.github/surface-parity.md
+++ b/.github/surface-parity.md
@@ -18,7 +18,7 @@ One row per top-level command (CLI-R17), scored against the four surfaces a comm
 | `nself backup` | data | yes | yes | n/a | n/a (see below) |
 | `nself build` | core | yes | yes | undocumented: NSELF_PROFILE | n/a (see below) |
 | `nself bundle` | extend | yes | no | n/a | n/a (see below) |
-| `nself ci` | deploy | yes | no | undocumented: NSELF_FORGEJO_ADMIN_PASSWORD, NSELF_FORGEJO_ADMIN_USER | n/a (see below) |
+| `nself ci` | deploy | yes | no | undocumented: NSELF_CI_ALLOWED_REPOS, NSELF_CI_ALLOW_UNSANDBOXED, NSELF_FORGEJO_ADMIN_PASSWORD, NSELF_FORGEJO_ADMIN_USER | n/a (see below) |
 | `nself clean` | core | yes | no | n/a | n/a (see below) |
 | `nself completion` | account | yes | no | n/a | n/a (see below) |
 | `nself config` | config | yes | yes | n/a | n/a (see below) |

--- a/cmd/commands/ci_serve.go
+++ b/cmd/commands/ci_serve.go
@@ -12,6 +12,9 @@ package commands
 // SPORT: CLI-CMD-CI-SERVE-001
 
 import (
+	"os"
+	"strings"
+
 	nscicmd "github.com/nself-org/cli/internal/cmd/ci"
 	"github.com/spf13/cobra"
 )
@@ -30,15 +33,31 @@ commit-status target.
 The server posts a "nself-ci" GitHub commit status (pending → success/failure)
 via gh OAuth, identical to the nself ci one-shot command.
 
+Fail-closed defaults (T32): this daemon clones and executes attacker-
+influenced repo content on inbound webhooks, so three things are required,
+not optional, unless explicitly overridden:
+  - a webhook secret must be configured (--secret / GITHUB_WEBHOOK_SECRET),
+    or the server refuses to start. --insecure overrides this (NOT
+    recommended: disables signature verification entirely).
+  - the triggering repo must be in --allowed-repos / NSELF_CI_ALLOWED_REPOS,
+    or the job is rejected with 403 before any clone happens. An empty
+    allowlist rejects every job — there is no "allow all" override.
+  - Docker must be available to sandbox the job, or the run refuses, unless
+    --allow-unsandboxed is passed (NOT recommended: the cloned repo's gate
+    commands then execute directly on this host with the daemon's own
+    privileges).
+
 Environment variables:
-  GITHUB_WEBHOOK_SECRET  HMAC secret (same value configured in GitHub webhook settings)
-  NSELF_CI_EVENT_SINK    Optional URL to POST completion events (JSON) to — seam for
-                         the nself-cron-monitor plugin on port 3839.
+  GITHUB_WEBHOOK_SECRET     HMAC secret (same value configured in GitHub webhook settings)
+  NSELF_CI_ALLOWED_REPOS    Comma-separated "owner/repo" allowlist (merged with --allowed-repos)
+  NSELF_CI_ALLOW_UNSANDBOXED  "true" to allow running the gate outside Docker (same as --allow-unsandboxed)
+  NSELF_CI_EVENT_SINK       Optional URL to POST completion events (JSON) to — seam for
+                            the nself-cron-monitor plugin on port 3839.
 
 Examples:
-  nself ci serve
-  nself ci serve --addr :3845 --concurrency 4
-  nself ci serve --secret "$GITHUB_WEBHOOK_SECRET" --workdir /var/ci/workdirs`,
+  nself ci serve --secret "$GITHUB_WEBHOOK_SECRET" --allowed-repos nself-org/cli
+  nself ci serve --addr :3845 --concurrency 4 --allowed-repos nself-org/cli,nself-org/web
+  nself ci serve --secret "$GITHUB_WEBHOOK_SECRET" --workdir /var/ci/workdirs --allowed-repos nself-org/cli`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		addr, _ := cmd.Flags().GetString("addr")
 		secret, _ := cmd.Flags().GetString("secret")
@@ -46,16 +65,43 @@ Examples:
 		workdir, _ := cmd.Flags().GetString("workdir")
 		jobTimeout, _ := cmd.Flags().GetInt("timeout")
 		verbose, _ := cmd.Flags().GetBool("verbose")
+		insecure, _ := cmd.Flags().GetBool("insecure")
+		allowUnsandboxed, _ := cmd.Flags().GetBool("allow-unsandboxed")
+		allowedRepos, _ := cmd.Flags().GetStringSlice("allowed-repos")
+
+		if !allowUnsandboxed && strings.EqualFold(os.Getenv("NSELF_CI_ALLOW_UNSANDBOXED"), "true") {
+			allowUnsandboxed = true
+		}
+		allowedRepos = append(allowedRepos, splitAllowedReposEnv(os.Getenv("NSELF_CI_ALLOWED_REPOS"))...)
 
 		return nscicmd.RunServe(nscicmd.ServeConfig{
-			Addr:        addr,
-			Secret:      secret,
-			Concurrency: concurrency,
-			WorkDir:     workdir,
-			JobTimeout:  jobTimeout,
-			Verbose:     verbose,
+			Addr:             addr,
+			Secret:           secret,
+			Concurrency:      concurrency,
+			WorkDir:          workdir,
+			JobTimeout:       jobTimeout,
+			Verbose:          verbose,
+			Insecure:         insecure,
+			AllowUnsandboxed: allowUnsandboxed,
+			AllowedRepos:     allowedRepos,
 		})
 	},
+}
+
+// splitAllowedReposEnv parses a comma-separated NSELF_CI_ALLOWED_REPOS value
+// into a slice, trimming whitespace and dropping empty entries.
+func splitAllowedReposEnv(v string) []string {
+	if v == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(v, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func init() {
@@ -65,6 +111,9 @@ func init() {
 	ciServeCmd.Flags().String("workdir", "/tmp/nself-ci-workdirs", "Base directory for ephemeral checkout workdirs")
 	ciServeCmd.Flags().Int("timeout", 600, "Per-job timeout in seconds")
 	ciServeCmd.Flags().BoolP("verbose", "v", false, "Verbose gate output")
+	ciServeCmd.Flags().Bool("insecure", false, "DANGEROUS: start without a webhook secret (disables signature verification). Default: refuse to start when no secret is configured.")
+	ciServeCmd.Flags().Bool("allow-unsandboxed", false, "DANGEROUS: run the gate directly on this host when Docker is unavailable, instead of refusing the job. Default: refuse.")
+	ciServeCmd.Flags().StringSlice("allowed-repos", nil, "Comma-separated or repeatable \"owner/repo\" allowlist. Default: empty, which rejects every job (fail-closed, no \"allow all\").")
 
 	ciCmd.AddCommand(ciServeCmd)
 }

--- a/cmd/commands/deploy.go
+++ b/cmd/commands/deploy.go
@@ -9,12 +9,18 @@ import (
 	"strings"
 
 	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/deploy"
 
 	"github.com/spf13/cobra"
 )
 
 // remotePathRe allows safe remote path characters: alphanumeric, slash, hyphen, underscore, dot.
-var remotePathRe = regexp.MustCompile(`^[a-zA-Z0-9/_.-]+$`)
+// Aliased from internal/deploy.RemotePathRe (T31 fix) so every remote-path
+// validation site in the codebase (this file's --remote-path flag,
+// env_target_crud.go's `env target add --remote-path`, and
+// internal/controlplane's inventory Load/synthesize) shares one definition
+// instead of three that could silently drift apart.
+var remotePathRe = deploy.RemotePathRe
 
 // sshKeyRe allows safe filesystem path characters for the SSH key path.
 // The key path is interpolated into the rsync "-e ssh -i %s ..." string, which

--- a/cmd/commands/env_target_crud.go
+++ b/cmd/commands/env_target_crud.go
@@ -20,6 +20,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/nself-org/cli/internal/controlplane"
+	"github.com/nself-org/cli/internal/deploy"
 	"github.com/spf13/cobra"
 )
 
@@ -130,6 +131,14 @@ func runEnvTargetAdd(cmd *cobra.Command, args []string) error {
 	}
 	if err := rejectInlineSecret("--key-ref", keyRef); err != nil {
 		return err
+	}
+	// Security (T31): remotePath is persisted into .nself/control-plane.yaml
+	// and later interpolated into shell command strings run on the remote
+	// host (see internal/deploy/ssh.go's DeployViaSsh). Reject unsafe
+	// characters here, at the same point --host/--key-ref are already
+	// checked, using the same charset as `nself deploy --remote-path`.
+	if err := deploy.ValidateRemotePath(remotePath); err != nil {
+		return fmt.Errorf("--remote-path: %w", err)
 	}
 
 	role, ok := validRoles[strings.ToLower(roleStr)]

--- a/cmd/commands/env_target_test.go
+++ b/cmd/commands/env_target_test.go
@@ -289,6 +289,98 @@ func TestEnvTargetAdd_InlineKeyRefRejected(t *testing.T) {
 	}
 }
 
+// TestEnvTargetAdd_RemotePathInjectionRejected (T31) verifies that
+// `env target add --remote-path` rejects values containing shell
+// metacharacters before they are ever persisted to
+// .nself/control-plane.yaml, since RemotePath is later interpolated into a
+// shell command string run on the remote host over SSH.
+func TestEnvTargetAdd_RemotePathInjectionRejected(t *testing.T) {
+	payloads := []string{
+		"/opt/x; id",
+		"/opt/x$(id)",
+		"/opt/x`id`",
+		"/opt/x | id",
+		"/opt/x && id",
+	}
+
+	for _, payload := range payloads {
+		payload := payload
+		t.Run(payload, func(t *testing.T) {
+			root, cleanup := newTestRoot(t)
+			defer cleanup()
+
+			writeInventory(t, root, &controlplane.Inventory{
+				SchemaVersion: 1,
+				Project:       "test",
+				Environments:  map[string]controlplane.Environment{},
+			})
+
+			cmd := envTargetAddCmd
+			cmd.ResetFlags()
+			cmd.Flags().String("host", "ubuntu@staging.example.com", "")
+			cmd.Flags().String("role", "app", "")
+			cmd.Flags().String("key-ref", "NSELF_SSH_KEY_STAGING", "")
+			cmd.Flags().String("remote-path", "/opt/nself", "")
+			cmd.Flags().Bool("primary", false, "")
+			cmd.Flags().StringSlice("upstreams", nil, "")
+			_ = cmd.Flags().Set("remote-path", payload)
+
+			err := runEnvTargetAdd(cmd, []string{"staging", "web1"})
+			if err == nil {
+				t.Fatalf("expected error for malicious --remote-path %q, got nil", payload)
+			}
+			if !strings.Contains(err.Error(), "unsafe characters") {
+				t.Errorf("unexpected error for %q: %v", payload, err)
+			}
+
+			// The malicious value must never reach the inventory file.
+			inv := readInventory(t, root)
+			if stg, ok := inv.Environments["staging"]; ok {
+				for _, s := range stg.Servers {
+					if s.RemotePath == payload {
+						t.Errorf("malicious RemotePath %q was written to control-plane.yaml", payload)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestEnvTargetAdd_RemotePathNormalPathAccepted (T31) proves the new guard
+// causes no regression for legitimate remote paths.
+func TestEnvTargetAdd_RemotePathNormalPathAccepted(t *testing.T) {
+	root, cleanup := newTestRoot(t)
+	defer cleanup()
+
+	writeInventory(t, root, &controlplane.Inventory{
+		SchemaVersion: 1,
+		Project:       "test",
+		Environments:  map[string]controlplane.Environment{},
+	})
+
+	cmd := envTargetAddCmd
+	cmd.ResetFlags()
+	cmd.Flags().String("host", "ubuntu@staging.example.com", "")
+	cmd.Flags().String("role", "app", "")
+	cmd.Flags().String("key-ref", "NSELF_SSH_KEY_STAGING", "")
+	cmd.Flags().String("remote-path", "/opt/nself", "")
+	cmd.Flags().Bool("primary", false, "")
+	cmd.Flags().StringSlice("upstreams", nil, "")
+
+	if err := runEnvTargetAdd(cmd, []string{"staging", "web1"}); err != nil {
+		t.Fatalf("add with normal --remote-path: %v", err)
+	}
+
+	inv := readInventory(t, root)
+	stg, ok := inv.Environments["staging"]
+	if !ok || len(stg.Servers) != 1 {
+		t.Fatal("expected staging environment with 1 server")
+	}
+	if stg.Servers[0].RemotePath != "/opt/nself" {
+		t.Errorf("RemotePath: got %q, want /opt/nself", stg.Servers[0].RemotePath)
+	}
+}
+
 func TestEnvTargetRemove_NotFound(t *testing.T) {
 	root, cleanup := newTestRoot(t)
 	defer cleanup()

--- a/internal/cmd/ci/serve.go
+++ b/internal/cmd/ci/serve.go
@@ -35,6 +35,28 @@ type ServeConfig struct {
 	WorkDir     string // base dir for ephemeral checkouts
 	JobTimeout  int    // per-job timeout in seconds
 	Verbose     bool
+
+	// Insecure opts out of the fail-closed "refuse to start without a
+	// webhook secret" default (T32). When true and no secret is configured,
+	// RunServe starts anyway with signature verification disabled — the
+	// previous, unconditional behavior. Off by default.
+	Insecure bool
+
+	// AllowUnsandboxed opts out of the fail-closed "refuse to run a job
+	// when Docker is unavailable" default (T32). When false (default) and
+	// Docker is not on PATH, runGateInDocker refuses the job instead of
+	// silently executing the cloned repo's gate commands directly on the
+	// host. When true, the previous runGateDirect fallback behavior
+	// applies.
+	AllowUnsandboxed bool
+
+	// AllowedRepos is the set of "owner/repo" full names this server will
+	// dispatch jobs for. Fail-closed by design: an EMPTY list rejects every
+	// job (not "allow all") — an operator who configured zero repos almost
+	// certainly forgot to configure this, not intentionally wants an open
+	// relay that clones and executes whatever repository a validly-signed
+	// (or, if --insecure, any) webhook payload names.
+	AllowedRepos []string
 }
 
 // RunServe starts the webhook listener and blocks until SIGINT/SIGTERM.
@@ -45,6 +67,13 @@ func RunServe(cfg ServeConfig) error {
 		secret = os.Getenv("GITHUB_WEBHOOK_SECRET")
 	}
 	if secret == "" {
+		// T32: a webhook endpoint with no secret accepts and dispatches ANY
+		// POST body with no authentication at all — a fully open trigger
+		// for cloning and executing arbitrary repository content. Fail
+		// closed by default; --insecure is the loud, explicit opt-out.
+		if !cfg.Insecure {
+			return fmt.Errorf("refusing to start: no webhook secret configured (--secret or GITHUB_WEBHOOK_SECRET); pass --insecure to start anyway (NOT recommended — this exposes an unauthenticated arbitrary-repo code-execution endpoint)")
+		}
 		ui.Warn("GITHUB_WEBHOOK_SECRET not set — webhook signature verification DISABLED (insecure)")
 	}
 

--- a/internal/cmd/ci/serve_job.go
+++ b/internal/cmd/ci/serve_job.go
@@ -118,7 +118,15 @@ func runGateInDocker(binaryPath, workdir string, cfg ServeConfig) (passed bool, 
 
 	// Check Docker availability.
 	if _, lookErr := exec.LookPath("docker"); lookErr != nil {
-		// Docker not available — fall back to running the binary directly on host.
+		// T32: Docker absence used to silently fall back to running the
+		// just-cloned, attacker-influenced repo's gate commands directly on
+		// the host with this daemon's own privileges — no log line
+		// distinguished this from the sandboxed path. Refuse by default;
+		// --allow-unsandboxed / NSELF_CI_ALLOW_UNSANDBOXED is the explicit,
+		// loud opt-in for legitimate no-Docker deployments.
+		if !cfg.AllowUnsandboxed {
+			return false, "Docker not available", fmt.Errorf("Docker not available; refusing to run gate unsandboxed — pass --allow-unsandboxed to override, understanding the cloned repo's content would then execute directly on this host")
+		}
 		return runGateDirect(binaryPath, workdir, cfg)
 	}
 

--- a/internal/cmd/ci/serve_job.go
+++ b/internal/cmd/ci/serve_job.go
@@ -125,7 +125,7 @@ func runGateInDocker(binaryPath, workdir string, cfg ServeConfig) (passed bool, 
 		// --allow-unsandboxed / NSELF_CI_ALLOW_UNSANDBOXED is the explicit,
 		// loud opt-in for legitimate no-Docker deployments.
 		if !cfg.AllowUnsandboxed {
-			return false, "Docker not available", fmt.Errorf("Docker not available; refusing to run gate unsandboxed — pass --allow-unsandboxed to override, understanding the cloned repo's content would then execute directly on this host")
+			return false, "Docker not available", fmt.Errorf("cannot reach Docker; refusing to run the gate unsandboxed. Pass --allow-unsandboxed to override, understanding that the cloned repo's content would then execute directly on this host")
 		}
 		return runGateDirect(binaryPath, workdir, cfg)
 	}

--- a/internal/cmd/ci/serve_job.go
+++ b/internal/cmd/ci/serve_job.go
@@ -125,7 +125,7 @@ func runGateInDocker(binaryPath, workdir string, cfg ServeConfig) (passed bool, 
 		// --allow-unsandboxed / NSELF_CI_ALLOW_UNSANDBOXED is the explicit,
 		// loud opt-in for legitimate no-Docker deployments.
 		if !cfg.AllowUnsandboxed {
-			return false, "Docker not available", fmt.Errorf("cannot reach Docker; refusing to run the gate unsandboxed. Pass --allow-unsandboxed to override, understanding that the cloned repo's content would then execute directly on this host")
+			return false, "Docker not available", fmt.Errorf("cannot reach Docker; refusing to run gate unsandboxed. Pass --allow-unsandboxed to override, understanding that the cloned repo's content would then execute directly on this host")
 		}
 		return runGateDirect(binaryPath, workdir, cfg)
 	}

--- a/internal/cmd/ci/serve_job_test.go
+++ b/internal/cmd/ci/serve_job_test.go
@@ -1,0 +1,71 @@
+package ci
+
+// Purpose: Tests for the T32 fail-closed Docker-absent behavior in
+//
+//	runGateInDocker — a job must refuse to run unsandboxed on the host
+//	when Docker is unavailable, unless the operator explicitly opts in.
+//
+// Inputs:  a PATH manipulated to guarantee `docker` is not resolvable
+// Outputs: pass/fail refusal behavior of runGateInDocker
+// Constraints: does not require Docker or the nself-ci binary to be present;
+//
+//	exercises only the LookPath("docker") branch and its two outcomes.
+//
+// SPORT: CLI-CMD-CI-SERVE-001
+
+import (
+	"strings"
+	"testing"
+)
+
+// withNoDockerOnPath points PATH at an empty temp dir for the duration of
+// the test, guaranteeing exec.LookPath("docker") fails regardless of what
+// is actually installed on the host running this test suite.
+func withNoDockerOnPath(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
+// TestRunGateInDocker_RefusesWhenDockerAbsentAndNotAllowed (T32) is the
+// core fail-closed assertion: Docker missing + AllowUnsandboxed=false must
+// refuse the job with a clear error, never silently fall back to running
+// the cloned repo's gate commands directly on the host.
+func TestRunGateInDocker_RefusesWhenDockerAbsentAndNotAllowed(t *testing.T) {
+	withNoDockerOnPath(t)
+
+	cfg := ServeConfig{JobTimeout: 5, AllowUnsandboxed: false}
+	passed, summary, err := runGateInDocker("/usr/local/bin/nself-ci", t.TempDir(), cfg)
+
+	if err == nil {
+		t.Fatal("runGateInDocker with Docker absent and AllowUnsandboxed=false: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to run gate unsandboxed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if passed {
+		t.Error("passed = true, want false for a refused job")
+	}
+	if summary != "Docker not available" {
+		t.Errorf("summary = %q, want %q", summary, "Docker not available")
+	}
+}
+
+// TestRunGateInDocker_FallsBackWhenAllowUnsandboxedSet (T32) proves the
+// opt-in path still works for legitimate no-Docker deployments: with
+// AllowUnsandboxed=true, runGateInDocker must NOT return the "refusing to
+// run gate unsandboxed" error — it proceeds to runGateDirect instead (which
+// will itself fail here because the binary path is fake, but that failure
+// is a different, unrelated error, proving the fallback branch was taken).
+func TestRunGateInDocker_FallsBackWhenAllowUnsandboxedSet(t *testing.T) {
+	withNoDockerOnPath(t)
+
+	cfg := ServeConfig{JobTimeout: 5, AllowUnsandboxed: true}
+	_, _, err := runGateInDocker("/nonexistent/nself-ci-binary", t.TempDir(), cfg)
+
+	if err == nil {
+		t.Fatal("expected an error from runGateDirect against a nonexistent binary, got nil")
+	}
+	if strings.Contains(err.Error(), "refusing to run gate unsandboxed") {
+		t.Errorf("AllowUnsandboxed=true still hit the refusal branch: %v", err)
+	}
+}

--- a/internal/cmd/ci/serve_test.go
+++ b/internal/cmd/ci/serve_test.go
@@ -166,7 +166,7 @@ func TestWebhookHandler_signatureRequired(t *testing.T) {
 		secret:     secret,
 		sem:        make(chan struct{}, 1),
 		binaryPath: "/usr/local/bin/nself-ci",
-		cfg:        ServeConfig{Concurrency: 1, JobTimeout: 60},
+		cfg:        ServeConfig{Concurrency: 1, JobTimeout: 60, AllowedRepos: []string{"o/r"}},
 	}
 
 	// Missing signature — must be 403.
@@ -190,13 +190,15 @@ func TestWebhookHandler_signatureRequired(t *testing.T) {
 }
 
 func TestWebhookHandler_noSecret(t *testing.T) {
-	// When secret is empty, all POSTs are accepted without signature check.
+	// When secret is empty (the --insecure path; RunServe refuses to reach
+	// this state otherwise per T32), POSTs for an allowlisted repo are
+	// still accepted without a signature check.
 	body := []byte(`{"after":"aabbcc","ref":"refs/heads/feat","deleted":false,"repository":{"full_name":"o/r","clone_url":"https://github.com/o/r.git"}}`)
 	handler := &webhookHandler{
 		secret:     "",
 		sem:        make(chan struct{}, 1),
 		binaryPath: "/usr/local/bin/nself-ci",
-		cfg:        ServeConfig{Concurrency: 1, JobTimeout: 60},
+		cfg:        ServeConfig{Concurrency: 1, JobTimeout: 60, AllowedRepos: []string{"o/r"}},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
 	req.Header.Set("X-GitHub-Event", "push")
@@ -204,6 +206,106 @@ func TestWebhookHandler_noSecret(t *testing.T) {
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusAccepted {
 		t.Errorf("no-secret: got %d, want 202", w.Code)
+	}
+}
+
+// TestWebhookHandler_repoNotAllowlisted (T32) verifies a validly-signed
+// payload for a repo NOT present in AllowedRepos is rejected with 403
+// before any clone/dispatch — the handler must never reach cloneRef/runJob
+// for a non-allowlisted repo, no matter how the signature check resolved.
+func TestWebhookHandler_repoNotAllowlisted(t *testing.T) {
+	secret := "webhook-secret"
+	body := []byte(`{"after":"abc123","ref":"refs/heads/main","deleted":false,"repository":{"full_name":"attacker/evil-repo","clone_url":"https://github.com/attacker/evil-repo.git"}}`)
+
+	handler := &webhookHandler{
+		secret:     secret,
+		sem:        make(chan struct{}, 1),
+		binaryPath: "/usr/local/bin/nself-ci",
+		cfg:        ServeConfig{Concurrency: 1, JobTimeout: 60, AllowedRepos: []string{"nself-org/cli"}},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("X-Hub-Signature-256", signBody(secret, body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("non-allowlisted repo: got %d, want 403 — body: %s", w.Code, w.Body.String())
+	}
+	// The dispatch semaphore must never have been acquired for a rejected
+	// repo — if it had, len(handler.sem) would be nonzero right after
+	// ServeHTTP returns synchronously with the rejection (no goroutine was
+	// launched to release it).
+	if len(handler.sem) != 0 {
+		t.Errorf("non-allowlisted repo: job appears to have been dispatched (sem held), want no dispatch")
+	}
+}
+
+// TestWebhookHandler_emptyAllowlistRejectsEverything (T32) proves the
+// fail-closed default: an empty AllowedRepos list rejects every repo, not
+// "allow all" — an operator who configured zero repos almost certainly
+// forgot to configure --allowed-repos, not intentionally wants an open relay.
+func TestWebhookHandler_emptyAllowlistRejectsEverything(t *testing.T) {
+	secret := "webhook-secret"
+	body := []byte(`{"after":"abc123","ref":"refs/heads/main","deleted":false,"repository":{"full_name":"nself-org/cli","clone_url":"https://github.com/nself-org/cli.git"}}`)
+
+	handler := &webhookHandler{
+		secret:     secret,
+		sem:        make(chan struct{}, 1),
+		binaryPath: "/usr/local/bin/nself-ci",
+		cfg:        ServeConfig{Concurrency: 1, JobTimeout: 60, AllowedRepos: nil},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("X-Hub-Signature-256", signBody(secret, body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("empty allowlist: got %d, want 403 — body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestIsRepoAllowed (T32) unit-tests the allowlist predicate directly.
+func TestIsRepoAllowed(t *testing.T) {
+	cases := []struct {
+		repo    string
+		allowed []string
+		want    bool
+	}{
+		{"o/r", nil, false},
+		{"o/r", []string{}, false},
+		{"o/r", []string{"o/r"}, true},
+		{"o/r", []string{"other/repo"}, false},
+		{"o/r", []string{"other/repo", "o/r"}, true},
+	}
+	for _, c := range cases {
+		if got := isRepoAllowed(c.repo, c.allowed); got != c.want {
+			t.Errorf("isRepoAllowed(%q, %v) = %v, want %v", c.repo, c.allowed, got, c.want)
+		}
+	}
+}
+
+// TestRunServe_RefusesToStartWithoutSecret (T32) is the fail-closed unit
+// test for RunServe's startup gate: with no --secret, no
+// GITHUB_WEBHOOK_SECRET, and Insecure=false, RunServe must return an error
+// immediately (before creating a workdir or resolving the ci binary), never
+// warn-and-continue.
+func TestRunServe_RefusesToStartWithoutSecret(t *testing.T) {
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "")
+
+	err := RunServe(ServeConfig{
+		Addr:     ":0",
+		Secret:   "",
+		Insecure: false,
+	})
+	if err == nil {
+		t.Fatal("RunServe with no secret and Insecure=false: expected refusal error, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to start") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 
@@ -263,7 +365,7 @@ func TestWebhookHandler_concurrencyLimit(t *testing.T) {
 		secret:     "",
 		sem:        make(chan struct{}),
 		binaryPath: "/usr/local/bin/nself-ci",
-		cfg:        ServeConfig{Concurrency: 0, JobTimeout: 60},
+		cfg:        ServeConfig{Concurrency: 0, JobTimeout: 60, AllowedRepos: []string{"o/r"}},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
 	req.Header.Set("X-GitHub-Event", "push")
@@ -299,11 +401,12 @@ func TestWebhookHandler_getNotAllowed(t *testing.T) {
 func TestIntegration_HttpServer(t *testing.T) {
 	secret := "integration-test-secret"
 	cfg := ServeConfig{
-		Addr:        ":0", // let OS assign port
-		Secret:      secret,
-		Concurrency: 1,
-		WorkDir:     t.TempDir(),
-		JobTimeout:  5,
+		Addr:         ":0", // let OS assign port
+		Secret:       secret,
+		Concurrency:  1,
+		WorkDir:      t.TempDir(),
+		JobTimeout:   5,
+		AllowedRepos: []string{"nself-org/test"},
 	}
 
 	// Start server in background.

--- a/internal/cmd/ci/serve_webhook.go
+++ b/internal/cmd/ci/serve_webhook.go
@@ -92,6 +92,18 @@ func (h *webhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Repo allowlist (T32): reject any job whose RepoFullName is not in the
+	// configured set BEFORE cloneRef is ever called. An empty AllowedRepos
+	// list rejects everything — fail-closed, not "allow all" — since a
+	// valid signature alone (or, under --insecure, no signature at all)
+	// must never be sufficient to dispatch a clone+build of an arbitrary
+	// repository.
+	if !isRepoAllowed(job.RepoFullName, h.cfg.AllowedRepos) {
+		ui.Warn(fmt.Sprintf("[ci-serve] rejected: repo %q is not in --allowed-repos", job.RepoFullName))
+		http.Error(w, fmt.Sprintf("repo %q is not allowlisted", job.RepoFullName), http.StatusForbidden)
+		return
+	}
+
 	// Dispatch asynchronously.
 	select {
 	case h.sem <- struct{}{}:
@@ -169,6 +181,23 @@ func parseEvent(event string, body []byte) (ciJob, error) {
 	default:
 		return ciJob{}, fmt.Errorf("event %q: skip", event)
 	}
+}
+
+// isRepoAllowed reports whether repoFullName ("owner/repo") is present in
+// allowed. An empty allowed list rejects everything — fail-closed by design
+// (T32) — since an operator with zero configured repos almost certainly
+// forgot to configure --allowed-repos / NSELF_CI_ALLOWED_REPOS, rather than
+// intentionally wanting an open relay.
+func isRepoAllowed(repoFullName string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return false
+	}
+	for _, a := range allowed {
+		if a == repoFullName {
+			return true
+		}
+	}
+	return false
 }
 
 // verifySignature checks the X-Hub-Signature-256 header against body using secret.

--- a/internal/controlplane/inventory.go
+++ b/internal/controlplane/inventory.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nself-org/cli/internal/deploy"
 	"gopkg.in/yaml.v3"
 )
 
@@ -58,7 +59,17 @@ func Load(projectRoot string) (*Inventory, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return synthesize(), nil
+			synthesized := synthesize()
+			// T31: synthesize() builds Server.RemotePath from
+			// NSELF_REMOTE_PATH_<TARGET> environment variables, another
+			// external-input path into the same field the YAML-load path
+			// below validates. Apply the identical guard so an operator
+			// (or a compromised env) cannot smuggle shell metacharacters in
+			// through this route either.
+			if err := validateInventoryNames(synthesized); err != nil {
+				return nil, err
+			}
+			return synthesized, nil
 		}
 		return nil, fmt.Errorf("controlplane: read inventory: %w", err)
 	}
@@ -81,12 +92,24 @@ func Load(projectRoot string) (*Inventory, error) {
 	return &inv, nil
 }
 
-// validateInventoryNames checks every Server.Name in inv against serverNameRe.
+// validateInventoryNames checks every Server.Name against serverNameRe and
+// every Server.RemotePath against deploy.ValidateRemotePath.
+//
+// This is the defense point for the file-load path: .nself/control-plane.yaml
+// is a hand-editable / import-able YAML file, so a RemotePath smuggled in via
+// a manually edited or migrated inventory file (rather than through
+// `env target add --remote-path`, which validates at the flag layer) is
+// caught here before the inventory is ever used to build an SSH deploy
+// command (T31 — RemotePath is interpolated into a remote shell string in
+// internal/deploy/ssh.go's DeployViaSsh).
 func validateInventoryNames(inv *Inventory) error {
 	for envName, env := range inv.Environments {
 		for _, srv := range env.Servers {
 			if err := ValidateServerName(srv.Name); err != nil {
 				return fmt.Errorf("controlplane: env %q: %w", envName, err)
+			}
+			if err := deploy.ValidateRemotePath(srv.RemotePath); err != nil {
+				return fmt.Errorf("controlplane: env %q: server %q: %w", envName, srv.Name, err)
 			}
 		}
 	}

--- a/internal/controlplane/inventory_test.go
+++ b/internal/controlplane/inventory_test.go
@@ -308,3 +308,61 @@ environments:
 		t.Error("Load: expected error for invalid server name, got nil")
 	}
 }
+
+// TestLoadRejectsInvalidRemotePath (T31) verifies that a hand-edited or
+// imported .nself/control-plane.yaml carrying a RemotePath with shell
+// metacharacters is rejected by Load, not just the `env target add` CLI
+// flag path. RemotePath is later interpolated into a shell command string
+// executed on the remote host over SSH (internal/deploy/ssh.go).
+func TestLoadRejectsInvalidRemotePath(t *testing.T) {
+	payloads := []string{
+		"/opt/x; id",
+		"/opt/x$(id)",
+		"/opt/x`id`",
+	}
+
+	for _, payload := range payloads {
+		dir := t.TempDir()
+		nself := filepath.Join(dir, ".nself")
+		if err := os.MkdirAll(nself, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		content := "schema_version: 1\n" +
+			"project: evilproject\n" +
+			"environments:\n" +
+			"  prod:\n" +
+			"    name: prod\n" +
+			"    kind: remote\n" +
+			"    servers:\n" +
+			"      - name: web1\n" +
+			"        role: app\n" +
+			"        host: ubuntu@prod.example.com\n" +
+			"        ssh_key_ref: NSELF_SSH_KEY_PROD\n" +
+			"        remote_path: \"" + payload + "\"\n" +
+			"        primary: true\n"
+
+		p := filepath.Join(nself, "control-plane.yaml")
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+
+		if _, err := Load(dir); err == nil {
+			t.Errorf("Load: expected error for RemotePath %q, got nil", payload)
+		}
+	}
+}
+
+// TestLoadSynthesizeRejectsInvalidRemotePathEnvVar (T31) verifies the
+// env-var synthesis path (Load when .nself/control-plane.yaml is absent)
+// applies the same RemotePath guard, since NSELF_REMOTE_PATH_<TARGET> is
+// just as much external input as the YAML file.
+func TestLoadSynthesizeRejectsInvalidRemotePathEnvVar(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("NSELF_DEPLOY_HOST_STAGING", "ubuntu@staging.example.com")
+	t.Setenv("NSELF_REMOTE_PATH_STAGING", "/opt/x; id")
+
+	if _, err := Load(dir); err == nil {
+		t.Error("Load: expected error for malicious NSELF_REMOTE_PATH_STAGING, got nil")
+	}
+}

--- a/internal/deploy/ssh.go
+++ b/internal/deploy/ssh.go
@@ -67,6 +67,18 @@ func DeployViaSsh(ctx context.Context, cfg SSHConfig, composePath string) error 
 		return err
 	}
 
+	// T31 defense-in-depth: remotePath is about to be joined into a path and
+	// interpolated into shell command strings executed on the remote host
+	// (see the fmt.Sprintf calls below and runSSH). The CLI-flag and
+	// inventory-file layers (cmd/commands/env_target_crud.go,
+	// internal/controlplane's inventory Load/synthesize) already validate
+	// this before it reaches SSHConfig, but this check holds even if a
+	// future caller (a test, a new command) constructs an SSHConfig
+	// directly, bypassing those layers.
+	if err := ValidateRemotePath(remotePath); err != nil {
+		return fmt.Errorf("SSHConfig.Host: %w", err)
+	}
+
 	remoteCompose := filepath.Join(remotePath, "nself-compose.yml")
 	if remotePath == "" || remotePath == "/" {
 		remoteCompose = "/tmp/nself-compose.yml"

--- a/internal/deploy/ssh_test.go
+++ b/internal/deploy/ssh_test.go
@@ -1,0 +1,44 @@
+package deploy
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestDeployViaSsh_RejectsInjectedRemotePath (T31) is the defense-in-depth
+// test for DeployViaSsh: even when an SSHConfig is constructed directly
+// (bypassing the CLI-flag and inventory-file validation layers in
+// cmd/commands and internal/controlplane), a Host carrying a RemotePath
+// with shell metacharacters must be rejected before any rsync/ssh exec call
+// is attempted -- so this test needs neither binary to be present on PATH.
+func TestDeployViaSsh_RejectsInjectedRemotePath(t *testing.T) {
+	payloads := []string{
+		"ubuntu@example.com:/opt/x; id",
+		"ubuntu@example.com:/opt/x$(id)",
+		"ubuntu@example.com:/opt/x`id`",
+	}
+
+	for _, host := range payloads {
+		cfg := SSHConfig{Host: host, KeyPath: "/tmp/does-not-matter"}
+		err := DeployViaSsh(context.Background(), cfg, "/tmp/nself-compose.yml")
+		if err == nil {
+			t.Fatalf("DeployViaSsh(%q): expected rejection, got nil error", host)
+		}
+		if !strings.Contains(err.Error(), "unsafe characters") {
+			t.Errorf("DeployViaSsh(%q): unexpected error: %v", host, err)
+		}
+	}
+}
+
+// TestDeployViaSsh_EmptyHost proves the pre-existing empty-Host guard is
+// unaffected by the new RemotePath check (which runs after it).
+func TestDeployViaSsh_EmptyHost(t *testing.T) {
+	err := DeployViaSsh(context.Background(), SSHConfig{}, "/tmp/nself-compose.yml")
+	if err == nil {
+		t.Fatal("DeployViaSsh with empty Host: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Host is empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/deploy/validate.go
+++ b/internal/deploy/validate.go
@@ -1,0 +1,46 @@
+// Purpose: shared validation for remote-path values that get interpolated
+// into shell command strings executed on remote hosts over SSH (docker
+// compose invocations built with fmt.Sprintf and handed to `ssh` as a single
+// argv element, which the remote shell then parses).
+// Inputs: a candidate remote-path string, from any input source: a CLI flag
+// (`nself deploy --remote-path`, `nself env target add --remote-path`), a
+// parsed .nself/control-plane.yaml inventory file, or an
+// NSELF_REMOTE_PATH_<TARGET> environment variable.
+// Outputs: nil when the path is empty or matches the allowed charset;
+// otherwise a descriptive error naming the offending value.
+// Constraints: this is the single source of truth for the remote-path
+// charset enforced across cmd/commands (deploy, deploy_remote, env target
+// add) and internal/controlplane (inventory Load/synthesize). Centralizing
+// it here (rather than in cmd/commands, which internal/controlplane already
+// imports transitively via internal/deploy) avoids an import cycle while
+// keeping every enforcement point byte-identical. Deliberately an allowlist
+// (reject anything outside a known-safe charset), not a blacklist of known-
+// bad shell metacharacters, per the standing guidance that allowlists are
+// harder to bypass via an overlooked special character.
+package deploy
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// RemotePathRe allows safe remote path characters: alphanumeric, slash,
+// hyphen, underscore, dot. Anything else (';', '$', '`', '|', '&', spaces,
+// etc.) is rejected, since the value is later embedded directly into a
+// shell command string executed on a remote host.
+var RemotePathRe = regexp.MustCompile(`^[a-zA-Z0-9/_.-]+$`)
+
+// ValidateRemotePath returns an error when path is non-empty and contains
+// characters outside RemotePathRe's allowed charset. An empty path is
+// treated as valid here — callers that require a non-empty path (e.g. a
+// remote deploy target) must check that separately; ssh.go's DeployViaSsh
+// already falls back to /tmp when the recovered remote path is empty.
+func ValidateRemotePath(path string) error {
+	if path == "" {
+		return nil
+	}
+	if !RemotePathRe.MatchString(path) {
+		return fmt.Errorf("remote path contains unsafe characters (got %q): only [a-zA-Z0-9/_.-] allowed", path)
+	}
+	return nil
+}

--- a/internal/deploy/validate_test.go
+++ b/internal/deploy/validate_test.go
@@ -1,0 +1,41 @@
+package deploy
+
+import "testing"
+
+// TestValidateRemotePath_RejectsInjectionPayloads (T31) asserts the shared
+// remote-path validator rejects shell metacharacters that would otherwise
+// reach a remote shell via DeployViaSsh's fmt.Sprintf-built commands.
+func TestValidateRemotePath_RejectsInjectionPayloads(t *testing.T) {
+	payloads := []string{
+		"/opt/x; id",
+		"/opt/x$(id)",
+		"/opt/x`id`",
+		"/opt/x | id",
+		"/opt/x && id",
+		"/opt/x\nid",
+		"/opt/x id",
+	}
+	for _, p := range payloads {
+		if err := ValidateRemotePath(p); err == nil {
+			t.Errorf("ValidateRemotePath(%q): expected error, got nil", p)
+		}
+	}
+}
+
+// TestValidateRemotePath_AcceptsLegitimatePaths proves no regression for the
+// paths real deployments use.
+func TestValidateRemotePath_AcceptsLegitimatePaths(t *testing.T) {
+	ok := []string{
+		"",
+		"/opt/nself",
+		"/opt/nself-staging",
+		"/home/ubuntu/app_v2",
+		"opt/nself",
+		"/opt/nself.d",
+	}
+	for _, p := range ok {
+		if err := ValidateRemotePath(p); err != nil {
+			t.Errorf("ValidateRemotePath(%q): unexpected error: %v", p, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- T31 (P6-E11-W2-S2-T31): `env target add --remote-path` had no validation, unlike the adjacent `--host`/`--key-ref` checks. The value reaches `internal/deploy/ssh.go`'s `DeployViaSsh`, which interpolates it into `fmt.Sprintf`-built docker-compose command strings executed on the remote host over a single `ssh` argv element -- shell metacharacters achieved arbitrary remote command execution. Added a shared `internal/deploy.ValidateRemotePath` and enforced it at every boundary: the CLI flag, the control-plane.yaml file-load path, the env-var synthesis path, and defense-in-depth inside `DeployViaSsh` itself.
- T32 (P6-E11-W2-S2-T32): `nself ci serve` failed open on three axes -- ran with signature verification disabled when no secret was configured, had no repo allowlist (any signed/unsigned payload could trigger a clone+build of an arbitrary repo), and silently ran gate commands unsandboxed on the host when Docker was absent. All three are now fail-closed by default with explicit opt-out flags: `--insecure`, `--allowed-repos` (empty = reject everything), `--allow-unsandboxed`.
- Regenerated `.github/command-inventory.json` and `.github/surface-parity.{json,md}` for the three new flags.

## Test plan
- [x] `go build ./...` -- success
- [x] `go vet ./...` -- clean
- [x] `go test ./...` -- all packages pass (including previously-failing `TestCommandInventoryIsCurrent`/`TestParityMatrixIsCurrent`, fixed by regenerating those files)
- [x] Live repro: `nself env target add staging web1 --remote-path '/opt/x; id'` rejected; `--remote-path /opt/nself` succeeds and round-trips correctly
- [x] Live repro: `nself ci serve` (no secret) refuses to start with the documented error; `--help` shows the three new fail-closed flags
- [x] Added unit tests: injection-payload rejection at all 4 RemotePath boundaries, allowlist rejection (including empty-allowlist-rejects-all), RunServe refusal without a secret, Docker-absent refusal and opt-in fallback