### PR TITLE
fix: close 6 P4 deferred-backlog LOW rows (P6-E11-W2-S3-T16)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
-# Dependabot — GitHub Actions version pinning + Go module CVE tracking
+# Dependabot — GitHub Actions version pinning + Go module CVE tracking + npm SDK tracking
 # S44-T-SEC-01: keep Actions SHA-pinned via Dependabot PRs.
 # P4-E5-W3-S05-T17: gomod ecosystem added for automated Go CVE detection.
+# P6-E11-W2-S3-T16 (row 16): npm ecosystem added for sdk/ts + sdk/ts-sdk — the
+# two TS SDK packages with their own package.json were previously untracked.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -26,6 +28,42 @@ updates:
     labels:
       - dependencies
       - go
+    commit-message:
+      prefix: 'chore(deps)'
+      include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+
+  - package-ecosystem: npm
+    directory: /sdk/ts
+    schedule:
+      interval: weekly
+      day: monday
+      time: '04:00'
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+    commit-message:
+      prefix: 'chore(deps)'
+      include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+
+  - package-ecosystem: npm
+    directory: /sdk/ts-sdk
+    schedule:
+      interval: weekly
+      day: monday
+      time: '04:00'
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
     commit-message:
       prefix: 'chore(deps)'
       include: scope

--- a/.github/wiki/Config-Env-Vars.md
+++ b/.github/wiki/Config-Env-Vars.md
@@ -24,6 +24,7 @@ All ɳSelf project configuration lives in `.env` (and optionally `.env.local` fo
 - [AI (Zero-Config AI Pool)](#ai-zero-config-ai-pool)
 - [Optional Service Toggles](#optional-service-toggles)
 - [Custom Services (CS\_N)](#custom-services-cs_n)
+- [Observability / Profiling](#observability--profiling)
 - [Computed Variables](#computed-variables)
 
 ---
@@ -285,6 +286,19 @@ This registers a Node.js service named `ping_api` accessible at `ping.{BASE_DOMA
 |---|---|---|---|---|
 | `NSELF_EMBEDDED_PG` | bool | `false` | No | When `true`, uses embedded PostgreSQL via pglite/wasmtime instead of a Docker Postgres container. Hasura connects via a Unix-domain socket bridge. Requires a `CGO_ENABLED=1` build of the CLI. Pass `--embedded-pg` to `nself start` as well. |
 | `NSELF_POSTGRES_MODE` | string | `docker` | No | Selects the Postgres runtime. `docker` runs the standard Postgres container (default, fully supported). `wasm` runs the experimental embedded pglite/wasmtime lane. The `wasm` mode is gated behind the Emscripten ABI shim and is not yet production ready. |
+
+---
+
+## Observability / Profiling
+
+| Variable | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `NSELF_PROFILING_TOKEN` | string | *(empty)* | No | Bearer token required in the `X-Profile-Token` header to reach any `/debug/pprof/*` endpoint (`internal/observability`). Empty means no token is configured — see `NSELF_PPROF_DEV` below for the only way to still reach pprof in that case. |
+| `NSELF_PPROF_BIND` | string | `127.0.0.1:6060` | No | Bind address for the standalone pprof HTTP server started by `ServeProfiling`. Keep this loopback-only; it is never exposed publicly via nginx. |
+| `NSELF_PPROF_DEV` | bool (`"1"`) | unset | No | Local-dev escape hatch for pprof when `NSELF_PROFILING_TOKEN` is unset. Pprof normally fails closed (403) with no token configured — set `NSELF_PPROF_DEV=1` to allow unauthenticated access, but **only** when the pprof handler's bind address is loopback (`127.0.0.1`, `::1`, or `localhost`). On any non-loopback bind this variable has no effect and pprof stays closed. Every request served through this escape hatch logs a `slog.Warn` line so it is never silently active. |
+| `PYROSCOPE_ENABLED` | bool | `false` | No | Enables continuous profiling push to a Pyroscope server. |
+| `PYROSCOPE_SERVER_URL` | string | *(empty)* | No | Pyroscope server address; required when `PYROSCOPE_ENABLED=true`. |
+| `PYROSCOPE_APPLICATION_NAME` | string | `OTEL_SERVICE_NAME`, else *(empty)* | No | Application name reported to Pyroscope. Falls back to `OTEL_SERVICE_NAME` when unset. |
 
 ---
 

--- a/cmd/commands/controller.go
+++ b/cmd/commands/controller.go
@@ -73,7 +73,20 @@ func assertControllerEnabled(cmd *cobra.Command) bool {
 	return true
 }
 
+// CreateProjectRequest is the typed body for POST /projects/create, replacing
+// the untyped map[string]string literal previously built inline at the call
+// site (P4 deferred-backlog row 2 — no generic [T any] request-builder
+// pattern exists elsewhere in this CLI to mirror, so each doControllerRequest
+// call site gets its own typed struct instead).
+type CreateProjectRequest struct {
+	Slug   string
+	Domain string
+}
+
 // doControllerRequest performs an authenticated HTTP request to the controller daemon.
+// body is intentionally interface{}: it is marshalled straight to JSON, and
+// every call site now passes either nil or a typed *Request struct (see
+// CreateProjectRequest) rather than an ad hoc map literal.
 func doControllerRequest(method, path string, body interface{}) ([]byte, int, error) {
 	var reqBody io.Reader
 	if body != nil {

--- a/cmd/commands/plugin_compat_check.go
+++ b/cmd/commands/plugin_compat_check.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -52,7 +51,7 @@ func runPluginCompatCheck(cmd *cobra.Command, args []string) error {
 	pluginDir := resolvePluginDir()
 	cliVer := version.GetVersion()
 
-	ctx := context.Background()
+	ctx := cmd.Context()
 	cacheDir := plugin.DefaultCacheDir()
 	reg, regErr := plugin.FetchRegistry(ctx, "", cacheDir)
 	if regErr != nil {

--- a/cmd/commands/plugin_dev.go
+++ b/cmd/commands/plugin_dev.go
@@ -162,8 +162,18 @@ func findDevWatchScript() (string, error) {
 	}
 
 	for _, c := range candidates {
-		if _, err := os.Stat(c); err == nil {
-			return c, nil
+		// A candidate may carry an unexpanded glob segment (e.g. the
+		// GOPATH module-cache path, which embeds the SDK's version suffix
+		// as `plugin-sdk-go*`). os.Stat never matches a literal glob
+		// pattern, so expand it explicitly and use the first match; a
+		// plain path with no glob metacharacters passes through Glob
+		// unchanged and behaves exactly like the old os.Stat check.
+		matches, err := filepath.Glob(c)
+		if err != nil || len(matches) == 0 {
+			continue
+		}
+		if _, err := os.Stat(matches[0]); err == nil {
+			return matches[0], nil
 		}
 	}
 

--- a/cmd/commands/project_cmd_core.go
+++ b/cmd/commands/project_cmd_core.go
@@ -46,9 +46,9 @@ var projectCreateCmd = &cobra.Command{
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Creating project %q at %s...\n",
 			projectCreateFlags.Slug, projectCreateFlags.Domain)
 
-		body, code, err := doControllerRequest("POST", "/projects/create", map[string]string{
-			"Slug":   projectCreateFlags.Slug,
-			"Domain": projectCreateFlags.Domain,
+		body, code, err := doControllerRequest("POST", "/projects/create", CreateProjectRequest{
+			Slug:   projectCreateFlags.Slug,
+			Domain: projectCreateFlags.Domain,
 		})
 		if err != nil {
 			return fmt.Errorf("controller error: %w", err)

--- a/internal/observability/profiling.go
+++ b/internal/observability/profiling.go
@@ -4,6 +4,7 @@ package observability
 
 import (
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -54,7 +55,7 @@ func ServeProfiling(cfg ProfilingConfig) {
 
 	// Wrap all pprof handlers with token auth.
 	wrap := func(h http.HandlerFunc) http.Handler {
-		return tokenAuth(cfg.Token, h)
+		return tokenAuth(cfg.Token, cfg.BindAddr, h)
 	}
 
 	mux.Handle("/debug/pprof/", wrap(pprof.Index))
@@ -69,12 +70,18 @@ func ServeProfiling(cfg ProfilingConfig) {
 	}
 }
 
-// PprofHandler returns an http.Handler that serves pprof endpoints
-// with token authentication. Useful for registering on an existing mux.
-func PprofHandler(token string) http.Handler {
+// PprofHandler returns an http.Handler that serves pprof endpoints with
+// token authentication. Useful for registering on an existing mux.
+//
+// bindAddr is the address (host:port) the caller intends to serve this
+// handler on — e.g. the same value passed to http.ListenAndServe. It is
+// used only to evaluate the NSELF_PPROF_DEV escape hatch (see tokenAuth);
+// pass "" if unknown, which is treated as non-loopback (escape hatch
+// never applies).
+func PprofHandler(token, bindAddr string) http.Handler {
 	mux := http.NewServeMux()
 	wrap := func(h http.HandlerFunc) http.Handler {
-		return tokenAuth(token, h)
+		return tokenAuth(token, bindAddr, h)
 	}
 	mux.Handle("/debug/pprof/", wrap(pprof.Index))
 	mux.Handle("/debug/pprof/cmdline", wrap(pprof.Cmdline))
@@ -84,15 +91,41 @@ func PprofHandler(token string) http.Handler {
 	return mux
 }
 
-// tokenAuth middleware checks X-Profile-Token header. If token is empty,
-// pprof is disabled entirely (fail-closed) rather than left open — profiling
-// requires an explicit NSELF_PROFILING_TOKEN opt-in (P4 deferred-backlog
-// row 20; the prior "empty token = open" behavior was a default-deny gap
-// for whenever this handler is wired into a server's mux).
-func tokenAuth(token string, next http.HandlerFunc) http.Handler {
+// isLoopbackBind reports whether addr (a host:port pair, as passed to
+// http.ListenAndServe) resolves to a loopback-only bind. An empty host
+// (e.g. ":6060", meaning "all interfaces") and any host that is not a
+// literal loopback IP or "localhost" are treated as non-loopback.
+func isLoopbackBind(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil || host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// tokenAuth middleware checks the X-Profile-Token header.
+//
+// Contract (P4 deferred-backlog row 20, revised per manager decision after
+// cli#354 CI failure): empty token = pprof CLOSED (403) by default — the
+// original "empty token = open" behavior was a default-deny gap. A narrow
+// dev escape hatch exists: empty token is allowed ONLY when both
+// NSELF_PPROF_DEV=1 is set AND bindAddr is loopback-only (127.0.0.1, ::1,
+// or "localhost") — never on a non-loopback bind, even with the env var
+// set. Every request served through the escape hatch logs a one-line
+// warning so it is never silently active.
+func tokenAuth(token, bindAddr string, next http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if token == "" {
-			http.Error(w, "Forbidden: profiling disabled (set NSELF_PROFILING_TOKEN to enable)", http.StatusForbidden)
+			if os.Getenv("NSELF_PPROF_DEV") == "1" && isLoopbackBind(bindAddr) {
+				slog.Warn("pprof serving without a token — NSELF_PPROF_DEV=1 escape hatch active on loopback bind", "addr", bindAddr)
+				next(w, r)
+				return
+			}
+			http.Error(w, "Forbidden: profiling disabled (set NSELF_PROFILING_TOKEN to enable, or NSELF_PPROF_DEV=1 on a loopback bind for local dev)", http.StatusForbidden)
 			return
 		}
 		if r.Header.Get("X-Profile-Token") != token {

--- a/internal/observability/profiling.go
+++ b/internal/observability/profiling.go
@@ -85,10 +85,17 @@ func PprofHandler(token string) http.Handler {
 }
 
 // tokenAuth middleware checks X-Profile-Token header. If token is empty,
-// auth is disabled (dev mode).
+// pprof is disabled entirely (fail-closed) rather than left open — profiling
+// requires an explicit NSELF_PROFILING_TOKEN opt-in (P4 deferred-backlog
+// row 20; the prior "empty token = open" behavior was a default-deny gap
+// for whenever this handler is wired into a server's mux).
 func tokenAuth(token string, next http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if token != "" && r.Header.Get("X-Profile-Token") != token {
+		if token == "" {
+			http.Error(w, "Forbidden: profiling disabled (set NSELF_PROFILING_TOKEN to enable)", http.StatusForbidden)
+			return
+		}
+		if r.Header.Get("X-Profile-Token") != token {
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}

--- a/internal/observability/profiling_test.go
+++ b/internal/observability/profiling_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTokenAuth_ValidToken(t *testing.T) {
-	handler := PprofHandler("test-token-123")
+	handler := PprofHandler("test-token-123", "127.0.0.1:6060")
 	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
 	req.Header.Set("X-Profile-Token", "test-token-123")
 	w := httptest.NewRecorder()
@@ -18,7 +18,7 @@ func TestTokenAuth_ValidToken(t *testing.T) {
 }
 
 func TestTokenAuth_InvalidToken(t *testing.T) {
-	handler := PprofHandler("test-token-123")
+	handler := PprofHandler("test-token-123", "127.0.0.1:6060")
 	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
 	req.Header.Set("X-Profile-Token", "wrong-token")
 	w := httptest.NewRecorder()
@@ -28,22 +28,70 @@ func TestTokenAuth_InvalidToken(t *testing.T) {
 	}
 }
 
-func TestTokenAuth_NoToken_DisablesAuth(t *testing.T) {
-	handler := PprofHandler("")
+// TestTokenAuth_NoToken_DefaultsClosed is the row-20 contract: an empty
+// token means pprof is disabled (403) by default, with no escape hatch
+// env var set. This replaces the old TestTokenAuth_NoToken_DisablesAuth,
+// which asserted the opposite (empty token = open) — that behavior was
+// the default-deny gap this fix closes.
+func TestTokenAuth_NoToken_DefaultsClosed(t *testing.T) {
+	handler := PprofHandler("", "127.0.0.1:6060")
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 with empty token and no NSELF_PPROF_DEV, got %d", w.Code)
+	}
+}
+
+func TestTokenAuth_NoToken_DevOptIn_Loopback_Allows(t *testing.T) {
+	t.Setenv("NSELF_PPROF_DEV", "1")
+	handler := PprofHandler("", "127.0.0.1:6060")
 	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code == http.StatusForbidden {
-		t.Error("expected access when token is empty (dev mode), got 403")
+		t.Error("expected access with NSELF_PPROF_DEV=1 on a loopback bind, got 403")
+	}
+}
+
+func TestTokenAuth_NoToken_DevOptIn_NonLoopback_StillClosed(t *testing.T) {
+	t.Setenv("NSELF_PPROF_DEV", "1")
+	handler := PprofHandler("", "0.0.0.0:6060")
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403: NSELF_PPROF_DEV=1 must not open pprof on a non-loopback bind, got %d", w.Code)
 	}
 }
 
 func TestTokenAuth_MissingHeader(t *testing.T) {
-	handler := PprofHandler("test-token-123")
+	handler := PprofHandler("test-token-123", "127.0.0.1:6060")
 	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusForbidden {
 		t.Errorf("expected 403 when header missing, got %d", w.Code)
+	}
+}
+
+func TestIsLoopbackBind(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:6060", true},
+		{"localhost:6060", true},
+		{"[::1]:6060", true},
+		{"0.0.0.0:6060", false},
+		{":6060", false},
+		{"192.168.1.5:6060", false},
+		{"", false},
+		{"not-a-valid-addr", false},
+	}
+	for _, c := range cases {
+		if got := isLoopbackBind(c.addr); got != c.want {
+			t.Errorf("isLoopbackBind(%q) = %v, want %v", c.addr, got, c.want)
+		}
 	}
 }


### PR DESCRIPTION
## What
Closes 6 of the P4 deferred-backlog LOW rows assigned to P6-E11-W2-S3-T16:

- **Row 2**: typed `CreateProjectRequest` struct replaces an untyped `map[string]string` at the one `doControllerRequest` call site that built its body inline.
- **Row 3**: `plugin_compat_check.go` threads `cmd.Context()` instead of `context.Background()`.
- **Row 6**: `findDevWatchScript`'s GOPATH candidate carried an unexpanded glob passed straight to `os.Stat` (never matches); now resolved via `filepath.Glob()` first.
- **Row 16**: `dependabot.yml` gained `npm` ecosystem entries for `sdk/ts` and `sdk/ts-sdk` (each ships its own `package.json`, previously untracked).
- **Row 20**: `profiling.go`'s `tokenAuth` now fails closed (403) when `NSELF_PROFILING_TOKEN` is unset, instead of leaving pprof open with no token configured. **See "Contract change" below — this was revised after the first CI run.**

Rows 21/23/24/25 were already closed by a prior session (PR #343). Row 1 (1067 `fmt.Print` call sites) is out of scope for a mechanical fix here — re-homed to P7-E1-W1-S1-T1 (`internal/output` package), which is the dedicated ticket for exactly this migration.

## Contract change (row 20, revised after CI caught it)
The first push broke `TestTokenAuth_NoToken_DisablesAuth`, which asserted the *old* behavior (empty token = pprof open) as intentional dev-mode support — a real regression, not a flaky test.

- **Old**: empty `NSELF_PROFILING_TOKEN` = pprof open (any request served, no auth).
- **New**: empty token = pprof **closed** (403), **unless** `NSELF_PPROF_DEV=1` is set **and** the bind address is loopback-only (`127.0.0.1`, `::1`, or `localhost`). The opt-in has no effect on a non-loopback bind — pprof stays closed even with `NSELF_PPROF_DEV=1` set. Every request served through the escape hatch logs a one-line `slog.Warn` so it's never silently active.

`PprofHandler(token string)` is now `PprofHandler(token, bindAddr string)` so `tokenAuth` can evaluate the loopback condition. The only callers were this package's own tests — no other call site exists anywhere in the repo (this handler is currently unwired/dead code).

`NSELF_PPROF_DEV` (and the previously-undocumented `NSELF_PROFILING_TOKEN`, `NSELF_PPROF_BIND`, `PYROSCOPE_*`) are now documented in `.github/wiki/Config-Env-Vars.md` under a new "Observability / Profiling" section.

## Test plan
- `go test ./internal/observability/... -v` — 42 passed (replaced `TestTokenAuth_NoToken_DisablesAuth` with `TestTokenAuth_NoToken_DefaultsClosed`; added `TestTokenAuth_NoToken_DevOptIn_Loopback_Allows`, `TestTokenAuth_NoToken_DevOptIn_NonLoopback_StillClosed`, `TestIsLoopbackBind`)
- `go build ./...` — success
- `go vet ./cmd/commands/... ./internal/observability/...` — clean
- `gofmt -l` on every touched file — clean

Local gate only (no GitHub Actions run — public repo, standing local-gate policy).