### PR TITLE
feat(ci): wire nself ci build (local Android artifact-build lane)

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -443,6 +443,21 @@
     ],
     "subcommands": [
       {
+        "name": "build",
+        "path": "nself ci build",
+        "short": "Build a signed release artifact locally (Android only)",
+        "hidden": false,
+        "flags": [
+          "--artifact",
+          "--owner",
+          "--repo",
+          "--tag",
+          "--timeout",
+          "--upload",
+          "--verbose"
+        ]
+      },
+      {
         "name": "eval",
         "path": "nself ci eval",
         "short": "Run eval-gate suite or validate an eval-set YAML",

--- a/.github/wiki/Commands.md
+++ b/.github/wiki/Commands.md
@@ -104,7 +104,7 @@ Run `make cmd-inventory` to refresh. **Total top-level commands: 50**
 | `nself backup` | Backup operations: create, list, restore, verify, prune, config, status, init-key | data | config, create, drill, init-key, list, pitr, prune, restore, restore-remote, resume, schedule, status, stream, verify |
 | `nself build` | Compose your infrastructure from .env | core | — |
 | `nself bundle` | Manage and inspect nSelf plugin bundles | extend | info, install, list, remove |
-| `nself ci` | Run the nself-ci gate suite and post a GitHub commit status | deploy | eval, forgejo, serve |
+| `nself ci` | Run the nself-ci gate suite and post a GitHub commit status | deploy | build, eval, forgejo, serve |
 | `nself clean` | Remove generated artifacts (docker-compose.yml, nginx configs, build cache) | core | — |
 | `nself completion` | Generate shell completion scripts | account | — |
 | `nself config` | Manage project configuration | config | export, features, get, import, list, set, show, validate |

--- a/.github/wiki/cmd-ci.md
+++ b/.github/wiki/cmd-ci.md
@@ -89,6 +89,7 @@ is why `nself ci` could not be used as a required status check.
 <!-- BEGIN GENERATED:subcommands -->
 | Name | Description |
 |------|-------------|
+| `build` | Build a signed release artifact locally (Android only) |
 | `eval` | Run eval-gate suite or validate an eval-set YAML |
 | `forgejo` | Show Forgejo server + runner health (ops profile) |
 | `serve` | Start the nself-ci webhook listener daemon (port 3845) |

--- a/.github/wiki/llms.txt
+++ b/.github/wiki/llms.txt
@@ -155,6 +155,7 @@ nself ci [repo-root] <subcommand> [flags]
 
 Subcommands:
 
+- `build` — Build a signed release artifact locally (Android only)
 - `eval` — Run eval-gate suite or validate an eval-set YAML
 - `forgejo` — Show Forgejo server + runner health (ops profile)
 - `serve` — Start the nself-ci webhook listener daemon (port 3845)

--- a/cmd/commands/ci.go
+++ b/cmd/commands/ci.go
@@ -55,6 +55,9 @@ func init() {
 	evalCmd.AddCommand(nscicmd.NewEvalGateCmd())
 	ciCmd.AddCommand(evalCmd)
 
+	initCIBuildCmd()
+	ciCmd.AddCommand(ciBuildCmd)
+
 	RootCmd.AddCommand(ciCmd)
 }
 

--- a/cmd/commands/ci_build.go
+++ b/cmd/commands/ci_build.go
@@ -1,0 +1,120 @@
+package commands
+
+// Purpose: nself ci build — local release-artifact build lane.
+//   Wraps the nself-ci binary's "build" subcommand (plugins/free/ci) so a
+//   private repo (web, packages, plugins-pro) can produce a signed Android
+//   release APK on the developer's own machine and optionally attach it to
+//   a GitHub release, without a GitHub-hosted runner or a third nSelf
+//   server. Split out of ci.go (which shells to the same binary for the
+//   default gate command) purely to keep each command's flag set and RunE
+//   in its own file — same pattern as ci_bootstrap.go / ci_forgejo.go /
+//   ci_serve.go.
+// Inputs:  [flags] [android-project-dir]
+// Outputs: build log to stdout, signed APK on disk, optional gh release
+//   upload, exit 0/1
+// Constraints: Android only — macOS/Windows/TV/WearOS artifacts stay on
+//   GitHub-hosted runners (P6-E11-W2-S1-T6). No hardcoded keystore secrets;
+//   ANDROID_KEYSTORE_BASE64/ANDROID_KEYSTORE_PASSWORD/ANDROID_KEY_ALIAS/
+//   ANDROID_KEY_PASSWORD are read from the environment by the gate binary.
+// SPORT: CLI-CMD-CI-002
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/nself-org/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var ciBuildCmd = &cobra.Command{
+	Use:   "build [android-project-dir]",
+	Short: "Build a signed release artifact locally (Android only)",
+	Long: `Build a signed release artifact on this machine instead of a GitHub-hosted runner.
+
+Only "android" is supported today. Mirrors the exact keystore-signing steps
+nchat's own workflows already use (build-react-native.yml,
+deploy-mobile-android.yml): base64-decode a keystore from
+ANDROID_KEYSTORE_BASE64, run "./gradlew assembleRelease" with the standard
+ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_ALIAS / ANDROID_KEY_PASSWORD env
+vars, then locate the produced signed APK.
+
+macOS, Windows, TV, and Wear OS artifacts are explicitly out of scope — they
+stay on GitHub-hosted runners; see .claude/docs/doctrines/nself-ci-runner-ceiling.md.
+
+Examples:
+  nself ci build --artifact android frontend/platforms/react-native/android
+  nself ci build --artifact android --upload --tag v1.2.3 frontend/platforms/react-native/android`,
+	RunE: runCIBuild,
+}
+
+func initCIBuildCmd() {
+	ciBuildCmd.Flags().String("artifact", "android", `Artifact type to build (only "android" is supported)`)
+	ciBuildCmd.Flags().Bool("upload", false, "Attach the built artifact to a GitHub release via `gh release upload`")
+	ciBuildCmd.Flags().String("tag", "", "Release tag to upload to (required with --upload)")
+	ciBuildCmd.Flags().String("owner", "", "GitHub owner for --upload (default: from git remote)")
+	ciBuildCmd.Flags().String("repo", "", "GitHub repo for --upload (default: from git remote)")
+	ciBuildCmd.Flags().BoolP("verbose", "v", false, "Print each command before running")
+	ciBuildCmd.Flags().Int("timeout", 900, "Build step timeout in seconds (release builds are slow)")
+}
+
+func runCIBuild(cmd *cobra.Command, args []string) error {
+	projectDir := "."
+	if len(args) > 0 {
+		projectDir = args[0]
+	}
+	abs, err := filepath.Abs(projectDir)
+	if err != nil {
+		return fmt.Errorf("cannot resolve path: %w", err)
+	}
+	projectDir = abs
+
+	artifact, _ := cmd.Flags().GetString("artifact")
+	upload, _ := cmd.Flags().GetBool("upload")
+	tag, _ := cmd.Flags().GetString("tag")
+	owner, _ := cmd.Flags().GetString("owner")
+	repo, _ := cmd.Flags().GetString("repo")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	timeout, _ := cmd.Flags().GetInt("timeout")
+
+	if upload && tag == "" {
+		return fmt.Errorf("--tag is required with --upload")
+	}
+
+	binaryPath, buildErr := ensureCIBinary(verbose)
+	if buildErr != nil {
+		return fmt.Errorf("cannot build nself-ci gate binary: %w", buildErr)
+	}
+
+	buildArgs := []string{"build", "--artifact", artifact, "--timeout", fmt.Sprintf("%d", timeout)}
+	if verbose {
+		buildArgs = append(buildArgs, "-v")
+	}
+	if upload {
+		buildArgs = append(buildArgs, "--upload", "--tag", tag)
+		if owner != "" {
+			buildArgs = append(buildArgs, "--owner", owner)
+		}
+		if repo != "" {
+			buildArgs = append(buildArgs, "--repo", repo)
+		}
+	}
+	buildArgs = append(buildArgs, projectDir)
+
+	ui.Section("nself-ci artifact build")
+	ui.Info(fmt.Sprintf("artifact: %s, dir: %s", artifact, projectDir))
+
+	c := exec.Command(binaryPath, buildArgs...)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	if err := c.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return fmt.Errorf("artifact build failed")
+		}
+		return fmt.Errorf("nself-ci build: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Wires `nself ci build --artifact android [dir]` as a cobra subcommand of the existing `nself ci` command. Shells out to the `nself-ci` gate binary's new `build` subcommand (implemented in nself-org/plugins#76, `plugins/free/ci`), same pattern the existing `ci` command already uses to run gates.

`--upload --tag <tag>` attaches the produced signed APK to a GitHub release via `gh release upload`.

## Why

Closes the local artifact-build gap from `msg-2026-08-21-nself-ci-local-artifact-builds.md` — private repos (web, packages, plugins-pro) need a way to produce release artifacts without a GitHub-hosted runner or a third nSelf server, per the PPI's Two-Servers-Only doctrine.

## Ticket

P6-E11-W2-S1-T6 (companion PR: nself-org/plugins#76)

## Test plan

- [x] `go vet ./cmd/commands/...` clean
- [x] `go build ./...` (full repo) passes
- [x] `go test ./cmd/commands/...` passes (39s)
- [x] Live-verified end-to-end via a locally built binary + the plugins-side fixture (fake `gradlew`, real `gh release upload` round-trip against an ephemeral test release) — see plugins#76 for the fixture evidence

## Depends on

nself-org/plugins#76 must land first (or at least be mergeable) for `nself ci build` to have a `build` subcommand to shell out to; this PR's Go code compiles independently either way since it only constructs argv for the external binary.