### PR TITLE
fix(plugin,build,license): install-path nesting, network-alias corruption, Plus-key bundle union

### DIFF
--- a/cmd/commands/license_bundles.go
+++ b/cmd/commands/license_bundles.go
@@ -1,0 +1,86 @@
+package commands
+
+// Purpose: resolve `nself license show --json`'s bundles_unlocked value from
+// the shared internal/bundle resolver (bundles.json / ADR-P6-03). Split out
+// of license_status.go for file size (engineering-standard <=300 lines, ASI
+// Policy 3).
+// Inputs: a license.ProductPrefix (from license.DetectProduct) and a
+// context for the bundle.EnsureLoaded fetch.
+// Outputs: the ordered list of unlocked bundle display names.
+// Constraints: never fabricates a union — degrades to the raw product
+// display name when bundles.json cannot be loaded or the product code has
+// no known bundle mapping. See resolveBundlesUnlocked's doc comment.
+
+import (
+	"context"
+
+	"github.com/nself-org/cli/internal/bundle"
+	"github.com/nself-org/cli/internal/license"
+)
+
+// productToBundleSlug maps a license key's detected product code
+// (license.ProductPrefix.Product) to its bundles.json canonical bundle
+// slug, for keys tied to exactly one paid bundle. Products with no 1:1
+// bundle mapping — legacy business tiers "pro"/"enterprise"/"max", or a
+// product code with no bundles.json counterpart yet — are intentionally
+// absent; resolveBundlesUnlocked falls back to the raw product display
+// name for those rather than guessing a bundle slug.
+var productToBundleSlug = map[string]string{
+	"claw":   "claw",
+	"clawde": "clawde",
+	"chat":   "chat",
+	"family": "family",
+	"media":  "tv", // nself_media_ prefix predates bundles.json's "tv" slug rename
+}
+
+// resolveBundlesUnlocked computes `nself license show --json`'s
+// bundles_unlocked value: the union of every paid bundle a license key
+// entitles, resolved from bundles.json (ADR-P6-03) via the shared
+// internal/bundle resolver — never a single hand-picked product name.
+//
+// P6-E6-W4-S3-T7 (2026-09-03) found this previously always resolved to
+// []string{pp.DisplayName} (e.g. just "ɳSelf+"), regardless of tier, because
+// no code path called the bundle union resolver at all. Rules, in order:
+//
+//   - owner/plus keys unlock every currently-installable paid bundle in
+//     bundles.json (IsInstallable already excludes the free "task" bundle
+//     and the synthetic "nself-plus" meta-bundle — Ruling 2's one
+//     hand-coded membership rule, reused here rather than re-derived).
+//   - a key tied to exactly one bundle (productToBundleSlug) unlocks that
+//     one bundle.
+//   - any other/unrecognized product code, or a bundle slug not present in
+//     the currently loaded bundles.json, degrades to the raw product
+//     display name (the pre-fix behavior) rather than fabricating a bundle
+//     list.
+//   - if bundles.json cannot be loaded at all (network failure with no
+//     local cache — the production plugins.nself.org/bundles.json endpoint
+//     currently 404s, tracked separately, T8 CF worker owner), this also
+//     degrades to the raw product display name: honest partial
+//     information, never a fabricated union.
+func resolveBundlesUnlocked(ctx context.Context, pp *license.ProductPrefix) []string {
+	if pp == nil {
+		return nil
+	}
+	if err := bundle.EnsureLoaded(ctx); err != nil {
+		return []string{pp.DisplayName}
+	}
+	if pp.Product == "plus" || pp.Product == "owner" {
+		var names []string
+		for _, b := range bundle.All() {
+			if !b.IsInstallable() {
+				continue
+			}
+			names = append(names, b.Name)
+		}
+		if len(names) == 0 {
+			return []string{pp.DisplayName}
+		}
+		return names
+	}
+	if slug, ok := productToBundleSlug[pp.Product]; ok {
+		if b, found := bundle.Get(slug); found {
+			return []string{b.Name}
+		}
+	}
+	return []string{pp.DisplayName}
+}

--- a/cmd/commands/license_bundles_test.go
+++ b/cmd/commands/license_bundles_test.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/nself-org/cli/internal/license"
+)
+
+// TestResolveBundlesUnlocked_PlusUnion is a regression test for
+// P6-E6-W4-S3-T7 (2026-09-03): `nself license show --json`'s bundles_unlocked
+// field for an ɳSelf+ key previously always resolved to []string{"ɳSelf+"}
+// (license_status.go:158, pre-fix), never the union of paid bundles.
+// bundle.LoadBytes is seeded once for the whole package in bundle_test.go's
+// TestMain with fixtureBundlesJSON (6 paid bundles, tv included).
+func TestResolveBundlesUnlocked_PlusUnion(t *testing.T) {
+	pp := &license.ProductPrefix{Prefix: "nself_plus_", Product: "plus", DisplayName: "ɳSelf+"}
+	got := resolveBundlesUnlocked(context.Background(), pp)
+	want := []string{"ɳChat", "ɳClaw", "ɳFamily", "ɳSentry", "ɳTV", "ClawDE"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("plus key bundles_unlocked = %v, want %v (union of every paid bundle, DisplayOrder)", got, want)
+	}
+}
+
+// TestResolveBundlesUnlocked_OwnerUnion verifies the owner product code
+// (all-access, per PPI's NSELF_PLUGIN_LICENSE_KEY_OWNER) resolves the same
+// full paid-bundle union as plus.
+func TestResolveBundlesUnlocked_OwnerUnion(t *testing.T) {
+	pp := &license.ProductPrefix{Prefix: "nself_owner_", Product: "owner", DisplayName: "ɳSelf Owner"}
+	got := resolveBundlesUnlocked(context.Background(), pp)
+	want := []string{"ɳChat", "ɳClaw", "ɳFamily", "ɳSentry", "ɳTV", "ClawDE"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("owner key bundles_unlocked = %v, want %v", got, want)
+	}
+}
+
+// TestResolveBundlesUnlocked_SingleBundle verifies a key tied to exactly one
+// bundle (nself_chat_ prefix) resolves to that one bundle only, not the
+// full union and not a raw product-prefix name mismatched from
+// bundles.json's display string.
+func TestResolveBundlesUnlocked_SingleBundle(t *testing.T) {
+	cases := []struct {
+		product string
+		want    string
+	}{
+		{"chat", "ɳChat"},
+		{"claw", "ɳClaw"},
+		{"clawde", "ClawDE"},
+		{"family", "ɳFamily"},
+		{"media", "ɳTV"}, // nself_media_ prefix predates the "tv" bundles.json slug
+	}
+	for _, c := range cases {
+		pp := &license.ProductPrefix{Prefix: "nself_" + c.product + "_", Product: c.product, DisplayName: "irrelevant"}
+		got := resolveBundlesUnlocked(context.Background(), pp)
+		want := []string{c.want}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("product %q bundles_unlocked = %v, want %v", c.product, got, want)
+		}
+	}
+}
+
+// TestResolveBundlesUnlocked_UnmappedProductDegradesToDisplayName verifies a
+// product code with no bundles.json counterpart (legacy business tiers)
+// degrades honestly to the raw product display name rather than fabricating
+// a bundle list.
+func TestResolveBundlesUnlocked_UnmappedProductDegradesToDisplayName(t *testing.T) {
+	pp := &license.ProductPrefix{Prefix: "nself_pro_", Product: "pro", DisplayName: "ɳSelf Pro"}
+	got := resolveBundlesUnlocked(context.Background(), pp)
+	want := []string{"ɳSelf Pro"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unmapped product bundles_unlocked = %v, want %v (degrade to display name)", got, want)
+	}
+}
+
+// TestResolveBundlesUnlocked_NilProduct verifies a nil ProductPrefix (key
+// prefix not recognized at all) returns nil rather than panicking.
+func TestResolveBundlesUnlocked_NilProduct(t *testing.T) {
+	got := resolveBundlesUnlocked(context.Background(), nil)
+	if got != nil {
+		t.Fatalf("nil product bundles_unlocked = %v, want nil", got)
+	}
+}

--- a/cmd/commands/license_status.go
+++ b/cmd/commands/license_status.go
@@ -215,11 +215,11 @@ Use --json for machine-readable output.`,
 			}
 		}
 
-		// Bundles from product prefix.
-		var bundles []string
-		if pp != nil {
-			bundles = []string{pp.DisplayName}
-		}
+		// Bundles unlocked — computed from bundles.json (ADR-P6-03) as the
+		// union of every paid bundle this key entitles, never a single
+		// hand-picked product name. See resolveBundlesUnlocked's doc
+		// comment for the plus/single-bundle/degrade-on-load-failure rules.
+		bundles := resolveBundlesUnlocked(cmd.Context(), pp)
 
 		// Plugins from cache.
 		var pluginsCount int

--- a/internal/build/plugin_network_alias_test.go
+++ b/internal/build/plugin_network_alias_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 )
 
-// TestNormalizeComposeNetworkAliases_ShortForm verifies that the short-form
-// networks list is rewritten to the long form with a plugin-{name} alias so
-// inter-plugin DNS works with the CLI-injected PLUGIN_*_INTERNAL_URL env vars.
+// TestNormalizeComposeNetworkAliases_ShortForm verifies that a service with
+// the short-form networks list gets a `hostname: plugin-{name}` sibling key
+// so inter-plugin DNS works with the CLI-injected PLUGIN_*_INTERNAL_URL env
+// vars, and that the networks: block itself is left untouched (it is already
+// valid Compose — see the doc comment on normalizeComposeNetworkAliases for
+// why a map-form `${DOCKER_NETWORK}: {aliases: [...]}` rewrite is invalid).
 func TestNormalizeComposeNetworkAliases_ShortForm(t *testing.T) {
 	in := `services:
   mux:
@@ -22,14 +25,17 @@ func TestNormalizeComposeNetworkAliases_ShortForm(t *testing.T) {
       - "127.0.0.1:3711:3711"
 `
 	out := string(normalizeComposeNetworkAliases([]byte(in), "mux"))
-	if !strings.Contains(out, "aliases:") {
-		t.Fatalf("expected aliases block, got:\n%s", out)
+	if !strings.Contains(out, "hostname: plugin-mux") {
+		t.Fatalf("expected hostname: plugin-mux, got:\n%s", out)
 	}
-	if !strings.Contains(out, "- plugin-mux") {
-		t.Fatalf("expected plugin-mux alias, got:\n%s", out)
+	// The networks: block must remain in its original, valid list form —
+	// rewriting it into a map keyed by ${DOCKER_NETWORK} is the bug this
+	// test guards against (Compose does not interpolate map keys).
+	if !strings.Contains(out, "networks:\n      - ${DOCKER_NETWORK}") {
+		t.Fatalf("networks: list form must be preserved unchanged, got:\n%s", out)
 	}
-	if !strings.Contains(out, "${DOCKER_NETWORK}:") {
-		t.Fatalf("expected long-form network key, got:\n%s", out)
+	if strings.Contains(out, "${DOCKER_NETWORK}:") {
+		t.Fatalf("must never rewrite ${DOCKER_NETWORK} into a map key, got:\n%s", out)
 	}
 	// Rest of the service block must remain intact.
 	if !strings.Contains(out, "container_name: ${COMPOSE_PROJECT_NAME}_mux") {
@@ -38,10 +44,13 @@ func TestNormalizeComposeNetworkAliases_ShortForm(t *testing.T) {
 	if !strings.Contains(out, `ports:`) || !strings.Contains(out, `127.0.0.1:3711:3711`) {
 		t.Fatalf("ports block was clobbered, got:\n%s", out)
 	}
+	if err := assertValidComposeYAML(out); err != nil {
+		t.Fatalf("normalized output is not valid YAML: %v\n%s", err, out)
+	}
 }
 
 // TestNormalizeComposeNetworkAliases_Idempotent verifies that running the
-// normalizer twice does not duplicate the aliases block.
+// normalizer twice does not duplicate the hostname line.
 func TestNormalizeComposeNetworkAliases_Idempotent(t *testing.T) {
 	in := `services:
   ai:
@@ -54,8 +63,8 @@ func TestNormalizeComposeNetworkAliases_Idempotent(t *testing.T) {
 	if string(once) != string(twice) {
 		t.Fatalf("normalizer is not idempotent:\nonce:\n%s\n---\ntwice:\n%s", string(once), string(twice))
 	}
-	if strings.Count(string(twice), "- plugin-ai") != 1 {
-		t.Fatalf("alias should appear exactly once, got:\n%s", string(twice))
+	if strings.Count(string(twice), "hostname: plugin-ai") != 1 {
+		t.Fatalf("hostname line should appear exactly once, got:\n%s", string(twice))
 	}
 }
 
@@ -84,5 +93,39 @@ func TestNormalizeComposeNetworkAliases_EmptyName(t *testing.T) {
 	out := normalizeComposeNetworkAliases([]byte(in), "")
 	if string(out) != in {
 		t.Fatalf("empty plugin name should be no-op, got:\n%s", string(out))
+	}
+}
+
+// TestNormalizeComposeNetworkAliases_RealFixtureIsValidYAML is a regression
+// test for P6-E3-W2-S1-T5's finding: the previous map-form rewrite produced
+// YAML that parsed fine (it was syntactically valid YAML) but that Docker
+// Compose's schema rejected at the semantic level
+// ("additional properties '${DOCKER_NETWORK}' not allowed"), which the old
+// substring-only tests never caught. Uses the real notifications plugin
+// compose fragment to guard against re-introducing that class of bug.
+func TestNormalizeComposeNetworkAliases_RealFixtureIsValidYAML(t *testing.T) {
+	in := `# NSELF-FIRST EXCEPTION: plugin-fragment
+services:
+  notifications:
+    image: nself/nself-notifications:latest
+    container_name: ${COMPOSE_PROJECT_NAME}_notifications
+    restart: unless-stopped
+    networks:
+      - ${DOCKER_NETWORK}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:3102:3102"
+`
+	out := string(normalizeComposeNetworkAliases([]byte(in), "notifications"))
+	if !strings.Contains(out, "hostname: plugin-notifications") {
+		t.Fatalf("expected hostname: plugin-notifications, got:\n%s", out)
+	}
+	if strings.Contains(out, "${DOCKER_NETWORK}:") {
+		t.Fatalf("must never emit ${DOCKER_NETWORK} as a map key, got:\n%s", out)
+	}
+	if err := assertValidComposeYAML(out); err != nil {
+		t.Fatalf("normalized output is not valid YAML: %v\n%s", err, out)
 	}
 }

--- a/internal/build/plugin_network_alias_yaml_test.go
+++ b/internal/build/plugin_network_alias_yaml_test.go
@@ -1,0 +1,15 @@
+package build
+
+import "gopkg.in/yaml.v3"
+
+// assertValidComposeYAML parses s as generic YAML and returns an error if it
+// does not parse. This is a syntax-only check (it cannot catch compose-spec
+// schema violations like a `${VAR}` map key, which is syntactically valid
+// YAML — see docker/compose-network-alias tests for the schema-level
+// regression guard) but it does catch structural corruption such as bad
+// indentation or duplicate/misaligned keys introduced by a byte-offset bug
+// in the rewrite logic.
+func assertValidComposeYAML(s string) error {
+	var out map[string]any
+	return yaml.Unmarshal([]byte(s), &out)
+}

--- a/internal/build/plugins_network_alias.go
+++ b/internal/build/plugins_network_alias.go
@@ -6,14 +6,18 @@ import (
 	"regexp"
 )
 
-// Purpose: rewrites a plugin's short-form docker-compose networks block into
-// the long form with a `plugin-{name}` alias, so the CLI-generated
-// PLUGIN_{DEP}_INTERNAL_URL env vars resolve over Docker's embedded DNS.
+// Purpose: gives a plugin's docker-compose service a `plugin-{name}` DNS
+// alias so the CLI-generated PLUGIN_{DEP}_INTERNAL_URL env vars resolve over
+// Docker's embedded DNS.
 // Inputs: the compose fragment bytes and the plugin's short name.
 // Outputs: the (possibly rewritten) compose fragment bytes.
-// Constraints: split out of plugins.go (CLI-R12) as a pure move; no behavior
-// changed. Idempotent — a no-op when the alias is already present or no
-// short-form networks block is found.
+// Constraints: split out of plugins.go (CLI-R12) as a pure move originally;
+// P6-E3-W2-S1-T5 (2026-09-03) found the map-form `networks:` rewrite this
+// function used to emit was invalid Compose and replaced the body with a
+// `hostname:` injection — see the doc comment below. Signature and call
+// site (plugins.go DiscoverPluginComposeFiles) are unchanged. Idempotent —
+// a no-op when the alias is already present or no networks reference is
+// found.
 
 // shortNetworkListRE matches the short-form networks block used by most plugin
 // compose fragments:
@@ -21,19 +25,14 @@ import (
 //	networks:
 //	  - ${DOCKER_NETWORK}
 //
-// It captures (1) the indent before "networks:", (2) the network reference
-// after the list dash. The indent is preserved so the rewritten long form
-// lines up with the original service block.
+// It captures (1) the indent before "networks:". That indent is reused to
+// place the injected `hostname:` line at the same level as its sibling keys
+// in the service block.
 var shortNetworkListRE = regexp.MustCompile(`(?m)^([ \t]+)networks:\s*\n[ \t]+-[ \t]+(\S+)\s*$`)
 
-// longNetworkAliasGuardRE checks whether the normalized fragment already
-// contains an "aliases:" entry pointing at the plugin short name, so the
-// normalizer is idempotent and safe to run on already-patched files.
-var aliasAlreadyPresentRE = regexp.MustCompile(`aliases:\s*\n[ \t]+-[ \t]+plugin-`)
-
-// normalizeComposeNetworkAliases rewrites the short-form networks list used
-// by plugin compose fragments into the long form with a network alias that
-// matches the inter-plugin hostname convention (`plugin-{name}`).
+// normalizeComposeNetworkAliases ensures a plugin's compose service is
+// reachable at the `plugin-{name}` DNS alias used by the CLI-generated
+// PLUGIN_<DEP>_INTERNAL_URL env vars.
 //
 // Background: the nSelf CLI injects environment variables of the form
 // `PLUGIN_<DEP>_INTERNAL_URL=http://plugin-<dep>:<port>` for every installed
@@ -43,26 +42,44 @@ var aliasAlreadyPresentRE = regexp.MustCompile(`aliases:\s*\n[ \t]+-[ \t]+plugin
 // `plugin-*` alias that callers expect. The result is a "bad address" error
 // at runtime even though both containers live on the same network.
 //
-// The fix is to ensure the plugin container is reachable at BOTH its bare
-// service name (for local compose references and backward compatibility) AND
-// the `plugin-{name}` alias used by the CLI-generated env vars. This
-// normalizer performs that rewrite at build time so no plugin re-release is
-// required.
+// A prior version of this function rewrote the fragment's short-form
+// `networks: [- ${DOCKER_NETWORK}]` list into the long map form with an
+// `aliases:` entry (`${DOCKER_NETWORK}: {aliases: [plugin-<name>]}`). That
+// output is invalid: Docker Compose only interpolates `${VAR}` references in
+// scalar VALUES, never in YAML mapping KEYS, so `${DOCKER_NETWORK}` as a map
+// key is passed to compose-spec's schema validator un-substituted and
+// rejected — confirmed against docker compose v5.3.0:
+//
+//	services.<name>.networks additional properties '${DOCKER_NETWORK}' not allowed
+//
+// This broke `nself build`'s merged compose for every plugin using the
+// short-form list (P6-E3-W2-S1-T5 smoke test, 2026-09-03).
+//
+// The fix: leave the `networks:` block untouched (its `- ${DOCKER_NETWORK}`
+// list form is valid Compose and already connects the service to the shared
+// network) and instead inject `hostname: plugin-{name}` as a sibling key in
+// the service block. `hostname:` is a plain scalar value (interpolates fine,
+// though it needs none here) and Docker's embedded DNS resolves a
+// container's `hostname` on a user-defined bridge network exactly like a
+// network alias — verified empirically: a sibling container on the same
+// compose network resolves `plugin-<name>` via `getent hosts` with no
+// `aliases:` block involved at all.
 //
 // The rewrite is a no-op when:
-//   - The fragment already uses the long form with an explicit aliases block.
-//   - The fragment does not contain a short-form networks list (e.g. already
-//     rewritten, or uses a completely different network topology).
+//   - `hostname: plugin-{name}` is already present (already patched).
+//   - The fragment has no short-form `networks:` list to anchor the
+//     insertion point on (e.g. a completely different network topology).
 //
-// Only the first matching short-form networks block per fragment is rewritten,
-// which matches the one-service-per-plugin convention used across the
-// plugins-pro library.
+// Only the first matching short-form networks block per fragment is used to
+// anchor the insertion, which matches the one-service-per-plugin convention
+// used across the plugins library.
 func normalizeComposeNetworkAliases(content []byte, pluginName string) []byte {
 	if pluginName == "" {
 		return content
 	}
-	// Idempotency guard: if a plugin- alias is already present, do nothing.
-	if aliasAlreadyPresentRE.Match(content) {
+	hostnameLine := []byte("hostname: plugin-" + pluginName)
+	// Idempotency guard: if the alias hostname is already declared, do nothing.
+	if bytes.Contains(content, hostnameLine) {
 		return content
 	}
 	match := shortNetworkListRE.FindSubmatchIndex(content)
@@ -70,23 +87,14 @@ func normalizeComposeNetworkAliases(content []byte, pluginName string) []byte {
 		return content
 	}
 	indent := string(content[match[2]:match[3]])
-	netRef := string(content[match[4]:match[5]])
-	// Build the replacement using the captured indent so the YAML stays aligned
-	// with the surrounding service block.
-	innerIndent := indent + "  "
-	aliasIndent := innerIndent + "  "
-	aliasItemIndent := aliasIndent + "  "
-	replacement := fmt.Sprintf(
-		"%snetworks:\n%s%s:\n%saliases:\n%s- plugin-%s\n",
-		indent,
-		innerIndent, netRef,
-		aliasIndent,
-		aliasItemIndent, pluginName,
-	)
+	// Insert the hostname line immediately before the "networks:" line, at
+	// the same indent, as a new sibling key in the service block. The
+	// networks: block itself (match[0]:match[1]) is copied through unchanged.
+	insertion := fmt.Sprintf("%s%s\n", indent, hostnameLine)
 	var out bytes.Buffer
-	out.Grow(len(content) + len(replacement))
+	out.Grow(len(content) + len(insertion))
 	out.Write(content[:match[0]])
-	out.WriteString(replacement)
-	out.Write(content[match[1]:])
+	out.WriteString(insertion)
+	out.Write(content[match[0]:])
 	return out.Bytes()
 }

--- a/internal/plugin/flatten_extracted.go
+++ b/internal/plugin/flatten_extracted.go
@@ -1,0 +1,98 @@
+package plugin
+
+// Purpose: post-extraction layout normalization for a freshly installed
+// plugin — corrects a tarball-authoring bug that nests the plugin's files
+// one (or more) directory levels too deep. Split out of download.go for
+// file size (engineering-standard <=300 lines, ASI Policy 3).
+// Inputs: destDir, the plugin's extraction target (pluginDir/<name>/).
+// Outputs: destDir left with plugin.json (and the rest of the plugin's
+// files) directly at its root, or unchanged if no recognized wrapper
+// layout is found.
+// Constraints: called by installLocked (installer_locked.go) immediately
+// after extractTarGz; must be idempotent-safe to call on an already-flat
+// layout (no-ops via the plugin.json-at-root fast path).
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// flattenExtractedPlugin corrects a tarball-authoring bug where the archive
+// embeds its build-time source path (e.g. "free/<name>/...", from
+// `tar -czf dist/<name>.tar.gz free/<name>/` in plugins/scripts/build-tarballs.sh)
+// instead of packaging the plugin's own file tree at the archive root. When
+// that happens, extractTarGz faithfully reproduces the nesting on disk —
+// destDir/free/<name>/plugin.json instead of destDir/plugin.json — which
+// breaks every consumer that expects a flat layout directly under destDir:
+// internal/build/plugins.go's DiscoverPluginComposeFiles (build-time compose
+// discovery) and internal/plugin/runtime_start.go's Start (`nself plugin
+// start`). Confirmed as the root cause of 0/7 ntask free-plugin installs
+// reaching a running container (P6-E3-W2-S1-T5, 2026-09-03).
+//
+// This is a defensive fix on the extraction side (belt-and-suspenders with
+// any fix to the archive-building pipeline itself, which lives in a
+// different repo — plugins/scripts/build-tarballs.sh — and is out of this
+// ticket's scope): if plugin.json is not directly under destDir after
+// extraction, walk down while there is exactly one child and it is a
+// directory, and once a nested plugin.json is found, promote that
+// directory's contents up to destDir and remove the now-empty wrapper
+// chain. Bounded to a handful of levels so a malformed or unexpected
+// archive layout is left alone rather than walked indefinitely.
+func flattenExtractedPlugin(destDir string) error {
+	if _, err := os.Stat(filepath.Join(destDir, "plugin.json")); err == nil {
+		return nil // already flat — the common case for a correctly built archive
+	}
+
+	const maxDepth = 4
+	cur := destDir
+	for depth := 0; depth < maxDepth; depth++ {
+		entries, err := os.ReadDir(cur)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", cur, err)
+		}
+		if len(entries) != 1 || !entries[0].IsDir() {
+			// Not a single-directory wrapper — either already flat at a
+			// different shape or a layout this heuristic doesn't recognize.
+			// Leave it as extracted; downstream steps will surface a clear
+			// "plugin.json not found" error rather than this function
+			// guessing wrong and silently corrupting a valid layout.
+			return nil
+		}
+		cur = filepath.Join(cur, entries[0].Name())
+		if _, err := os.Stat(filepath.Join(cur, "plugin.json")); err == nil {
+			return promoteExtractedContents(cur, destDir)
+		}
+	}
+	return nil
+}
+
+// promoteExtractedContents moves every entry directly under src into dst,
+// then removes the now-empty wrapper directory chain between dst
+// (exclusive) and src (inclusive). src and dst are both under the same
+// destDir tree from flattenExtractedPlugin, so the moves are same-filesystem
+// renames.
+func promoteExtractedContents(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", src, err)
+	}
+	for _, e := range entries {
+		oldPath := filepath.Join(src, e.Name())
+		newPath := filepath.Join(dst, e.Name())
+		if err := os.Rename(oldPath, newPath); err != nil {
+			return fmt.Errorf("moving %s to %s: %w", oldPath, newPath, err)
+		}
+	}
+	// Best-effort cleanup of the now-empty wrapper directories. A failure
+	// here (e.g. a directory that turned out non-empty) is not fatal — the
+	// plugin's files are already promoted to dst, which is what matters.
+	for cur := src; cur != dst; {
+		parent := filepath.Dir(cur)
+		if err := os.Remove(cur); err != nil {
+			break
+		}
+		cur = parent
+	}
+	return nil
+}

--- a/internal/plugin/flatten_extracted_test.go
+++ b/internal/plugin/flatten_extracted_test.go
@@ -1,0 +1,122 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFlattenExtractedPlugin_NestedFreePrefix is a regression test for
+// P6-E3-W2-S1-T5 (2026-09-03): a tarball built by
+// plugins/scripts/build-tarballs.sh's `tar -czf dist/<name>.tar.gz free/<name>/`
+// embeds a "free/<name>/" prefix. extractTarGz faithfully reproduces that
+// nesting on disk; flattenExtractedPlugin must promote the nested
+// plugin.json (and everything alongside it) up to destDir.
+func TestFlattenExtractedPlugin_NestedFreePrefix(t *testing.T) {
+	destDir := t.TempDir()
+	entries := []struct{ name, content string }{
+		{"free/", ""},
+		{"free/notifications/", ""},
+		{"free/notifications/plugin.json", `{"name":"notifications","version":"1.0.0"}`},
+		{"free/notifications/docker-compose.plugin.yml", "services:\n  notifications:\n    image: x\n"},
+		{"free/notifications/lib/", ""},
+		{"free/notifications/lib/helper.sh", "#!/bin/sh\necho ok"},
+	}
+	archivePath := writeTempArchive(t, buildTarGz(t, entries))
+	if err := extractTarGz(archivePath, destDir); err != nil {
+		t.Fatalf("extractTarGz: %v", err)
+	}
+	// Sanity: confirm the bug is reproduced before the fix runs.
+	if _, err := os.Stat(filepath.Join(destDir, "plugin.json")); err == nil {
+		t.Fatalf("test fixture bug: plugin.json unexpectedly flat before flatten")
+	}
+
+	if err := flattenExtractedPlugin(destDir); err != nil {
+		t.Fatalf("flattenExtractedPlugin: %v", err)
+	}
+
+	for _, rel := range []string{"plugin.json", "docker-compose.plugin.yml", "lib/helper.sh"} {
+		if _, err := os.Stat(filepath.Join(destDir, rel)); err != nil {
+			t.Errorf("expected flattened file %q: %v", rel, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "free")); err == nil {
+		t.Errorf("expected wrapper dir %q/free to be removed after promotion", destDir)
+	}
+}
+
+// TestFlattenExtractedPlugin_AlreadyFlat verifies a correctly built archive
+// (plugin.json directly at the root) is left untouched.
+func TestFlattenExtractedPlugin_AlreadyFlat(t *testing.T) {
+	destDir := t.TempDir()
+	entries := []struct{ name, content string }{
+		{"plugin.json", `{"name":"cron","version":"1.0.0"}`},
+		{"docker-compose.plugin.yml", "services:\n  cron:\n    image: x\n"},
+	}
+	archivePath := writeTempArchive(t, buildTarGz(t, entries))
+	if err := extractTarGz(archivePath, destDir); err != nil {
+		t.Fatalf("extractTarGz: %v", err)
+	}
+	if err := flattenExtractedPlugin(destDir); err != nil {
+		t.Fatalf("flattenExtractedPlugin: %v", err)
+	}
+	for _, rel := range []string{"plugin.json", "docker-compose.plugin.yml"} {
+		if _, err := os.Stat(filepath.Join(destDir, rel)); err != nil {
+			t.Errorf("expected file %q to remain: %v", rel, err)
+		}
+	}
+}
+
+// TestFlattenExtractedPlugin_MultiLevelNesting verifies deeper wrapper
+// chains (two levels) are also promoted, bounded by maxDepth.
+func TestFlattenExtractedPlugin_MultiLevelNesting(t *testing.T) {
+	destDir := t.TempDir()
+	entries := []struct{ name, content string }{
+		{"a/", ""},
+		{"a/b/", ""},
+		{"a/b/plugin.json", `{"name":"jobs","version":"1.0.0"}`},
+		{"a/b/plugin.go", "package main"},
+	}
+	archivePath := writeTempArchive(t, buildTarGz(t, entries))
+	if err := extractTarGz(archivePath, destDir); err != nil {
+		t.Fatalf("extractTarGz: %v", err)
+	}
+	if err := flattenExtractedPlugin(destDir); err != nil {
+		t.Fatalf("flattenExtractedPlugin: %v", err)
+	}
+	for _, rel := range []string{"plugin.json", "plugin.go"} {
+		if _, err := os.Stat(filepath.Join(destDir, rel)); err != nil {
+			t.Errorf("expected flattened file %q: %v", rel, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "a")); err == nil {
+		t.Errorf("expected wrapper dir %q/a to be removed after promotion", destDir)
+	}
+}
+
+// TestFlattenExtractedPlugin_MultipleTopEntries verifies an archive that
+// legitimately has multiple top-level entries (not a single wrapper dir) is
+// left untouched rather than mis-flattened.
+func TestFlattenExtractedPlugin_MultipleTopEntries(t *testing.T) {
+	destDir := t.TempDir()
+	entries := []struct{ name, content string }{
+		{"plugin.json", `{"name":"multi","version":"1.0.0"}`},
+		{"README.md", "# multi"},
+		{"lib/", ""},
+		{"lib/helper.sh", "#!/bin/sh"},
+	}
+	archivePath := writeTempArchive(t, buildTarGz(t, entries))
+	if err := extractTarGz(archivePath, destDir); err != nil {
+		t.Fatalf("extractTarGz: %v", err)
+	}
+	if err := flattenExtractedPlugin(destDir); err != nil {
+		t.Fatalf("flattenExtractedPlugin: %v", err)
+	}
+	// Already flat (plugin.json at root) — flattenExtractedPlugin must no-op
+	// immediately and never touch README.md/lib/.
+	for _, rel := range []string{"plugin.json", "README.md", "lib/helper.sh"} {
+		if _, err := os.Stat(filepath.Join(destDir, rel)); err != nil {
+			t.Errorf("expected file %q to remain: %v", rel, err)
+		}
+	}
+}

--- a/internal/plugin/installer_identity.go
+++ b/internal/plugin/installer_identity.go
@@ -1,0 +1,48 @@
+package plugin
+
+// Purpose: best-effort per-plugin Ed25519 identity keypair generation and
+// ping_api registration, run as Step 7b of installLocked. Split out of
+// installer_locked.go for file size (engineering-standard <=300 lines, ASI
+// Policy 3) when the P6-E3-W2-S1-T5 install-path-nesting fix (Step 6a,
+// flattenExtractedPlugin) pushed that file over the cap.
+// Inputs: context, pluginDir (doubles as the identity data root), plugin
+// name.
+// Outputs: none — failures are logged via slog.Warn, never returned, since
+// the plugin still functions without JWT auth until Phase B-3 strict mode.
+// Constraints: pure move (Q01); no behavior change. Only runs when
+// PLUGIN_INTERNAL_SECRET is set (the operator has opted into the
+// inter-plugin JWT system) and does not re-generate an existing identity key.
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+// registerPluginIdentityIfEnabled generates a per-plugin Ed25519 identity
+// keypair and registers the public key with ping_api, when the operator has
+// opted into the inter-plugin JWT system (PLUGIN_INTERNAL_SECRET set) and no
+// identity key already exists for this plugin. Best-effort: a failure here
+// does not fail the install.
+func registerPluginIdentityIfEnabled(ctx context.Context, pluginDir, name string) {
+	if os.Getenv("PLUGIN_INTERNAL_SECRET") == "" {
+		return
+	}
+	// pluginDir doubles as the identity data root — each plugin's keypair
+	// is stored at pluginDir/<name>/identity.key alongside its manifest.
+	if IdentityKeyExists(pluginDir, name) {
+		return
+	}
+	pubKey, idErr := GenerateEd25519Keypair(pluginDir, name)
+	if idErr != nil {
+		slog.Warn("plugin identity key generation failed — inter-plugin JWT auth unavailable until resolved",
+			"plugin", name, "error", idErr)
+		return
+	}
+	if regErr := RegisterIdentity(ctx, name, pubKey); regErr != nil {
+		slog.Warn("plugin identity registration with ping_api failed — JWT auth unavailable until resolved",
+			"plugin", name, "error", regErr)
+		return
+	}
+	slog.Info("plugin.identity.registered", "plugin", name)
+}

--- a/internal/plugin/installer_locked.go
+++ b/internal/plugin/installer_locked.go
@@ -229,6 +229,14 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 		return fmt.Errorf("extracting plugin %q: %w", name, err)
 	}
 
+	// Step 6a: Correct a build-time tarball nesting bug (see
+	// flattenExtractedPlugin's doc comment) that otherwise leaves this
+	// plugin's files one directory level too deep for build-time compose
+	// discovery and `nself plugin start` to find.
+	if err := flattenExtractedPlugin(destDir); err != nil {
+		return fmt.Errorf("normalizing extracted layout for plugin %q: %w", name, err)
+	}
+
 	// Step 6b: Publish a CLI plugin's binary where ProxyCommand will find it.
 	// Without this a command-providing plugin installs cleanly and then cannot
 	// be run at all — the proxy only reads ~/.nself/plugins/bin/.
@@ -252,30 +260,9 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 		}
 	}
 
-	// Step 7b (Q01): Generate per-plugin Ed25519 identity keypair and register
-	// the public key with ping_api. This is a best-effort step — a failure is
-	// logged as a warning but does not roll back the install, because the plugin
-	// will still function without JWT auth until Phase B-3 strict mode.
-	// The key is only generated when PLUGIN_INTERNAL_SECRET is set (i.e., the
-	// operator has opted into the inter-plugin JWT system).
-	if os.Getenv("PLUGIN_INTERNAL_SECRET") != "" {
-		// pluginDir doubles as the identity data root — each plugin's keypair
-		// is stored at pluginDir/<name>/identity.key alongside its manifest.
-		if !IdentityKeyExists(pluginDir, name) {
-			pubKey, idErr := GenerateEd25519Keypair(pluginDir, name)
-			if idErr != nil {
-				slog.Warn("plugin identity key generation failed — inter-plugin JWT auth unavailable until resolved",
-					"plugin", name, "error", idErr)
-			} else {
-				if regErr := RegisterIdentity(ctx, name, pubKey); regErr != nil {
-					slog.Warn("plugin identity registration with ping_api failed — JWT auth unavailable until resolved",
-						"plugin", name, "error", regErr)
-				} else {
-					slog.Info("plugin.identity.registered", "plugin", name)
-				}
-			}
-		}
-	}
+	// Step 7b (Q01): best-effort per-plugin identity keypair + ping_api
+	// registration (split out — see installer_identity.go).
+	registerPluginIdentityIfEnabled(ctx, pluginDir, name)
 
 	// S71-T02: Emit structured audit log for the granted permission set.
 	// One line per install, consumable by Loki. Never logs secret values —


### PR DESCRIPTION
## Summary

Three live CLI defects found by P6-E3-W2-S1-T5's ntask free-plugin smoke test (0/7 plugins reached a running, health-checked container) and P6-E6-W4-S3-T7's entitlement parity test (CLI vs ping_api parity blocked). Repro sources: those two tickets' checkpoints in `.claude/phases/current/p6/`.

1. **`internal/plugin`: install-path nesting.** A fresh `nself plugin install <name>` extracted a tarball built with a `free/<name>/` source-path prefix baked in (`plugins/scripts/build-tarballs.sh`'s `tar -czf ... free/<name>/`) one directory level too deep for build-time compose discovery (`internal/build/plugins.go:DiscoverPluginComposeFiles`) and `nself plugin start` to find. Added `flattenExtractedPlugin` (`internal/plugin/flatten_extracted.go`), run immediately after extraction in `installLocked`, which promotes a single-directory-wrapper archive's contents up to the flat layout every consumer expects.

2. **`internal/build`: network-alias corruption.** `normalizeComposeNetworkAliases` rewrote a plugin's valid `networks: [- ${DOCKER_NETWORK}]` list into a map form keyed by the literal string `${DOCKER_NETWORK}` to attach a `plugin-<name>` DNS alias. Docker Compose never interpolates `${VAR}` used as a YAML mapping key (only scalar values), so compose-spec's schema rejected the result: `services.<name>.networks additional properties '${DOCKER_NETWORK}' not allowed` — reproduced against `docker compose v5.3.0` — breaking the whole merged stack for every plugin using the short-form list. Replaced the map-form rewrite with a `hostname: plugin-<name>` injection: Docker's embedded DNS resolves a container's hostname exactly like a network alias (verified empirically with two sibling containers on a compose network), and the `networks:` block itself is left untouched since it was already valid.

3. **`cmd/commands/license`: Plus-key bundle union.** `nself license show --json`'s `bundles_unlocked` field always resolved to a single product display name (`[]string{pp.DisplayName}`), never a computed union, so a Plus-tier key never showed the bundles it actually unlocks. Added `resolveBundlesUnlocked` (`cmd/commands/license_bundles.go`), using the existing `internal/bundle` resolver (bundles.json / ADR-P6-03, `NSELF_BUNDLES_URL` override) to compute the union of every installable paid bundle for a plus/owner key, resolve a single bundle for a key tied to exactly one, and degrade honestly to the raw product display name when bundles.json can't be loaded (the production endpoint currently 404s, tracked separately) or the product code has no known bundle mapping — never a fabricated list.

Also splits the new code in `license_status.go`, `download.go`, and `installer_locked.go` into sibling files (`license_bundles.go`, `flatten_extracted.go`, `installer_identity.go`) to hold the engineering-standard <=300-line-per-file cap (`internal/repoqa`'s file-size ratchet, budget 0) after these additions — matches the codebase's existing per-concern file-split convention.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green (full suite, including `internal/repoqa`'s file-size budget test)
- [x] Regression tests added: `internal/plugin/flatten_extracted_test.go` (nested `free/<name>/`, multi-level nesting, already-flat, multiple-top-level-entries cases), `internal/build/plugin_network_alias_test.go` + `plugin_network_alias_yaml_test.go` (real `notifications` plugin fixture, YAML-validity guard), `cmd/commands/license_bundles_test.go` (plus/owner union, single-bundle, unmapped-product degrade, nil-product)
- [x] Manually reproduced defect 2 end-to-end against real `docker compose config` (v5.3.0) with the actual `plugins/free/notifications/docker-compose.plugin.yml` fixture — confirmed the exact schema error pre-fix and a clean `docker compose config` output post-fix
- [ ] Re-run of P6-E3-W2-S1-T5's 7-plugin ntask smoke test against a binary built from this branch (tracked as follow-up in the P6 crunch log; the plugins-side packaging defects — jobs/cron table-prefix conflict, audit-log missing compose file, unpublished images, feature-flags/tokens build-context escape — are a separate FIX-PLUGINS unit in the `plugins` repo, not fixed here)

GH Actions billing/runner failures on this public repo are unaffected by this PR (Actions is free here); local gate above is authoritative.