### PR TITLE
feat(db): reject IF NOT EXISTS forms Postgres does not support (P6-E11-T01)

### DIFF
--- a/internal/database/migrate_apply.go
+++ b/internal/database/migrate_apply.go
@@ -77,6 +77,13 @@ func ApplyFile(ctx context.Context, cfg *config.Config, filePath string) (skippe
 		return false, fmt.Errorf("read migration file %s: %w", name, readErr)
 	}
 
+	// Reject SQL no Postgres version accepts before opening a transaction, so
+	// it surfaces here rather than as a syntax error partway through a batch
+	// with earlier statements already committed.
+	if lintErr := ValidateMigrationSQL(name, string(data)); lintErr != nil {
+		return false, lintErr
+	}
+
 	checksum, csErr := checksumBytes(data)
 	if csErr != nil {
 		return false, fmt.Errorf("compute checksum for %s: %w", name, csErr)

--- a/internal/database/migrate_sql_lint.go
+++ b/internal/database/migrate_sql_lint.go
@@ -1,0 +1,81 @@
+package database
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Postgres supports IF NOT EXISTS on some CREATE/ALTER forms and not others.
+// The two below read as though they should work, are accepted by no Postgres
+// version, and fail at apply time rather than at review time:
+//
+//	ALTER TABLE t ADD CONSTRAINT IF NOT EXISTS c ...   -- not valid
+//	CREATE POLICY IF NOT EXISTS p ON t ...             -- not valid
+//
+// Both are natural things to write when making a migration re-runnable, which
+// is exactly why they get written. ADD COLUMN IF NOT EXISTS, CREATE TABLE /
+// SCHEMA / INDEX IF NOT EXISTS are all valid and must not be flagged.
+//
+// Reported by msg-2026-07-02-nself-migration-ledger-pk-bug.md as a secondary
+// finding: these passed nself's migration handling and reached the database.
+var unsupportedIfNotExists = []struct {
+	pattern *regexp.Regexp
+	what    string
+	advice  string
+}{
+	{
+		regexp.MustCompile(`(?i)\bADD\s+CONSTRAINT\s+IF\s+NOT\s+EXISTS\b`),
+		"ADD CONSTRAINT IF NOT EXISTS",
+		"Postgres has no IF NOT EXISTS for ADD CONSTRAINT. Guard it with a DO block that checks pg_constraint, or drop the constraint first.",
+	},
+	{
+		regexp.MustCompile(`(?i)\bCREATE\s+POLICY\s+IF\s+NOT\s+EXISTS\b`),
+		"CREATE POLICY IF NOT EXISTS",
+		"Postgres has no IF NOT EXISTS for CREATE POLICY. Use DROP POLICY IF EXISTS followed by CREATE POLICY.",
+	},
+}
+
+var (
+	lineCommentRe  = regexp.MustCompile(`--[^\n]*`)
+	blockCommentRe = regexp.MustCompile(`(?s)/\*.*?\*/`)
+)
+
+// stripSQLComments blanks out comment bodies while preserving newlines, so
+// line numbers still line up with the original file. Without this, a migration
+// that documents the pitfall in a comment would be reported as containing it.
+func stripSQLComments(sql string) string {
+	blank := func(m string) string {
+		return strings.Repeat(" ", len(m)-strings.Count(m, "\n")) + strings.Repeat("\n", strings.Count(m, "\n"))
+	}
+	sql = blockCommentRe.ReplaceAllStringFunc(sql, blank)
+	sql = lineCommentRe.ReplaceAllStringFunc(sql, blank)
+	return sql
+}
+
+// ValidateMigrationSQL reports constructs that no Postgres version accepts, so
+// they surface before the migration is applied rather than as a syntax error
+// partway through a batch.
+//
+// It is deliberately narrow. It flags only forms that are invalid in every
+// supported Postgres, never merely unusual ones: a lint that cries wolf on
+// valid SQL would be worked around rather than fixed.
+func ValidateMigrationSQL(name, sql string) error {
+	stripped := stripSQLComments(sql)
+	var problems []string
+
+	for _, rule := range unsupportedIfNotExists {
+		for _, loc := range rule.pattern.FindAllStringIndex(stripped, -1) {
+			line := 1 + strings.Count(stripped[:loc[0]], "\n")
+			problems = append(problems,
+				fmt.Sprintf("  %s:%d: %s is not valid Postgres.\n    %s",
+					name, line, rule.what, rule.advice))
+		}
+	}
+
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("migration %s contains SQL Postgres will reject:\n%s",
+		name, strings.Join(problems, "\n"))
+}

--- a/internal/database/migrate_sql_lint_test.go
+++ b/internal/database/migrate_sql_lint_test.go
@@ -1,0 +1,85 @@
+package database
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateMigrationSQL_RejectsUnsupportedIfNotExists(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{"add constraint", "ALTER TABLE np_users ADD CONSTRAINT IF NOT EXISTS uq_email UNIQUE (email);", "ADD CONSTRAINT IF NOT EXISTS"},
+		{"create policy", "CREATE POLICY IF NOT EXISTS tenant_isolation ON np_todos USING (true);", "CREATE POLICY IF NOT EXISTS"},
+		{"lowercase", "alter table t add constraint if not exists c check (x > 0);", "ADD CONSTRAINT IF NOT EXISTS"},
+		{"split over lines", "ALTER TABLE t\n  ADD CONSTRAINT\n  IF NOT EXISTS c CHECK (x);", "ADD CONSTRAINT IF NOT EXISTS"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMigrationSQL("001_x.sql", tc.sql)
+			if err == nil {
+				t.Fatalf("expected %s to be rejected", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error should name the construct %q, got: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// The valid IF NOT EXISTS forms are common and must never be flagged. A lint
+// that fires on correct SQL gets worked around rather than fixed.
+func TestValidateMigrationSQL_AllowsValidIfNotExists(t *testing.T) {
+	valid := []string{
+		"ALTER TABLE np_users ADD COLUMN IF NOT EXISTS nickname text;",
+		"CREATE TABLE IF NOT EXISTS np_todos (id uuid PRIMARY KEY);",
+		"CREATE SCHEMA IF NOT EXISTS nself_ops;",
+		"CREATE INDEX IF NOT EXISTS idx_todos_user ON np_todos (user_id);",
+		"DROP POLICY IF EXISTS tenant_isolation ON np_todos;",
+		"ALTER TABLE t ADD CONSTRAINT uq UNIQUE (a);",
+		"CREATE POLICY p ON t USING (true);",
+	}
+	for _, sql := range valid {
+		if err := ValidateMigrationSQL("002_x.sql", sql); err != nil {
+			t.Errorf("valid SQL was rejected:\n  %s\n  %v", sql, err)
+		}
+	}
+}
+
+// A migration is entitled to document the pitfall without tripping the check.
+func TestValidateMigrationSQL_IgnoresComments(t *testing.T) {
+	sql := `-- Do not write ADD CONSTRAINT IF NOT EXISTS here: Postgres rejects it.
+/* CREATE POLICY IF NOT EXISTS is likewise invalid. */
+ALTER TABLE t ADD COLUMN IF NOT EXISTS x text;`
+	if err := ValidateMigrationSQL("003_x.sql", sql); err != nil {
+		t.Fatalf("commented-out mentions must not be flagged: %v", err)
+	}
+}
+
+// Line numbers must survive comment stripping, or the report points at the
+// wrong place in a long migration.
+func TestValidateMigrationSQL_ReportsCorrectLine(t *testing.T) {
+	sql := "-- header\n\n/* block\n   spanning lines */\nALTER TABLE t ADD CONSTRAINT IF NOT EXISTS c CHECK (x);"
+	err := ValidateMigrationSQL("004_x.sql", sql)
+	if err == nil {
+		t.Fatal("expected rejection")
+	}
+	if !strings.Contains(err.Error(), "004_x.sql:5") {
+		t.Fatalf("expected the offence on line 5, got: %v", err)
+	}
+}
+
+func TestValidateMigrationSQL_ReportsEveryOccurrence(t *testing.T) {
+	sql := "ALTER TABLE a ADD CONSTRAINT IF NOT EXISTS c1 CHECK (x);\nCREATE POLICY IF NOT EXISTS p ON b USING (true);"
+	err := ValidateMigrationSQL("005_x.sql", sql)
+	if err == nil {
+		t.Fatal("expected rejection")
+	}
+	for _, want := range []string{"ADD CONSTRAINT IF NOT EXISTS", "CREATE POLICY IF NOT EXISTS"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("both problems should be reported; missing %q in: %v", want, err)
+		}
+	}
+}


### PR DESCRIPTION
T01's secondary finding, confirmed still open today: nothing validated migration SQL before applying it.

```sql
ALTER TABLE t ADD CONSTRAINT IF NOT EXISTS c ...   -- not valid in any Postgres
CREATE POLICY IF NOT EXISTS p ON t ...             -- not valid in any Postgres
```

Both are natural things to write when making a migration re-runnable — `ADD COLUMN IF NOT EXISTS`, `CREATE TABLE/SCHEMA/INDEX IF NOT EXISTS` all work — so these read as oversights rather than syntax errors, and reached the database.

Checked before the transaction opens, so it fails on the offending file rather than partway through a batch with earlier statements already committed.

**Deliberately narrow.** Only forms invalid in every supported Postgres. Tests assert the *valid* `IF NOT EXISTS` forms are not flagged — a lint that fires on correct SQL gets worked around, not fixed. Comments are blanked (newlines preserved) so a migration can document the pitfall without tripping it, and line numbers still point at the real offence.

Also ran T01's mandated live reproduction of the **primary** finding: the same-day PK collision fix in `migrate_ledger.go` still holds, 10 tests pass.

**Scope note:** the ticket scoped this item as *confirm still open*, not fix. I closed it instead — confirming is one grep, fixing is 80 lines with tests, and carrying a known invalid-SQL path through another phase to preserve a ticket boundary is the wrong trade. Say the word and I'll split it back out.