### PR TITLE
fix(build): a profile switch must invalidate the compose cache

### DIFF
--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -12,6 +12,16 @@ import (
 // that produced the last build is recorded.
 const buildVersionFile = ".nself/build-version"
 
+// buildProfileFile records the service profile that produced the last build.
+//
+// NeedsRebuild compares .env against docker-compose.yml by mtime and checks the
+// CLI version, but the profile is neither of those: it arrives as a flag. So
+// `nself build --profile ops` on a project last built as "app" found the cache
+// fresh, regenerated nothing, exited 0, and left every app service in the
+// compose file. The operator asked for an ops server and kept redis, minio and
+// mailpit, with nothing in the output saying so.
+const buildProfileFile = ".nself/build-profile"
+
 // NeedsRebuild reports whether the build outputs are stale and a rebuild
 // is required. It returns true when any of the following hold:
 //
@@ -22,6 +32,32 @@ const buildVersionFile = ".nself/build-version"
 //
 // It returns false only when docker-compose.yml is at least as new as .env
 // and the recorded build version matches the current CLI version.
+// ProfileChanged reports whether the requested service profile differs from
+// the one recorded by the last build. An unreadable or missing record counts as
+// changed: the safe answer is to rebuild, since a stale compose file for the
+// wrong profile is the failure this exists to prevent.
+//
+// Kept separate from NeedsRebuild so the three existing callers that do not
+// know the profile keep working unchanged.
+func ProfileChanged(workdir, profile string) bool {
+	if profile == "" {
+		profile = "app"
+	}
+	recorded, err := os.ReadFile(filepath.Join(workdir, buildProfileFile))
+	if err != nil {
+		return true
+	}
+	return strings.TrimSpace(string(recorded)) != profile
+}
+
+// RecordProfile stores the profile that produced this build.
+func RecordProfile(workdir, profile string) error {
+	if profile == "" {
+		profile = "app"
+	}
+	return os.WriteFile(filepath.Join(workdir, buildProfileFile), []byte(profile), 0644)
+}
+
 func NeedsRebuild(workdir string) (bool, error) {
 	envPath := filepath.Join(workdir, ".env")
 	composePath := filepath.Join(workdir, "docker-compose.yml")

--- a/internal/build/cache_profile_test.go
+++ b/internal/build/cache_profile_test.go
@@ -1,0 +1,55 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A profile switch changes which services are emitted but touches neither
+// .env's mtime nor the CLI version, so NeedsRebuild cannot see it. Before this
+// check, `nself build --profile ops` on a project last built as "app" found the
+// cache fresh, regenerated nothing, exited 0, and left redis/minio/mailpit in
+// the compose file of a server explicitly asked to exclude them.
+func TestProfileChanged_DetectsSwitch(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".nself"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordProfile(dir, "app"); err != nil {
+		t.Fatal(err)
+	}
+	if ProfileChanged(dir, "app") {
+		t.Error("same profile must not force a rebuild")
+	}
+	if !ProfileChanged(dir, "ops") {
+		t.Error("switching app -> ops must force a rebuild")
+	}
+}
+
+// An empty profile is the default, "app". Treating "" and "app" as different
+// would rebuild on every invocation that omits the flag.
+func TestProfileChanged_EmptyMeansApp(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".nself"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordProfile(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	if ProfileChanged(dir, "app") {
+		t.Error(`recorded "" then asked for "app" — same thing, should not rebuild`)
+	}
+	if ProfileChanged(dir, "") {
+		t.Error(`recorded "" then asked for "" — should not rebuild`)
+	}
+}
+
+// No record means we cannot know what produced the existing compose file. The
+// safe answer is to rebuild: a stale compose for the wrong profile is the exact
+// failure this guards against.
+func TestProfileChanged_MissingRecordRebuilds(t *testing.T) {
+	if !ProfileChanged(t.TempDir(), "app") {
+		t.Error("missing profile record must force a rebuild")
+	}
+}

--- a/internal/build/orchestrator_build_config.go
+++ b/internal/build/orchestrator_build_config.go
@@ -73,6 +73,12 @@ func (st *buildState) loadValidateConfig() (*BuildResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("checking build cache: %w", err)
 		}
+		// A profile switch changes which services are emitted but touches
+		// neither .env's mtime nor the CLI version, so the mtime/version check
+		// above cannot see it.
+		if ProfileChanged(st.workdir, string(st.opts.Profile)) {
+			needsRebuild = true
+		}
 		if !needsRebuild {
 			return &BuildResult{
 				ProjectName: st.cfg.ProjectName,

--- a/internal/build/orchestrator_build_finish.go
+++ b/internal/build/orchestrator_build_finish.go
@@ -48,6 +48,12 @@ func (st *buildState) writeFinalArtifacts() (*BuildResult, error) {
 	}
 	st.filesGenerated++
 
+	// Record the profile too, so the next build notices a switch.
+	if err := RecordProfile(st.workdir, string(st.opts.Profile)); err != nil {
+		return nil, fmt.Errorf("writing build profile: %w", err)
+	}
+	st.filesGenerated++
+
 	// ── Step 11.6: Generate OpenAPI 3.1 spec + Scalar HTML page ─────
 	// Only runs when api_docs.enabled is true (default). Writes two files:
 	//   .nself/dist/openapi.json   — served at /api-docs by nginx


### PR DESCRIPTION
`nself build --profile ops` on a project last built as `app` finds the cache fresh, regenerates nothing, exits 0, and leaves **redis, minio and mailpit** in the compose file of a server explicitly defined to exclude them. Nothing says the flag was ignored.

`NeedsRebuild` compares `.env` mtime against `docker-compose.yml` and checks the CLI version. The profile is neither — it arrives as a flag, so a switch is invisible to both.

Records the profile in `.nself/build-profile` next to the existing `build-version` and treats a change as needing a rebuild. Missing/unreadable counts as changed (a stale compose for the wrong profile is the failure being prevented); empty normalises to `app` so flag-less builds don't rebuild every time. Kept separate from `NeedsRebuild` rather than changing its signature — three callers don't know the profile and needed no edit.

**Verified end to end** on a throwaway project:

| step | services generated |
|---|---|
| `--profile app` | postgres, hasura, auth, nginx, redis, minio, mailpit |
| `--profile ops` (nothing deleted) | postgres, hasura, auth, nginx |
| back to `--profile app` | full set restored |

Stubbing the new check to `false` reproduces the original silent no-op, so the guard is doing the work rather than the surrounding code.

**On the report that prompted this:** "nself build silently omits redis even when enabled" does **not** reproduce. On the default `app` profile, `REDIS_ENABLED=true` generates the redis service correctly — confirmed by generating a real compose file, not by reading. The reachable version of that symptom is this one, and it needs a profile switch to trigger.

**Noted, not fixed:** `DetectServices(cfg)` takes no profile argument, so it reports redis under `ops` while the generator correctly omits it. Cosmetic today (it feeds status/display, not generation), but it will mislead anyone comparing the two.