### PR TITLE
P6-E2 CLI Thin-Core: close reconciled tickets + critical-tables config

### DIFF
--- a/.github/wiki/Config-Env-Vars.md
+++ b/.github/wiki/Config-Env-Vars.md
@@ -76,7 +76,7 @@ These vars control the top-level identity and behavior of a project.
 | Variable | Type | Default | Required | Description |
 |---|---|---|---|---|
 | `POSTGRES_VERSION` | string | `16-alpine` | No | Docker image tag for the Postgres container. |
-| `BACKUP_CRITICAL_TABLES` | string | project defaults | No | Comma-separated tables the restore drill must verify after a restore. The drill certifies a restore only once every table named here is present and non-empty, so a project with its own critical tables can point the check at them instead of the built-in list. |
+| `BACKUP_CRITICAL_TABLES` | string | `np_users,np_licenses,np_audit_log,np_plugins,np_billing` | No | Comma-separated tables `nself backup drill` looks for after restoring into its scratch database. The check is presence-only and advisory: an empty table counts as present, and missing tables are reported without failing the drill. Set this when your schema does not use the `np_` prefix, or the defaults will all read as missing. See [[cmd-backup]]. |
 | `POSTGRES_HOST` | string | `postgres` | No | Internal container hostname. Change only if running Postgres externally. |
 | `POSTGRES_PORT` | int | `5432` | No | Port exposed to the host machine. |
 | `POSTGRES_DB` | string | `nself` | No | Name of the default database created on first start. |

--- a/.github/wiki/cmd-backup.md
+++ b/.github/wiki/cmd-backup.md
@@ -228,6 +228,41 @@ nself backup status [--format json]
 
 ---
 
+## backup drill
+
+Restore the most recent backup into a scratch database, measure how long the
+restore took against an RTO target, and smoke-check the result.
+
+```bash
+nself backup drill [--file <backup>] [--rto-hours 4] [--dry-run] [--json]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--file` | most recent backup | Backup file to drill against. |
+| `--rto-hours` | `4.0` | RTO target in hours. `0` disables the gate. |
+| `--dry-run` | `false` | Validate inputs and exit without restoring. |
+| `--json` | `false` | Emit the drill result as JSON on stdout. |
+
+### Critical tables
+
+After the restore, the drill checks that a list of critical tables exists by
+name in the scratch database. The list comes from `BACKUP_CRITICAL_TABLES`
+(comma-separated) when set, and otherwise falls back to the built-in
+`np_`-prefixed default: `np_users`, `np_licenses`, `np_audit_log`,
+`np_plugins`, `np_billing`.
+
+Two things about this check are worth knowing before you rely on it:
+
+- It tests **presence only**. A table that exists but holds no rows counts as
+  present. The drill does not compare row counts against the source database.
+- A missing table does **not** fail the drill. The verdict stays `PASS` and the
+  missing names are listed as an advisory. Treat the drill as a restore-path
+  smoke test, not as a data-completeness gate.
+
+Deployments whose schema does not use the `np_` prefix will see every default
+name reported missing until they set `BACKUP_CRITICAL_TABLES`.
+
 ## backup init-key
 
 Generate an age encryption keypair for backup encryption.

--- a/cmd/commands/backup_drill.go
+++ b/cmd/commands/backup_drill.go
@@ -80,7 +80,7 @@ func runBackupDrill(cmd *cobra.Command, _ []string) error {
 	ui.Dimmed(fmt.Sprintf("  Rows observed:  %d", result.RowsObserved))
 	ui.Dimmed(fmt.Sprintf("  RTO target met: %v", result.RTOTargetMet))
 	if len(result.MissingCriticalTables) > 0 {
-		ui.Dimmed(fmt.Sprintf("  Critical tables not found by name: %v (see CriticalTables naming note)",
+		ui.Dimmed(fmt.Sprintf("  Critical tables not found by name: %v (set BACKUP_CRITICAL_TABLES if your schema uses different names)",
 			result.MissingCriticalTables))
 	}
 	return nil

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -89,29 +89,17 @@ func runCI(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build argument list for the nself-ci binary.
-	ciArgs := []string{}
-	if checkMode || noStatus {
-		ciArgs = append(ciArgs, "--no-status")
-	}
-	if noGitleaks {
-		ciArgs = append(ciArgs, "--no-gitleaks")
-	}
-	if filesystem {
-		ciArgs = append(ciArgs, "--filesystem")
-	}
-	if verbose {
-		ciArgs = append(ciArgs, "-v")
-	}
-	if sha != "" {
-		ciArgs = append(ciArgs, "--sha", sha)
-	}
-	if owner != "" {
-		ciArgs = append(ciArgs, "--owner", owner)
-	}
-	if repo != "" {
-		ciArgs = append(ciArgs, "--repo", repo)
-	}
-	ciArgs = append(ciArgs, repoRoot)
+	ciArgs := buildCIArgs(ciArgsInput{
+		checkMode:  checkMode,
+		noStatus:   noStatus,
+		noGitleaks: noGitleaks,
+		filesystem: filesystem,
+		verbose:    verbose,
+		sha:        sha,
+		owner:      owner,
+		repo:       repo,
+		repoRoot:   repoRoot,
+	})
 
 	ui.Section("nself-ci gate")
 	if postStatus {
@@ -134,4 +122,51 @@ func runCI(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("nself-ci: %w", err)
 	}
 	return nil
+}
+
+// ciArgsInput holds the resolved flag values runCI passes to buildCIArgs. It
+// exists so the pure argument-construction logic below can be unit tested
+// without invoking cobra or building the nself-ci binary.
+type ciArgsInput struct {
+	checkMode  bool
+	noStatus   bool
+	noGitleaks bool
+	filesystem bool
+	verbose    bool
+	sha        string
+	owner      string
+	repo       string
+	repoRoot   string
+}
+
+// buildCIArgs constructs the argv passed to the nself-ci gate binary from
+// nself ci's own flags. --filesystem maps to --filesystem on the gate binary,
+// which plugins/free/ci's gitleaksArgs() honors by forcing a --no-git
+// (filesystem) gitleaks scan even inside a real git checkout — see
+// P6-E2-W1-S2-T6 / msg-2026-08-31-gitleaks-e2e-regression-fix.md.
+func buildCIArgs(in ciArgsInput) []string {
+	ciArgs := []string{}
+	if in.checkMode || in.noStatus {
+		ciArgs = append(ciArgs, "--no-status")
+	}
+	if in.noGitleaks {
+		ciArgs = append(ciArgs, "--no-gitleaks")
+	}
+	if in.filesystem {
+		ciArgs = append(ciArgs, "--filesystem")
+	}
+	if in.verbose {
+		ciArgs = append(ciArgs, "-v")
+	}
+	if in.sha != "" {
+		ciArgs = append(ciArgs, "--sha", in.sha)
+	}
+	if in.owner != "" {
+		ciArgs = append(ciArgs, "--owner", in.owner)
+	}
+	if in.repo != "" {
+		ciArgs = append(ciArgs, "--repo", in.repo)
+	}
+	ciArgs = append(ciArgs, in.repoRoot)
+	return ciArgs
 }

--- a/cmd/commands/ci_test.go
+++ b/cmd/commands/ci_test.go
@@ -1,0 +1,73 @@
+package commands
+
+import "testing"
+
+// TestBuildCIArgs_FilesystemFlagForcesNoGit closes the residual gap in
+// P6-E2-W1-S2-T6: nself ci --filesystem must translate into a --filesystem
+// argument on the nself-ci gate binary, which plugins/free/ci's
+// gitleaksArgs() uses to force gitleaks into filesystem (--no-git) scan mode
+// even inside a real git checkout. The e2e proof that gitleaks itself skips
+// the gitignored tree in git-mode lives in plugins/free/ci (a separate repo,
+// out of this ticket's cli-only scope); this test guards the cli-side flag
+// wiring that feeds it.
+func TestBuildCIArgs_FilesystemFlagForcesNoGit(t *testing.T) {
+	args := buildCIArgs(ciArgsInput{
+		filesystem: true,
+		repoRoot:   "/tmp/example",
+	})
+
+	found := false
+	for _, a := range args {
+		if a == "--filesystem" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected --filesystem in argv, got %v", args)
+	}
+}
+
+// TestBuildCIArgs_FilesystemFlagAbsentByDefault proves the flag is opt-in:
+// a plain `nself ci` run must NOT force filesystem mode (git-mode is the
+// default per the fix), or every checkout would pay the gitignored-tree scan
+// cost this ticket exists to avoid.
+func TestBuildCIArgs_FilesystemFlagAbsentByDefault(t *testing.T) {
+	args := buildCIArgs(ciArgsInput{repoRoot: "/tmp/example"})
+
+	for _, a := range args {
+		if a == "--filesystem" {
+			t.Fatalf("expected no --filesystem in argv by default, got %v", args)
+		}
+	}
+}
+
+// TestBuildCIArgs_AllFlagsMapCorrectly exercises the full flag surface so a
+// future flag added to nself ci without a matching buildCIArgs branch fails
+// loudly here instead of silently not reaching the gate binary.
+func TestBuildCIArgs_AllFlagsMapCorrectly(t *testing.T) {
+	args := buildCIArgs(ciArgsInput{
+		checkMode:  true,
+		noGitleaks: true,
+		filesystem: true,
+		verbose:    true,
+		sha:        "abc1234",
+		owner:      "nself-org",
+		repo:       "cli",
+		repoRoot:   "/tmp/example",
+	})
+
+	want := []string{
+		"--no-status", "--no-gitleaks", "--filesystem", "-v",
+		"--sha", "abc1234", "--owner", "nself-org", "--repo", "cli",
+		"/tmp/example",
+	}
+	if len(args) != len(want) {
+		t.Fatalf("argv length mismatch: got %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("argv[%d] = %q, want %q (full: got %v, want %v)", i, args[i], want[i], args, want)
+		}
+	}
+}

--- a/internal/config/exports.go
+++ b/internal/config/exports.go
@@ -172,6 +172,7 @@ func DefaultFor(key string) string {
 		"BACKUP_S3_SECRET_ACCESS_KEY":  "",
 		"BACKUP_S3_REGION":             "",
 		"BACKUP_S3_ENDPOINT":           "",
+		"BACKUP_CRITICAL_TABLES":       "",
 
 		// Disaster Recovery
 		"DR_SECONDARY_REGION": "",

--- a/internal/config/loader_known_vars_ops.go
+++ b/internal/config/loader_known_vars_ops.go
@@ -29,6 +29,7 @@ var knownEnvVarsOps = []string{
 	"BACKUP_S3_SECRET_ACCESS_KEY",
 	"BACKUP_S3_REGION",
 	"BACKUP_S3_ENDPOINT",
+	"BACKUP_CRITICAL_TABLES",
 	// App-level backup credential/target aliases seen in real .env files
 	// (e.g. ntask). Not read by the CLI loader (app backup scripts use them).
 	"BACKUP_ACCESS_KEY",

--- a/internal/config/loader_parse_env_ops.go
+++ b/internal/config/loader_parse_env_ops.go
@@ -80,6 +80,7 @@ func parseEnvOps(cfg *Config) {
 		S3SecretAccessKey:   os.Getenv("BACKUP_S3_SECRET_ACCESS_KEY"),
 		S3Region:            os.Getenv("BACKUP_S3_REGION"),
 		S3Endpoint:          os.Getenv("BACKUP_S3_ENDPOINT"),
+		CriticalTables:      os.Getenv("BACKUP_CRITICAL_TABLES"),
 	}
 
 	cfg.DR = DRConfig{

--- a/internal/config/types_ops_plugins.go
+++ b/internal/config/types_ops_plugins.go
@@ -54,6 +54,15 @@ type BackupConfig struct {
 	S3SecretAccessKey   string `env:"BACKUP_S3_SECRET_ACCESS_KEY"`
 	S3Region            string `env:"BACKUP_S3_REGION"`
 	S3Endpoint          string `env:"BACKUP_S3_ENDPOINT"`
+
+	// CriticalTables overrides database.DefaultCriticalTables for the backup
+	// drill's smoke check (comma-separated table names, e.g.
+	// "users,licenses,audit_logs,plugins"). Empty (the default) keeps the
+	// np_-prefixed convention. Deployed schemas vary in whether they use
+	// nSelf's np_ multi-app-isolation prefix, so the drill's critical-table
+	// presence check must be project-configurable rather than hardcoded to
+	// one convention — see .claude/qa/bugs/drill-critical-tables-naming.md.
+	CriticalTables string `env:"BACKUP_CRITICAL_TABLES"`
 }
 
 // LicenseConfig holds license validation and grace period configuration.

--- a/internal/database/drill.go
+++ b/internal/database/drill.go
@@ -29,58 +29,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/nself-org/cli/internal/config"
 )
-
-// DefaultCriticalTables is the canonical np_*-prefixed critical-table list
-// used when a project has not set BACKUP_CRITICAL_TABLES. The five tables
-// here are load-bearing for the most common recovery scenario on an
-// np_-prefixed (multi-app-isolation, per the Multi-Tenant Convention Wall)
-// schema: license validation + signup pipeline + audit log must survive a
-// restore.
-//
-// Decision (2026-09-01, closes .claude/qa/bugs/drill-critical-tables-naming.md,
-// option (c)): the list is project-configurable rather than a single hardcoded
-// convention, because real deployed schemas disagree on naming — this
-// project's own staging nself_web_db uses unprefixed names (users, licenses,
-// audit_logs, plugins) with no np_ prefix and no billing-equivalent table at
-// all. Hardcoding either convention would make the drill permanently
-// wrong-shaped for whichever projects don't use it. ResolveCriticalTables
-// reads the per-project override; this var stays the zero-config fallback so
-// existing np_-prefixed deployments (and every test in this package) see no
-// behavior change.
-var DefaultCriticalTables = []string{
-	"np_users",
-	"np_licenses",
-	"np_audit_log",
-	"np_plugins",
-	"np_billing",
-}
-
-// ResolveCriticalTables returns the critical-table list to smoke-check for
-// this project: cfg.Backup.CriticalTables (BACKUP_CRITICAL_TABLES,
-// comma-separated, whitespace-trimmed, empty entries dropped) when set, else
-// DefaultCriticalTables. A nil cfg (unit tests exercising smokeCheck/
-// verifyCriticalTables directly) also falls back to the default.
-func ResolveCriticalTables(cfg *config.Config) []string {
-	if cfg == nil || strings.TrimSpace(cfg.Backup.CriticalTables) == "" {
-		return DefaultCriticalTables
-	}
-	var out []string
-	for _, name := range strings.Split(cfg.Backup.CriticalTables, ",") {
-		name = strings.TrimSpace(name)
-		if name != "" {
-			out = append(out, name)
-		}
-	}
-	if len(out) == 0 {
-		return DefaultCriticalTables
-	}
-	return out
-}
 
 // smokeCheck evaluates a completed RestoreDrillResult against the drill's
 // smoke gate. Pulled out of Drill as a pure function specifically so it can

--- a/internal/database/drill.go
+++ b/internal/database/drill.go
@@ -29,17 +29,30 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/nself-org/cli/internal/config"
 )
 
-// CriticalTables is the canonical list of np_* tables the drill smoke suite
-// asserts presence on. The five tables here are load-bearing for the most
-// common recovery scenario: license validation + signup pipeline + audit log
-// must survive a restore. Adding a table here makes drill stricter; remove
-// only with explicit user approval (these are the smoke-check baseline).
-var CriticalTables = []string{
+// DefaultCriticalTables is the canonical np_*-prefixed critical-table list
+// used when a project has not set BACKUP_CRITICAL_TABLES. The five tables
+// here are load-bearing for the most common recovery scenario on an
+// np_-prefixed (multi-app-isolation, per the Multi-Tenant Convention Wall)
+// schema: license validation + signup pipeline + audit log must survive a
+// restore.
+//
+// Decision (2026-09-01, closes .claude/qa/bugs/drill-critical-tables-naming.md,
+// option (c)): the list is project-configurable rather than a single hardcoded
+// convention, because real deployed schemas disagree on naming — this
+// project's own staging nself_web_db uses unprefixed names (users, licenses,
+// audit_logs, plugins) with no np_ prefix and no billing-equivalent table at
+// all. Hardcoding either convention would make the drill permanently
+// wrong-shaped for whichever projects don't use it. ResolveCriticalTables
+// reads the per-project override; this var stays the zero-config fallback so
+// existing np_-prefixed deployments (and every test in this package) see no
+// behavior change.
+var DefaultCriticalTables = []string{
 	"np_users",
 	"np_licenses",
 	"np_audit_log",
@@ -47,31 +60,51 @@ var CriticalTables = []string{
 	"np_billing",
 }
 
+// ResolveCriticalTables returns the critical-table list to smoke-check for
+// this project: cfg.Backup.CriticalTables (BACKUP_CRITICAL_TABLES,
+// comma-separated, whitespace-trimmed, empty entries dropped) when set, else
+// DefaultCriticalTables. A nil cfg (unit tests exercising smokeCheck/
+// verifyCriticalTables directly) also falls back to the default.
+func ResolveCriticalTables(cfg *config.Config) []string {
+	if cfg == nil || strings.TrimSpace(cfg.Backup.CriticalTables) == "" {
+		return DefaultCriticalTables
+	}
+	var out []string
+	for _, name := range strings.Split(cfg.Backup.CriticalTables, ",") {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	if len(out) == 0 {
+		return DefaultCriticalTables
+	}
+	return out
+}
+
 // smokeCheck evaluates a completed RestoreDrillResult against the drill's
 // smoke gate. Pulled out of Drill as a pure function specifically so it can
 // be unit-tested without a live Postgres — RestoreDrill itself needs one, so
 // exercising this logic through Drill() end-to-end is not practical in CI.
 //
+// criticalTables is the resolved list (ResolveCriticalTables) used only for
+// the table-count floor below — it is NOT re-checked by name here; presence
+// by name is verifyCriticalTables' job and stays advisory-only (see
+// MissingCriticalTables on DrillResult).
+//
 // Two independent conditions, either of which fails the drill:
-//  1. Table-count floor: fewer than len(CriticalTables) tables were found at
-//     all. Weak alone (any 5+ tables of any name pass) but cheap and kept.
+//  1. Table-count floor: fewer than len(criticalTables) tables were found at
+//     all. Weak alone (any N+ tables of any name pass) but cheap and kept.
 //  2. Row-total: subResult.RowsVerified is an EXACT total across every user
 //     table (see VerifyRestoredDatabase — no LIMIT-10 sampling), so it is
 //     safe to hard-fail on zero. A fresh-init DB has zero rows in user
 //     tables; a real restore must not. Proven live on staging 2026-08-31: a
 //     drill reported tables_checked=107, rows_observed=0, success=true under
 //     the old code, which had no row assertion at all — this is that gate.
-//
-// subResult.MissingCriticalTables (CriticalTables entries not found by name)
-// is intentionally NOT part of this gate: several drilled environments do
-// not use the np_ prefix the canonical list assumes, so failing on it would
-// make the drill permanently red for them. It is surfaced on DrillResult for
-// visibility; see .claude/qa/bugs/drill-critical-tables-naming.md for the
-// naming question, which needs a human decision, not a silent list edit.
-func smokeCheck(subResult RestoreDrillResult) error {
-	if subResult.TablesVerified < len(CriticalTables) {
+func smokeCheck(subResult RestoreDrillResult, criticalTables []string) error {
+	if subResult.TablesVerified < len(criticalTables) {
 		return fmt.Errorf("only %d tables verified, want >= %d (critical: %v)",
-			subResult.TablesVerified, len(CriticalTables), CriticalTables)
+			subResult.TablesVerified, len(criticalTables), criticalTables)
 	}
 	if subResult.RowsVerified <= 0 {
 		return fmt.Errorf(
@@ -180,8 +213,8 @@ func Drill(ctx context.Context, cfg *config.Config, opts DrillOptions) (DrillRes
 	// subResult while the DB was still alive.
 	//
 	// Two independent gates:
-	//  1. Table-count floor: ≥len(CriticalTables) tables were found at all.
-	//     Weak on its own (any 5+ tables pass regardless of name) but kept as
+	//  1. Table-count floor: ≥len(criticalTables) tables were found at all.
+	//     Weak on its own (any N+ tables pass regardless of name) but kept as
 	//     a cheap first check.
 	//  2. Row-total assertion: subResult.RowsVerified is an EXACT total across
 	//     every user table (see VerifyRestoredDatabase — no more LIMIT-10
@@ -191,18 +224,17 @@ func Drill(ctx context.Context, cfg *config.Config, opts DrillOptions) (DrillRes
 	//     rows_observed=0, success=true under the old code — this gate is
 	//     what was missing.
 	//
-	// CriticalTables presence-by-name (subResult.MissingCriticalTables) is
-	// surfaced for visibility but does NOT fail the drill: several drilled
-	// environments do not use the np_ prefix the canonical list assumes, so a
-	// hard fail here would make the drill permanently red for them. See
-	// .claude/qa/bugs/drill-critical-tables-naming.md for the naming
-	// question, which needs a human decision, not a silent list edit.
+	// criticalTables presence-by-name (subResult.MissingCriticalTables) is
+	// surfaced for visibility but does NOT fail the drill: the list itself is
+	// per-project (ResolveCriticalTables / BACKUP_CRITICAL_TABLES) precisely
+	// because deployed schemas disagree on naming conventions — see
+	// .claude/qa/bugs/drill-critical-tables-naming.md for the decision.
 	result.Phase = "smoke"
 	smokeStart := time.Now()
 	result.TablesChecked = subResult.TablesVerified
 	result.MissingCriticalTables = subResult.MissingCriticalTables
 
-	if smokeErr := smokeCheck(subResult); smokeErr != nil {
+	if smokeErr := smokeCheck(subResult, ResolveCriticalTables(cfg)); smokeErr != nil {
 		result.ErrorMessage = fmt.Sprintf("smoke: %v", smokeErr)
 		result.SmokeSeconds = time.Since(smokeStart).Seconds()
 		result.CompletedAt = time.Now()

--- a/internal/database/drill_critical_tables.go
+++ b/internal/database/drill_critical_tables.go
@@ -1,0 +1,60 @@
+// Package database — drill_critical_tables.go: the drill's critical-table
+// list and its per-project resolution. Split out of drill.go (file-size
+// ratchet, internal/repoqa) — this is the self-contained piece of the drill
+// smoke gate that needed its own home once it grew a resolution function and
+// tests, per the same drill_*.go concern-split convention already used for
+// restore_drill.go.
+package database
+
+import (
+	"strings"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// DefaultCriticalTables is the canonical np_*-prefixed critical-table list
+// used when a project has not set BACKUP_CRITICAL_TABLES. The five tables
+// here are load-bearing for the most common recovery scenario on an
+// np_-prefixed (multi-app-isolation, per the Multi-Tenant Convention Wall)
+// schema: license validation + signup pipeline + audit log must survive a
+// restore.
+//
+// Decision (2026-09-01, closes the drill-critical-tables-naming bug note,
+// option (c)): the list is project-configurable rather than a single hardcoded
+// convention, because real deployed schemas disagree on naming — this
+// project's own staging nself_web_db uses unprefixed names (users, licenses,
+// audit_logs, plugins) with no np_ prefix and no billing-equivalent table at
+// all. Hardcoding either convention would make the drill permanently
+// wrong-shaped for whichever projects don't use it. ResolveCriticalTables
+// reads the per-project override; this var stays the zero-config fallback so
+// existing np_-prefixed deployments (and every test in this package) see no
+// behavior change.
+var DefaultCriticalTables = []string{
+	"np_users",
+	"np_licenses",
+	"np_audit_log",
+	"np_plugins",
+	"np_billing",
+}
+
+// ResolveCriticalTables returns the critical-table list to smoke-check for
+// this project: cfg.Backup.CriticalTables (BACKUP_CRITICAL_TABLES,
+// comma-separated, whitespace-trimmed, empty entries dropped) when set, else
+// DefaultCriticalTables. A nil cfg (unit tests exercising smokeCheck/
+// verifyCriticalTables directly) also falls back to the default.
+func ResolveCriticalTables(cfg *config.Config) []string {
+	if cfg == nil || strings.TrimSpace(cfg.Backup.CriticalTables) == "" {
+		return DefaultCriticalTables
+	}
+	var out []string
+	for _, name := range strings.Split(cfg.Backup.CriticalTables, ",") {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	if len(out) == 0 {
+		return DefaultCriticalTables
+	}
+	return out
+}

--- a/internal/database/drill_test.go
+++ b/internal/database/drill_test.go
@@ -101,9 +101,9 @@ func TestLastSuccessfulDrill_IgnoresFailures(t *testing.T) {
 	}
 }
 
-// TestCriticalTables_Stable: changing the canonical critical-table list is a
-// breaking change to the drill smoke suite. This test pins the list so any
-// modification is intentional + reviewed.
+// TestCriticalTables_Stable: changing the canonical default critical-table
+// list is a breaking change to the drill smoke suite. This test pins the
+// list so any modification is intentional + reviewed.
 func TestCriticalTables_Stable(t *testing.T) {
 	want := []string{
 		"np_users",
@@ -112,13 +112,59 @@ func TestCriticalTables_Stable(t *testing.T) {
 		"np_plugins",
 		"np_billing",
 	}
-	if len(CriticalTables) != len(want) {
-		t.Fatalf("CriticalTables length changed: want %d, got %d", len(want), len(CriticalTables))
+	if len(DefaultCriticalTables) != len(want) {
+		t.Fatalf("DefaultCriticalTables length changed: want %d, got %d", len(want), len(DefaultCriticalTables))
 	}
 	for i, name := range want {
-		if CriticalTables[i] != name {
-			t.Errorf("CriticalTables[%d]: want %q, got %q", i, name, CriticalTables[i])
+		if DefaultCriticalTables[i] != name {
+			t.Errorf("DefaultCriticalTables[%d]: want %q, got %q", i, name, DefaultCriticalTables[i])
 		}
+	}
+}
+
+// TestResolveCriticalTables_DefaultsWhenUnset covers the zero-config path:
+// no cfg, or a cfg with no BACKUP_CRITICAL_TABLES override, must return
+// DefaultCriticalTables unchanged — every np_-prefixed deployment (and every
+// other test in this file) depends on this staying true.
+func TestResolveCriticalTables_DefaultsWhenUnset(t *testing.T) {
+	if got := ResolveCriticalTables(nil); len(got) != len(DefaultCriticalTables) {
+		t.Fatalf("ResolveCriticalTables(nil) = %v, want %v", got, DefaultCriticalTables)
+	}
+	if got := ResolveCriticalTables(&config.Config{}); len(got) != len(DefaultCriticalTables) {
+		t.Fatalf("ResolveCriticalTables(empty cfg) = %v, want %v", got, DefaultCriticalTables)
+	}
+}
+
+// TestResolveCriticalTables_OverrideSplitsAndTrims proves the
+// BACKUP_CRITICAL_TABLES override (closes
+// .claude/qa/bugs/drill-critical-tables-naming.md option (c)) is parsed as a
+// comma-separated, whitespace-trimmed list — the unprefixed convention this
+// project's own staging nself_web_db actually uses.
+func TestResolveCriticalTables_OverrideSplitsAndTrims(t *testing.T) {
+	cfg := &config.Config{Backup: config.BackupConfig{
+		CriticalTables: "users, licenses,audit_logs ,plugins",
+	}}
+	got := ResolveCriticalTables(cfg)
+	want := []string{"users", "licenses", "audit_logs", "plugins"}
+	if len(got) != len(want) {
+		t.Fatalf("ResolveCriticalTables = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ResolveCriticalTables[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestResolveCriticalTables_BlankOverrideFallsBackToDefault guards against a
+// set-but-empty/whitespace-only override silently producing a zero-length
+// critical-table list (which would make smokeCheck's table-count floor
+// trivially always pass).
+func TestResolveCriticalTables_BlankOverrideFallsBackToDefault(t *testing.T) {
+	cfg := &config.Config{Backup: config.BackupConfig{CriticalTables: "  , , "}}
+	got := ResolveCriticalTables(cfg)
+	if len(got) != len(DefaultCriticalTables) {
+		t.Fatalf("ResolveCriticalTables(blank override) = %v, want default %v", got, DefaultCriticalTables)
 	}
 }
 
@@ -132,10 +178,10 @@ func TestCriticalTables_Stable(t *testing.T) {
 func TestSmokeCheck_ZeroRowsFails(t *testing.T) {
 	sub := RestoreDrillResult{
 		Success:        true,
-		TablesVerified: 107, // well over len(CriticalTables) — the old gate's only check
+		TablesVerified: 107, // well over len(DefaultCriticalTables) — the old gate's only check
 		RowsVerified:   0,   // fresh-init / nothing-really-restored signal
 	}
-	if err := smokeCheck(sub); err == nil {
+	if err := smokeCheck(sub, DefaultCriticalTables); err == nil {
 		t.Fatalf("smokeCheck: want error for 0 rows observed across %d tables, got nil (hollow gate)", sub.TablesVerified)
 	}
 }
@@ -149,21 +195,21 @@ func TestSmokeCheck_RealDataPasses(t *testing.T) {
 		TablesVerified: 107,
 		RowsVerified:   4213,
 	}
-	if err := smokeCheck(sub); err != nil {
+	if err := smokeCheck(sub, DefaultCriticalTables); err != nil {
 		t.Errorf("smokeCheck: want nil for a real restore with rows observed, got %v", err)
 	}
 }
 
 // TestSmokeCheck_TooFewTablesFails preserves the pre-existing table-count
-// floor: fewer than len(CriticalTables) tables found still fails, even with a
+// floor: fewer than len(criticalTables) tables found still fails, even with a
 // nonzero row count (e.g. one giant table).
 func TestSmokeCheck_TooFewTablesFails(t *testing.T) {
 	sub := RestoreDrillResult{
 		Success:        true,
-		TablesVerified: len(CriticalTables) - 1,
+		TablesVerified: len(DefaultCriticalTables) - 1,
 		RowsVerified:   999,
 	}
-	if err := smokeCheck(sub); err == nil {
+	if err := smokeCheck(sub, DefaultCriticalTables); err == nil {
 		t.Fatalf("smokeCheck: want error for too few tables verified, got nil")
 	}
 }

--- a/internal/database/restore_drill.go
+++ b/internal/database/restore_drill.go
@@ -184,17 +184,19 @@ func VerifyRestoredDatabase(ctx context.Context, cfg *config.Config, drillDB str
 	return tableCount, totalRows, nil
 }
 
-// verifyCriticalTables reports which entries of CriticalTables (drill.go) are
-// missing by name, in any schema, from drillDB. CriticalTables are
-// compile-time-constant literals defined in this package, not DB-sourced
-// input, so they are safe to place directly into a SQL literal list here —
-// SEC-SQL-01's "never interpolate DB-sourced identifiers without quoting"
-// concerns table_schema/table_name values read back FROM the database
-// (handled via format('%I.%I') in VerifyRestoredDatabase above), not our own
-// hardcoded constants.
+// verifyCriticalTables reports which entries of ResolveCriticalTables(cfg)
+// (drill.go — DefaultCriticalTables unless the project sets
+// BACKUP_CRITICAL_TABLES) are missing by name, in any schema, from drillDB.
+// The resolved names are project config, not DB-sourced input, so they are
+// safe to place directly into a SQL literal list here (properly
+// single-quote-escaped below) — SEC-SQL-01's "never interpolate DB-sourced
+// identifiers without quoting" concerns table_schema/table_name values read
+// back FROM the database (handled via format('%I.%I') in
+// VerifyRestoredDatabase above), not our own resolved string-literal values.
 func verifyCriticalTables(ctx context.Context, cfg *config.Config, drillDB string) ([]string, error) {
-	literals := make([]string, len(CriticalTables))
-	for i, name := range CriticalTables {
+	criticalTables := ResolveCriticalTables(cfg)
+	literals := make([]string, len(criticalTables))
+	for i, name := range criticalTables {
 		literals[i] = "'" + strings.ReplaceAll(name, "'", "''") + "'"
 	}
 	sqlText := fmt.Sprintf(
@@ -205,7 +207,7 @@ func verifyCriticalTables(ctx context.Context, cfg *config.Config, drillDB strin
 	if err != nil {
 		return nil, fmt.Errorf("query critical tables in %s: %w", drillDB, err)
 	}
-	present := make(map[string]bool, len(CriticalTables))
+	present := make(map[string]bool, len(criticalTables))
 	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
@@ -213,7 +215,7 @@ func verifyCriticalTables(ctx context.Context, cfg *config.Config, drillDB strin
 		}
 	}
 	var missing []string
-	for _, name := range CriticalTables {
+	for _, name := range criticalTables {
 		if !present[name] {
 			missing = append(missing, name)
 		}

--- a/test/e2e/deprecation_installed_binary_test.go
+++ b/test/e2e/deprecation_installed_binary_test.go
@@ -1,0 +1,103 @@
+// Package e2e — deprecation_installed_binary_test.go
+//
+// CLI-R03 regression guard (P6-E2-W1-S1-T2): resolveRegistryPath() used to
+// look for internal/deprecation/registry.yaml beside the executable, which
+// never exists after `make install`/brew (the yaml source only lives in the
+// dev tree). The fix embeds the registry via `//go:embed registry.yaml`
+// (internal/deprecation/embedded.go) so it travels inside the binary.
+//
+// internal/deprecation/embedded_test.go already proves byte-identical
+// embed-vs-disk equality in-process, but nothing previously simulated a real
+// `make install` + copy-away scenario: a binary built once, then copied to a
+// second, completely empty directory with no source tree — and therefore no
+// registry.yaml — anywhere nearby. This is that black-box proof.
+//
+// This test is fully headless: it builds the CLI, copies it to an isolated
+// temp dir, and runs it there, asserting a clean exit with no
+// registry-file-not-found error in stderr.
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDeprecationInstalledBinary builds the nself CLI, copies the resulting
+// binary into a second, empty temp directory with no adjacent
+// registry.yaml or source tree, runs it there, and asserts the deprecation
+// registry lookup does not fail with a missing-file error — proving the
+// go:embed fix travels with a copied-away, installed-style binary.
+func TestDeprecationInstalledBinary(t *testing.T) {
+	buildDir := t.TempDir()
+	bin := filepath.Join(buildDir, "nself-copy-test")
+
+	buildCmd := exec.Command("go", "build", "-mod=vendor", "-o", bin, "../../cmd/nself")
+	buildCmd.Dir = mustGetwdT2(t)
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("building nself: %v\n%s", err, out)
+	}
+
+	// Copy the binary to a second, unrelated empty directory. This is the
+	// exact scenario CLI-R03 described: no source tree, no
+	// internal/deprecation/registry.yaml anywhere on disk nearby — only the
+	// compiled binary itself.
+	emptyDir := t.TempDir()
+	copiedBin := filepath.Join(emptyDir, "nself")
+	copyFile(t, bin, copiedBin)
+	if err := os.Chmod(copiedBin, 0o755); err != nil {
+		t.Fatalf("chmod copied binary: %v", err)
+	}
+
+	// Run a command that exercises the deprecation checker (any real
+	// command does, since it is wired at the root command layer via
+	// cmd/commands/root.go's deprecationRegistry). "version" is side-effect
+	// free and always available.
+	runCmd := exec.Command(copiedBin, "version")
+	runCmd.Dir = emptyDir
+	// HOME/USERPROFILE point at a scratch dir too, so the binary cannot
+	// accidentally find a registry.yaml via an unrelated project or dotfile
+	// lookup rooted at the real developer home directory.
+	scratchHome := t.TempDir()
+	runCmd.Env = append(os.Environ(),
+		"HOME="+scratchHome,
+		"USERPROFILE="+scratchHome,
+	)
+	out, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running copied binary failed: %v\noutput:\n%s", err, out)
+	}
+
+	output := string(out)
+	for _, bad := range []string{
+		"registry.yaml not found",
+		"no such file or directory",
+		"registry.yaml: no such file",
+	} {
+		if strings.Contains(output, bad) {
+			t.Errorf("copied-binary run referenced a missing registry file (%q) in output:\n%s", bad, output)
+		}
+	}
+}
+
+func mustGetwdT2(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wd
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("reading %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		t.Fatalf("writing %s: %v", dst, err)
+	}
+}

--- a/test/e2e/deprecation_installed_binary_test.go
+++ b/test/e2e/deprecation_installed_binary_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -32,7 +33,10 @@ import (
 // go:embed fix travels with a copied-away, installed-style binary.
 func TestDeprecationInstalledBinary(t *testing.T) {
 	buildDir := t.TempDir()
-	bin := filepath.Join(buildDir, "nself-copy-test")
+	// Windows decides what is executable by the .exe extension, not a mode bit,
+	// so a binary written without it cannot be exec'd there. See the repo rules
+	// on Windows-portable tests.
+	bin := filepath.Join(buildDir, "nself-copy-test"+exeSuffix())
 
 	buildCmd := exec.Command("go", "build", "-mod=vendor", "-o", bin, "../../cmd/nself")
 	buildCmd.Dir = mustGetwdT2(t)
@@ -45,7 +49,7 @@ func TestDeprecationInstalledBinary(t *testing.T) {
 	// internal/deprecation/registry.yaml anywhere on disk nearby — only the
 	// compiled binary itself.
 	emptyDir := t.TempDir()
-	copiedBin := filepath.Join(emptyDir, "nself")
+	copiedBin := filepath.Join(emptyDir, "nself"+exeSuffix())
 	copyFile(t, bin, copiedBin)
 	if err := os.Chmod(copiedBin, 0o755); err != nil {
 		t.Fatalf("chmod copied binary: %v", err)
@@ -100,4 +104,15 @@ func copyFile(t *testing.T, src, dst string) {
 	if err := os.WriteFile(dst, data, 0o755); err != nil {
 		t.Fatalf("writing %s: %v", dst, err)
 	}
+}
+
+// exeSuffix returns the extension an executable needs on this platform.
+// Windows resolves executability from the extension, so a test that builds a
+// binary and then runs it must add .exe or exec fails with "file does not
+// exist" on that platform only.
+func exeSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary

Reconciliation-first pass over P6 epic E2 (CLI Thin-Core, 17 pending tickets). Most were already resolved on `main` by other recent merges; this PR carries the genuinely remaining code changes plus one recovered-and-verified artifact from an interrupted prior session.

- **P6-E2-W1-S1-T2** (deprecation registry embed): recovered `test/e2e/deprecation_installed_binary_test.go` from an interrupted prior session's worktree, independently re-verified green, and closed the residual gap from T6 by extracting `buildCIArgs()` in `cmd/commands/ci.go` as a pure, unit-testable function for the `--filesystem` -> gate-binary argv mapping.
- **P6-E2-W2-S3-T19** (drill critical-tables naming): resolves the open naming decision — `BACKUP_CRITICAL_TABLES` env var makes the backup drill's critical-table list project-configurable (`database.ResolveCriticalTables`), since deployed schemas disagree on the `np_` prefix convention (this project's own staging `nself_web_db` doesn't use it). Split into its own file to stay under the 300-line cap.

## Reconciled as already-done on `main` (no changes needed)

T01, T04, T08 (previously marked done) plus, verified this session: **T03** (all 7 frozen-list files already split, 0 files >300 lines), **T05** (wiki coverage 50/50, plugin-proxy hint fix live), **T06** (gitleaks e2e + PCI reply already landed in `plugins/free/ci`), **T07** (`isRepoScopedCommand`/bootstrap/cache all fixed+tested), **T09** (secrets templating tests green), **T11** (ssl cert-path regression tests exist and pass), **T14** (release-status legacy-spelling tests exist and pass), **T15** (ssl renew install-order bug already fixed), **T16** (config set redirect notice already fixed), **T18** (PR #325 merged — `DetectMonorepoRoot` in `doctor.go` confirmed live).

## Deferred (out of this PR's reach)

- **T10, T12, T13**: require live Docker build/start cycles and admin GUI smoke tests — explicitly out of scope for this session (no Docker).
- **T17**: `EXTERNAL-GATES.md` created at the project level (`.claude/docs/`, gitignored) documenting the `NPM_TOKEN` create-scope gate — not part of this PR's diff.
- **T20** (nginx path-scoped rate limiting): genuine unfixed feature gap, needs template/generator work across `internal/nginx` + `ssl_install.go` plus live staging verification — left for a follow-up ticket.

## Test plan
- [x] `go build ./...` — exit 0
- [x] `go vet ./...` — exit 0
- [x] `bash scripts/ci/gofmt-check.sh` — clean
- [x] `go test ./...` — all packages green (full suite, no Docker/integration tag)
- [x] File-size gate (`internal/repoqa` `TestFileSizeBudgetNotExceeded`) — 0 files over 300 lines