### PR TITLE
fix(backup): refuse to write an unencrypted backup by accident

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -335,6 +335,7 @@
         "hidden": false,
         "flags": [
           "--dry-run",
+          "--no-encrypt",
           "--recipient",
           "--to"
         ]

--- a/cmd/commands/backup_key_stream.go
+++ b/cmd/commands/backup_key_stream.go
@@ -67,11 +67,13 @@ func runBackupStream(cmd *cobra.Command, _ []string) error {
 	to, _ := cmd.Flags().GetString("to")
 	recipients, _ := cmd.Flags().GetStringArray("recipient")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	noEncrypt, _ := cmd.Flags().GetBool("no-encrypt")
 
 	result, err := backup.Stream(cmd.Context(), cfg, backup.StreamOptions{
-		To:         to,
-		Recipients: recipients,
-		DryRun:     dryRun,
+		To:               to,
+		Recipients:       recipients,
+		DryRun:           dryRun,
+		AllowUnencrypted: noEncrypt,
 	})
 	if err != nil {
 		return fmt.Errorf("backup stream: %w", err)

--- a/cmd/commands/backup_ops.go
+++ b/cmd/commands/backup_ops.go
@@ -80,6 +80,8 @@ func init() {
 	backupStreamCmd.Flags().String("to", "", "Destination URL (rclone remote path, e.g. s3:bucket/prefix)")
 	backupStreamCmd.Flags().StringArray("recipient", nil, "Encryption recipient: age key, SSH key, or github:<username> (repeatable)")
 	backupStreamCmd.Flags().Bool("dry-run", false, "Preview without running")
+	backupStreamCmd.Flags().Bool("no-encrypt", false,
+		"Stream in the clear when no recipient is configured. Without this, a missing recipient is an error rather than a silent plaintext upload.")
 
 	// backup resume flags (no extra flags beyond the positional backup-id)
 

--- a/internal/backup/create_targets.go
+++ b/internal/backup/create_targets.go
@@ -100,7 +100,16 @@ func createFullBackup(ctx context.Context, cfg *config.Config, backupDir, ts, ta
 	if opts.NoEncrypt {
 		encrypt = false
 	}
-	if encrypt && cfg.Backup.AgeRecipients != "" {
+	// Asking for encryption and getting plaintext is worse than not asking.
+	// This was `encrypt && AgeRecipients != ""`, so a caller who passed
+	// --encrypt (or set NSELF_BACKUP_ENCRYPTION) with no recipient configured
+	// silently got an unencrypted backup: the condition was false and nothing
+	// reported it. Refuse instead.
+	if encrypt && cfg.Backup.AgeRecipients == "" {
+		return fmt.Errorf(
+			"encryption requested but no recipient configured: set NSELF_BACKUP_AGE_RECIPIENTS, or pass --no-encrypt to write the backup in the clear")
+	}
+	if encrypt {
 		if err := encryptFile(outputPath, cfg.Backup.AgeRecipients); err != nil {
 			return fmt.Errorf("encrypt backup: %w", err)
 		}

--- a/internal/backup/stream.go
+++ b/internal/backup/stream.go
@@ -97,9 +97,9 @@ func Stream(ctx context.Context, cfg *config.Config, opts StreamOptions) (*Strea
 	// and the failure is invisible precisely when it matters: offsite backups.
 	if len(recipients) == 0 && !opts.AllowUnencrypted {
 		return nil, fmt.Errorf(
-			"refusing to stream an unencrypted backup: no recipient configured.\n"+
-				"  Pass --recipient <age1... | ssh-... | github:username>, or set %s.\n"+
-				"  To stream in the clear anyway, pass --no-encrypt (the object will NOT be encrypted).",
+			"refusing to stream an unencrypted backup: no recipient configured "+
+				"(pass --recipient <age1...|ssh-...|github:username>, or set %s, "+
+				"or pass --no-encrypt to stream in the clear)",
 			"NSELF_BACKUP_AGE_RECIPIENTS")
 	}
 	if len(recipients) == 0 {

--- a/internal/backup/stream.go
+++ b/internal/backup/stream.go
@@ -45,6 +45,10 @@ type StreamOptions struct {
 	To         string   // destination URL (rclone remote path)
 	Recipients []string // --recipient flags (may be specified multiple times)
 	DryRun     bool
+	// AllowUnencrypted permits streaming in the clear when no recipient
+	// resolves. Off by default: without it, a missing recipient is an error
+	// rather than a silent plaintext upload. See the check in Stream.
+	AllowUnencrypted bool
 }
 
 // StreamResult is returned by Stream on success.
@@ -83,6 +87,24 @@ func Stream(ctx context.Context, cfg *config.Config, opts StreamOptions) (*Strea
 	recipients, err = resolveRecipients(ctx, recipients)
 	if err != nil {
 		return nil, fmt.Errorf("resolve recipients: %w", err)
+	}
+
+	// Fail closed. Encryption was previously skipped whenever no recipient
+	// resolved, with no error and no warning, so `nself backup stream --to
+	// s3:bucket/path` uploaded a plaintext database dump to object storage
+	// while the operator had every reason to believe it was encrypted. Under
+	// the Security-Always-Free doctrine a silent-plaintext default is a defect,
+	// and the failure is invisible precisely when it matters: offsite backups.
+	if len(recipients) == 0 && !opts.AllowUnencrypted {
+		return nil, fmt.Errorf(
+			"refusing to stream an unencrypted backup: no recipient configured.\n"+
+				"  Pass --recipient <age1... | ssh-... | github:username>, or set %s.\n"+
+				"  To stream in the clear anyway, pass --no-encrypt (the object will NOT be encrypted).",
+			"NSELF_BACKUP_AGE_RECIPIENTS")
+	}
+	if len(recipients) == 0 {
+		slog.Warn("streaming an UNENCRYPTED backup: --no-encrypt was passed and no recipient is configured",
+			"destination", opts.To)
 	}
 
 	// Build the object key.

--- a/internal/backup/stream_encryption_test.go
+++ b/internal/backup/stream_encryption_test.go
@@ -1,0 +1,94 @@
+package backup
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+func streamTestConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.ProjectName = "testproj"
+	cfg.Postgres.DB = "testdb"
+	cfg.Postgres.User = "postgres"
+	cfg.Postgres.Password = "pw"
+	cfg.Postgres.Host = "localhost"
+	cfg.Postgres.Port = 5432
+	return cfg
+}
+
+// Streaming with no recipient used to skip encryption silently, so
+// `nself backup stream --to s3:bucket/path` uploaded a plaintext database dump
+// to object storage with nothing in the output saying so. It must fail closed.
+func TestStream_NoRecipient_FailsClosed(t *testing.T) {
+	_, err := Stream(context.Background(), streamTestConfig(), StreamOptions{
+		To:     "s3:bucket/path",
+		DryRun: true,
+	})
+	if err == nil {
+		t.Fatal("streaming with no recipient must not succeed silently")
+	}
+	msg := err.Error()
+	for _, want := range []string{"unencrypted", "--recipient", "--no-encrypt"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should mention %q so the operator knows how to proceed; got: %s", want, msg)
+		}
+	}
+}
+
+// The escape hatch must exist and must be explicit, so an operator who really
+// wants a plaintext stream can have one, but never by accident.
+func TestStream_NoRecipient_AllowedWhenExplicit(t *testing.T) {
+	res, err := Stream(context.Background(), streamTestConfig(), StreamOptions{
+		To:               "s3:bucket/path",
+		DryRun:           true,
+		AllowUnencrypted: true,
+	})
+	if err != nil {
+		t.Fatalf("--no-encrypt should permit an unencrypted stream: %v", err)
+	}
+	if res.Encrypted {
+		t.Error("result claims Encrypted with no recipient configured")
+	}
+	if strings.HasSuffix(res.BackupID, ".age") {
+		t.Errorf("unencrypted object must not carry the .age suffix: %s", res.BackupID)
+	}
+}
+
+// A configured recipient still produces an encrypted stream, and the object key
+// still advertises it.
+func TestStream_WithRecipient_Encrypts(t *testing.T) {
+	res, err := Stream(context.Background(), streamTestConfig(), StreamOptions{
+		To:         "s3:bucket/path",
+		Recipients: []string{"age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsxxxxxx"},
+		DryRun:     true,
+	})
+	if err != nil {
+		t.Fatalf("a configured recipient must stream fine: %v", err)
+	}
+	if !res.Encrypted {
+		t.Error("result should report Encrypted with a recipient configured")
+	}
+	if !strings.HasSuffix(res.BackupID, ".age") {
+		t.Errorf("encrypted object should carry the .age suffix: %s", res.BackupID)
+	}
+}
+
+// The env-configured recipient path must satisfy the check too, or operators
+// who configure encryption globally would be pushed toward --no-encrypt.
+func TestStream_EnvRecipient_SatisfiesCheck(t *testing.T) {
+	cfg := streamTestConfig()
+	cfg.Backup.AgeRecipients = "age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsxxxxxx"
+	res, err := Stream(context.Background(), cfg, StreamOptions{
+		To:     "s3:bucket/path",
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("a recipient from config must satisfy the check: %v", err)
+	}
+	if !res.Encrypted {
+		t.Error("config-supplied recipient should produce an encrypted stream")
+	}
+}

--- a/internal/backup/stream_test.go
+++ b/internal/backup/stream_test.go
@@ -280,9 +280,14 @@ func TestStream_DryRun(t *testing.T) {
 	cfg.ProjectName = "testproject"
 	cfg.Backup.Remote = "s3:mybucket"
 
+	// A recipient is supplied because streaming now fails closed without one.
+	// This test is about the dry-run path and the destination, not about
+	// encryption, so it exercises the ordinary encrypted case rather than
+	// depending on the unencrypted default that used to be silent.
 	result, err := Stream(context.Background(), cfg, StreamOptions{
-		To:     "s3:mybucket",
-		DryRun: true,
+		To:         "s3:mybucket",
+		Recipients: []string{"age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsxxxxxx"},
+		DryRun:     true,
 	})
 	if err != nil {
 		t.Fatalf("Stream dry-run: %v", err)


### PR DESCRIPTION
Two paths wrote plaintext without saying so. Reported by the P7 exec-readiness review; **verified live against the code before changing anything.**

**1. `backup stream` skipped encryption whenever no recipient resolved** — no error, no warning, and the object key silently lost its `.age` suffix. So:

```
nself backup stream --to s3:bucket/path
```

uploaded a **plaintext database dump to object storage** while the operator had every reason to believe it was encrypted. The command's own help text implies encryption is the norm.

**2. `backup create` guarded encryption with `encrypt && AgeRecipients != ""`.** A caller who passed `--encrypt` (or set `NSELF_BACKUP_ENCRYPTION`) with no recipient configured fell straight through the condition and got an unencrypted backup. Asking for encryption and silently not getting it is worse than not asking.

Both now **fail closed** with a message naming exactly what to set. Streaming keeps an explicit `--no-encrypt` escape hatch — there are legitimate reasons to stream in the clear — and logs a warning when it's used. Nobody reaches plaintext by accident.

The failure was invisible precisely where it matters most: offsite backups, where the plaintext sits in someone else's storage.

**Tests:** no recipient (refused), `--no-encrypt` (allowed, no `.age` suffix, not reported encrypted), flag recipient and config recipient (both encrypt, suffix kept). I verified the guard catches its own removal rather than assuming — stubbing the condition to `false` makes the fail-closed test fail.

`TestStream_DryRun` passed no recipient; it asserts the dry-run path and destination, not encryption, so it now supplies a recipient and exercises the ordinary encrypted case rather than depending on the default this removes. Command inventory regenerated for the new flag.