### PR TITLE
fix(nginx): propagate HasTrustedChain in the real generateAllRoutes build path

### DIFF
--- a/internal/nginx/generator_chain_test.go
+++ b/internal/nginx/generator_chain_test.go
@@ -79,3 +79,85 @@ func TestServiceRoute_EmitsTrustedChainWhenPresent(t *testing.T) {
 		t.Error("chain.pem exists but stapling was not enabled")
 	}
 }
+
+// TestGenerate_RealBuildPathEmitsTrustedChainWhenPresent is the regression
+// guard for a live-path gap found 2026-09-03 verifying P6-E11-W2-S1-T2:
+// TestServiceRoute_EmitsTrustedChainWhenPresent above proves RenderServiceRoute
+// sets HasTrustedChain correctly, but `nself build` never calls
+// RenderServiceRoute directly — it calls Generate(), which calls
+// generateAllRoutes(), which builds every nginx/sites/*.conf via its own
+// propagation loop. That loop set HasSSL and UpstreamName on each route's
+// data but never HasTrustedChain, so every route kept the Go zero value
+// (false) regardless of whether a real chain.pem was on disk: a genuine CA
+// chain (e.g. Let's Encrypt) placed in ssl/certificates/<dir>/chain.pem was
+// silently never reflected in any file `nself build` actually writes. This
+// test drives the real Generate() entrypoint, not RenderServiceRoute, so it
+// would have caught the gap the isolated unit test above could not.
+func TestGenerate_RealBuildPathEmitsTrustedChainWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	certDir := filepath.Join(dir, "ssl", "certificates", "local-nself-org")
+	if err := os.MkdirAll(certDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(certDir, "chain.pem"), []byte("-----BEGIN CERTIFICATE-----\n"), 0o600); err != nil {
+		t.Fatalf("write chain.pem: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(certDir, "fullchain.pem"), []byte("-----BEGIN CERTIFICATE-----\n"), 0o600); err != nil {
+		t.Fatalf("write fullchain.pem: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(certDir, "privkey.pem"), []byte("-----BEGIN PRIVATE KEY-----\n"), 0o600); err != nil {
+		t.Fatalf("write privkey.pem: %v", err)
+	}
+
+	g := newLocalSSLGenerator(t, dir)
+	files, err := g.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	hasura, ok := files["nginx/sites/hasura.conf"]
+	if !ok {
+		t.Fatal("Generate did not produce nginx/sites/hasura.conf (core route)")
+	}
+	if !strings.Contains(hasura, "ssl_trusted_certificate") {
+		t.Error("real Generate() build path: chain.pem exists on disk but " +
+			"nginx/sites/hasura.conf has no ssl_trusted_certificate — " +
+			"generateAllRoutes() is not propagating HasTrustedChain")
+	}
+	if !strings.Contains(hasura, "ssl_stapling on") {
+		t.Error("real Generate() build path: chain.pem exists but stapling was not enabled in hasura.conf")
+	}
+}
+
+// TestGenerate_RealBuildPathOmitsTrustedChainWhenMissing is the companion
+// no-chain case for the same real Generate() path, guarding against a fix to
+// the present-case regressing the already-fixed absent-case (nginx must
+// never be pointed at a chain.pem that does not exist).
+func TestGenerate_RealBuildPathOmitsTrustedChainWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	certDir := filepath.Join(dir, "ssl", "certificates", "local-nself-org")
+	if err := os.MkdirAll(certDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(certDir, "fullchain.pem"), []byte("-----BEGIN CERTIFICATE-----\n"), 0o600); err != nil {
+		t.Fatalf("write fullchain.pem: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(certDir, "privkey.pem"), []byte("-----BEGIN PRIVATE KEY-----\n"), 0o600); err != nil {
+		t.Fatalf("write privkey.pem: %v", err)
+	}
+
+	g := newLocalSSLGenerator(t, dir)
+	files, err := g.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	hasura, ok := files["nginx/sites/hasura.conf"]
+	if !ok {
+		t.Fatal("Generate did not produce nginx/sites/hasura.conf (core route)")
+	}
+	if strings.Contains(hasura, "ssl_trusted_certificate") {
+		t.Error("real Generate() build path: no chain.pem on disk but " +
+			"nginx/sites/hasura.conf emitted ssl_trusted_certificate — nginx will refuse to start")
+	}
+}

--- a/internal/nginx/routes.go
+++ b/internal/nginx/routes.go
@@ -82,8 +82,22 @@ func (g *Generator) generateAllRoutes() (map[string]string, error) {
 
 	// Propagate HasSSL to every route entry so templates can conditionally
 	// omit ssl_certificate directives when certs are not locally managed.
+	//
+	// HasTrustedChain must be computed here too: this loop (not
+	// RenderServiceRoute) is the code path `nself build` actually uses to
+	// render every nginx/sites/*.conf file. RenderServiceRoute sets it on its
+	// own ServiceRouteData and is exercised by generator_chain_test.go's
+	// TestServiceRoute_EmitsTrustedChainWhenPresent, but that test — and
+	// every other caller of RenderServiceRoute — never runs through
+	// generateAllRoutes(), so a real chain.pem placed on disk was silently
+	// never reflected in the routes this command actually writes: every
+	// entry kept HasTrustedChain at its Go zero value (false), so
+	// ssl_trusted_certificate/OCSP stapling never activated even with a
+	// genuine CA chain (Let's Encrypt, etc.) present. Found live 2026-09-03
+	// verifying P6-E11-W2-S1-T2 (chain.pem end-to-end fixture test).
 	for i := range allEntries {
 		allEntries[i].data.HasSSL = g.hasSSL
+		allEntries[i].data.HasTrustedChain = g.hasTrustedChain(allEntries[i].data.SSLDir)
 		allEntries[i].data.UpstreamName = upstreamName(allEntries[i].data.Route)
 	}
 


### PR DESCRIPTION
## Summary
P6-E11-W2-S1-T2 verification: both bugs from msg-2026-08-23-start-ignores-compose-override.md
were already fixed on main (docker-compose.override.yml -f merge, chain.pem conditional
emission via `hasTrustedChain()`), but live end-to-end verification against a real fixture
project surfaced a gap the existing unit tests could not catch — RenderServiceRoute() computes
`HasTrustedChain` correctly and its own unit test proves it, but `nself build`'s real code path
(`Generate() -> generateAllRoutes()`) never calls RenderServiceRoute directly. Its own
field-propagation loop set `HasSSL` and `UpstreamName` on every route but never
`HasTrustedChain`, so every nginx/sites/*.conf file `nself build` actually writes kept the Go
zero value (false) regardless of whether a real chain.pem was on disk.

This PR fixes that one-line gap in `internal/nginx/routes.go`'s `generateAllRoutes()` and adds
two regression tests that drive the real `Generate()` entrypoint (not RenderServiceRoute), so a
future regression here fails a fast unit test instead of only showing up in a live fixture.

## What/why
- `internal/nginx/routes.go`: propagate `HasTrustedChain` in the same loop that already
  propagates `HasSSL`/`UpstreamName` for every route entry before rendering.
- `internal/nginx/generator_chain_test.go`: add `TestGenerate_RealBuildPathEmitsTrustedChainWhenPresent`
  and `TestGenerate_RealBuildPathOmitsTrustedChainWhenMissing`, both calling `g.Generate()` (the
  real build path) instead of `RenderServiceRoute()` directly.

## Acceptance evidence (ticket P6-E11-W2-S1-T2)
- Live fixture (`nself init` + `nself build` + `nself start`, docker-compose.override.yml adding
  `FIXTURE_OVERRIDE_VAR=present` to postgres): `docker inspect <fixture>_postgres --format
  '{{index .Config.Labels "com.docker.compose.project.config_files"}}'` lists both
  docker-compose.yml and docker-compose.override.yml; `{{.Config.Env}}` contains
  `FIXTURE_OVERRIDE_VAR=present` — override genuinely merges into the running container.
- No chain.pem: `grep -rln ssl_trusted_certificate nginx/` returns zero matches; `nginx -t`
  against the generated config succeeds with no BIO_new_file()/chain.pem error (only benign
  "ssl_stapling ignored, issuer certificate not found" warnings, expected for a self-signed
  cert).
- chain.pem placed: BEFORE this fix, `nginx/sites/hasura.conf` still had zero
  `ssl_trusted_certificate` matches even with chain.pem present (the gap this PR fixes). AFTER:
  `ssl_trusted_certificate .../chain.pem` + `ssl_stapling on` correctly appear in
  nginx/sites/hasura.conf and nginx/sites/auth.conf. Removing chain.pem and rebuilding again
  confirms the negative case still holds (no regression).
- `go build ./... && go vet ./... && go test ./internal/nginx/... ./internal/docker/...` all
  exit 0 locally (worktree, not pushed to CI — GitHub Actions billing is ignored per standing
  doctrine, ran the gate locally per repo convention).

## Test plan
- [x] `go test ./internal/nginx/... -v` — all pass including the 2 new tests
- [x] `go test ./internal/docker/... -v` — all pass, no regression to compose -f merge tests
- [x] Live fixture: override merge confirmed via `docker inspect`
- [x] Live fixture: chain.pem absent -> no ssl_trusted_certificate, nginx config test clean
- [x] Live fixture: chain.pem present -> ssl_trusted_certificate + stapling now emitted (was the bug)