### PR TITLE
fix(license): honour revocation on the fail-open path (P6-E10-W5-S1-T06)

### DIFF
--- a/internal/license/checker.go
+++ b/internal/license/checker.go
@@ -106,6 +106,20 @@ func bundleEntitledFromCache(key, bundleName string) (bool, error) {
 		return false, fmt.Errorf("cached license does not match current key (bundle=%q)", bundleName)
 	}
 
+	// Revocation still applies when we cannot reach the server. Without this
+	// the fail-open path was the one route by which a revoked licence kept
+	// working indefinitely: it validated the key hash and the tier and never
+	// consulted the revocation list at all.
+	//
+	// Only KeyHash is available here. The cache entry carries no JTI, user id
+	// or key id, so a revocation published against any of those identifiers
+	// cannot be matched on this path; the revocation list must carry a
+	// key_hash entry for the refusal to fire. IsRecordRevoked itself remains
+	// fail-open for a cold or week-stale cache, which is deliberate.
+	if IsRecordRevoked(LicenseRecord{KeyHash: entry.KeyHash}) {
+		return false, fmt.Errorf("license has been revoked (bundle=%q); contact support if this is unexpected", bundleName)
+	}
+
 	tier := strings.ToLower(entry.Tier)
 	// ɳSelf+ / owner / enterprise cover all bundles. Delegated to IsAllAccessTier
 	// so this rule has one definition; the plugin installer needs the same one.

--- a/internal/license/checker_revocation_test.go
+++ b/internal/license/checker_revocation_test.go
@@ -1,0 +1,57 @@
+package license
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A revoked licence must not pass the fail-open cache path. Before this was
+// wired, bundleEntitledFromCache validated the key hash and the tier and
+// returned true without ever consulting the revocation list, so revoking a
+// licence had no effect on any client that could not reach the server.
+func TestBundleEntitledFromCache_RefusesRevokedKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // os.UserHomeDir reads USERPROFILE on Windows
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(dir, ".cache"))
+
+	const key = "test-license-key"
+	hash := HashKey(key)
+
+	if err := WriteCache(&CacheEntry{
+		KeyHash:   hash,
+		Tier:      "pro",
+		FetchedAt: time.Now().Unix(),
+		ExpiresAt: time.Now().Add(24 * time.Hour).Unix(),
+	}); err != nil {
+		t.Fatalf("seeding licence cache: %v", err)
+	}
+
+	// Not revoked yet: the cached entitlement decides, whatever it decides.
+	// We only assert that it does not refuse *for revocation* reasons.
+	if _, err := bundleEntitledFromCache(key, "task"); err != nil {
+		if got := err.Error(); strings.Contains(got, "revoked") {
+			t.Fatalf("unrevoked licence refused as revoked: %v", err)
+		}
+	}
+
+	// Now publish a revocation against this key hash.
+	if err := WriteRevocationCache(&RevocationCache{
+		FetchedAt: time.Now().Unix(),
+		List: RevocationList{
+			Revoked: []RevocationEntry{{Type: "key_hash", ID: hash, Reason: "test"}},
+		},
+	}); err != nil {
+		t.Fatalf("seeding revocation cache: %v", err)
+	}
+
+	ok, err := bundleEntitledFromCache(key, "task")
+	if ok {
+		t.Fatal("revoked licence was entitled via the fail-open path")
+	}
+	if err == nil || !strings.Contains(err.Error(), "revoked") {
+		t.Fatalf("expected a revocation refusal, got: %v", err)
+	}
+}


### PR DESCRIPTION
`bundleEntitledFromCache` validated the key hash and the cached tier, then returned an entitlement **without ever consulting the revocation list**. That made the fail-open path the one route by which a revoked licence kept working indefinitely — which is precisely the case fail-open exists to cover.

This is the second half of the revocation problem. The first half (the CLI's `GET /license/revocation-list` returning 404 in production) is a deployment gap and remains owner-blocked; see OWNER-ACTIONS item 1. Both had to be true for revocation to work, and neither was.

### Scope limit, stated honestly
Only `KeyHash` is available on this path. The cache entry carries no JTI, user id or key id, so a revocation published against one of those cannot be matched here — the revocation list must carry a `key_hash` entry for the refusal to fire. `IsRecordRevoked` itself stays fail-open for a cold or week-stale cache, which is deliberate and unchanged.

### Verification
The regression test was checked for teeth: with the new block removed it **fails**, reporting the old permissive outcome (`bundle "task" not found in cached license`) instead of a revocation refusal. With the fix it passes.

`go test ./internal/license/...` ok · `gofmt-check` passes · `golangci-lint` 0 issues · `go vet` clean.