### PR TITLE
feat(nginx): NGINX_FRONTED_BY — express a stack served by another stack's nginx

### DIFF
--- a/.github/wiki/Config-Env-Vars.md
+++ b/.github/wiki/Config-Env-Vars.md
@@ -175,6 +175,7 @@ All OAuth provider vars are optional. Set client ID and secret for each provider
 | `NGINX_HTTPS_PORT` | int | `443` | No | Host port for HTTPS traffic. |
 | `NGINX_BIND_IP` | string | `127.0.0.1` (dev) / `0.0.0.0` (prod) | No | IP address Nginx binds on. Set to `0.0.0.0` to accept external connections. |
 | `NGINX_CLIENT_MAX_BODY_SIZE` | string | `100M` | No | Maximum allowed size for client request bodies (controls upload limits). |
+| `NGINX_FRONTED_BY` | string | *(empty)* | No | Names the stack whose Nginx already serves this project's domains. When set, `nself build` generates no Nginx service for this project and `nself status` stops expecting one. See [[Config-Nginx]]. |
 | `SSL_MODE` | enum | `local` | No | SSL certificate strategy. Accepted values: `local` (self-signed), `letsencrypt`, `custom`, `none`. |
 | `EXTRA_SSL_DOMAINS` | string | *(empty)* | No | Additional domains to include in the certificate SAN (comma-separated). |
 

--- a/.github/wiki/Config-Nginx.md
+++ b/.github/wiki/Config-Nginx.md
@@ -18,6 +18,7 @@ This page covers every `NGINX_*` and `SSL_*` environment variable, how `BASE_DOM
 | `NGINX_GZIP_ENABLED` | `true` | Enables gzip compression on responses. Set to `false` if a CDN or upstream proxy is handling compression. |
 | `NGINX_MODE` | *(empty)* | Set to `shared` to enable multi-project mode, where a single Nginx instance routes traffic for multiple ɳSelf projects on the same host. Leave empty for standard single-project operation. |
 | `NGINX_MEM_LIMIT` | `256m` | Docker memory limit for the Nginx container. |
+| `NGINX_FRONTED_BY` | *(empty)* | Names another stack whose Nginx already fronts this project's domains, for a project that has no ingress Nginx of its own. See [Fronted by another stack](#fronted-by-another-stack) below. |
 | `SSL_MODE` | `local` | SSL mode to use. One of `local`, `letsencrypt`, `custom`, or `none`. See SSL Modes below. |
 | `EXTRA_SSL_DOMAINS` | *(empty)* | Additional domains to include in the SSL certificate as Subject Alternative Names (SANs). Comma-separated. Useful when your project is also reachable under an alias domain. |
 | `BASE_DOMAIN` | `local.nself.org` | Root domain for your project. Nginx generates all service subdomains from this value automatically. See Domain Configuration below. |
@@ -178,6 +179,25 @@ INTERNAL_ROUTE_1_TARGET=http://grafana:3000
 After running `nself build`, Nginx will proxy all traffic for `metrics.{BASE_DOMAIN}` to the `grafana` container on port 3000. SSL is applied automatically based on the configured `SSL_MODE`.
 
 Internal routes are generated into `nginx/sites/` and follow the same "do not hand-edit" rule as all other generated files. To modify a route, change its `INTERNAL_ROUTE_N_*` variables and rebuild.
+
+---
+
+## Fronted by Another Stack
+
+Some hosts run more than one ɳSelf project, with a single project's Nginx serving the domains of the others. Ports 80 and 443 can only be held once, so every other project on that host must not generate an Nginx of its own.
+
+Set `NGINX_FRONTED_BY` to the name of the stack that fronts this one:
+
+```bash
+# .env — this project is served by the nself-web stack's Nginx
+NGINX_FRONTED_BY=nself-web
+```
+
+With this set, `nself build` omits the Nginx service from the generated `docker-compose.yml` entirely, and `nself status` stops counting an Nginx container for this project. Leaving it unset is the default and changes nothing for a normal single-project stack.
+
+Without it, a fronted project still generates an Nginx that can never start: `nself start` fails its port check with 80/443 held by the fronting stack's `docker-proxy`, and `nself status` reports one permanently unhealthy service that nothing can clear.
+
+**This flag removes the container that cannot run. It does not wire the two projects' networks together.** The fronting Nginx resolves upstreams through Docker's embedded DNS at `127.0.0.11`, which only answers for container names on a network that Nginx is attached to. Routing `auth.task.example.com` to this project's `auth` container still requires the two projects to share a Docker network — declared as `external` in both compose files, or attached by hand. Automatically rewriting a project's network topology from a single flag is a larger change and is deliberately not part of this one.
 
 ---
 

--- a/internal/build/detection.go
+++ b/internal/build/detection.go
@@ -18,7 +18,10 @@ var pluginsNeedingRedis = []string{"ai", "claw", "mux", "cron", "notify", "push"
 // DetectServices returns the list of Docker service names that should be
 // generated in docker-compose.yml based on the current configuration.
 //
-// Core services (4):     postgres, hasura, auth, nginx
+// Core services (4):     postgres, hasura, auth, nginx (nginx is omitted
+//
+//	when NGINX_FRONTED_BY is set — see NginxConfig.FrontedBy)
+//
 // Optional services (6): redis, minio, mailpit (email), search, functions, admin
 // Custom services:       CS_1..CS_10
 //
@@ -30,8 +33,16 @@ var pluginsNeedingRedis = []string{"ai", "claw", "mux", "cron", "notify", "push"
 // so callers (e.g. Build) must also set cfg.Redis.Enabled = true before
 // passing cfg to compose.NewGenerator to keep both outputs consistent.
 func DetectServices(cfg *config.Config) []string {
-	// ── Core 4 (always enabled) ──────────────────────────────────────
-	services := []string{"postgres", "hasura", "auth", "nginx"}
+	// ── Core services (always enabled) ───────────────────────────────
+	// nginx is omitted when this stack is fronted by another stack's nginx
+	// (NGINX_FRONTED_BY set) — see NginxConfig.FrontedBy and the matching
+	// gate in compose.Generator.buildDockerCompose. Without this, `nself
+	// status` sizes its total off a nginx container that compose never
+	// generates, and reports it unhealthy forever.
+	services := []string{"postgres", "hasura", "auth"}
+	if cfg.Nginx.FrontedBy == "" {
+		services = append(services, "nginx")
+	}
 
 	// ── Redis (explicit or auto-enabled by BullMQ plugin) ────────────
 	if cfg.Redis.Enabled {

--- a/internal/build/detection_fronted_test.go
+++ b/internal/build/detection_fronted_test.go
@@ -1,0 +1,63 @@
+package build
+
+// detection_fronted_test.go — regression coverage for the 2026-09-03 staging
+// incident's "nself status" symptom: ntask's status stayed at 6/7 forever
+// because DetectServices always counts "nginx" as an expected service, even
+// on a stack whose compose file never generates one (NGINX_FRONTED_BY set —
+// see internal/compose/fronted_stack_test.go for the compose-side half of
+// this fix). RunAllChecks (internal/health/checker.go) sizes its Total
+// directly off len(DetectServices(cfg)), so this list being wrong is exactly
+// what makes status report a permanently-unhealthy phantom service.
+//
+// Purpose: prove DetectServices excludes "nginx" once FrontedBy is set, and
+// that the unset (default) case is unchanged.
+
+import (
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+func containsString(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDetectServices_ExcludesNginxWhenFronted(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Nginx.FrontedBy = "nself-web"
+
+	services := DetectServices(cfg)
+	if containsString(services, "nginx") {
+		t.Errorf("DetectServices returned nginx despite FrontedBy being set: %v", services)
+	}
+	for _, want := range []string{"postgres", "hasura", "auth"} {
+		if !containsString(services, want) {
+			t.Errorf("DetectServices is missing %q when fronted: %v", want, services)
+		}
+	}
+}
+
+func TestDetectServices_IncludesNginxByDefault(t *testing.T) {
+	cfg := &config.Config{}
+	// FrontedBy left empty — the default for every existing project.
+
+	services := DetectServices(cfg)
+	if !containsString(services, "nginx") {
+		t.Errorf("DetectServices dropped nginx for an unfronted (default) stack — regression: %v", services)
+	}
+}
+
+func TestExpectedCoreServices_ExcludesNginxWhenFronted(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Nginx.FrontedBy = "nself-web"
+
+	services := expectedCoreServices(cfg)
+	if containsString(services, "nginx") {
+		t.Errorf("expectedCoreServices returned nginx despite FrontedBy being set: %v", services)
+	}
+}

--- a/internal/build/manifest_resolve.go
+++ b/internal/build/manifest_resolve.go
@@ -102,7 +102,10 @@ func satisfiedByCoreService(name string, serviceSet map[string]bool) bool {
 // core service satisfies — the compose YAML is generated after plugin
 // resolution, so the names are derived rather than parsed.
 func expectedCoreServices(cfg *config.Config) []string {
-	services := []string{"postgres", "hasura", "auth", "nginx"}
+	services := []string{"postgres", "hasura", "auth"}
+	if cfg.Nginx.FrontedBy == "" {
+		services = append(services, "nginx")
+	}
 	if cfg.Minio.Enabled {
 		services = append(services, "minio")
 	}

--- a/internal/compose/fronted_stack_test.go
+++ b/internal/compose/fronted_stack_test.go
@@ -1,0 +1,89 @@
+package compose
+
+// fronted_stack_test.go — regression coverage for the 2026-09-03 staging
+// incident: `nself start` in /opt/nself-ntask failed with "port 80/443 held
+// by docker-proxy" because the generated docker-compose.yml always defines
+// an nginx service, even for a stack whose domains are actually served by
+// ANOTHER stack's nginx (nself-web fronted task.staging.nself.org). That
+// nginx container can never bind 80/443 — the fronting stack's nginx
+// already holds them — so it sits forever as one unhealthy container
+// `nself status` can never clear (reported "6/7").
+//
+// Purpose: prove that setting NGINX_FRONTED_BY (config.NginxConfig.FrontedBy)
+// removes the nginx service from the generated compose file entirely, and
+// that leaving it unset (the default, every existing project) is unchanged.
+// Inputs: a minimal valid Config, with and without FrontedBy set.
+// Outputs: pass/fail on whether "nginx" is a key in the built compose's
+// Services map.
+// Constraints: exercises buildDockerCompose exactly as NewGenerator(cfg)
+// callers do; no Docker or filesystem access.
+
+import (
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+func frontedTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := &config.Config{
+		ProjectName:   "ntask",
+		BaseDomain:    "task.staging.nself.org",
+		Env:           "dev",
+		DockerNetwork: "ntask_network",
+		Postgres: config.PostgresConfig{
+			Host: "postgres", User: "postgres", Password: "password", DB: "nself", Port: 5432,
+		},
+		Hasura: config.HasuraConfig{
+			AdminSecret: "secret", JWTKey: "testsecretkey12345678901234567890", JWTType: "HS256",
+		},
+	}
+	cfg, err := config.ApplyDefaults(cfg)
+	if err != nil {
+		t.Fatalf("ApplyDefaults() error: %v", err)
+	}
+	return cfg
+}
+
+// TestFrontedStackOmitsOwnNginx verifies that NGINX_FRONTED_BY removes the
+// nginx service from the generated compose file — it can never start
+// (another stack's nginx already holds 80/443), so it must not be generated.
+func TestFrontedStackOmitsOwnNginx(t *testing.T) {
+	cfg := frontedTestConfig(t)
+	cfg.Nginx.FrontedBy = "nself-web"
+
+	g := NewGenerator(cfg)
+	dc, err := g.buildDockerCompose()
+	if err != nil {
+		t.Fatalf("buildDockerCompose() error: %v", err)
+	}
+
+	if _, ok := dc.Services["nginx"]; ok {
+		t.Error("nginx service was generated despite NGINX_FRONTED_BY being set — it can never bind 80/443 and will sit unhealthy forever")
+	}
+
+	// The rest of the stack must be untouched.
+	for _, want := range []string{"postgres", "hasura", "auth"} {
+		if _, ok := dc.Services[want]; !ok {
+			t.Errorf("expected service %q to still be generated when fronted, but it was missing", want)
+		}
+	}
+}
+
+// TestUnfrontedStackKeepsOwnNginx is the negative control: the default
+// (FrontedBy empty) must generate its own nginx service exactly as every
+// existing project relies on today.
+func TestUnfrontedStackKeepsOwnNginx(t *testing.T) {
+	cfg := frontedTestConfig(t)
+	// cfg.Nginx.FrontedBy left empty — the default.
+
+	g := NewGenerator(cfg)
+	dc, err := g.buildDockerCompose()
+	if err != nil {
+		t.Fatalf("buildDockerCompose() error: %v", err)
+	}
+
+	if _, ok := dc.Services["nginx"]; !ok {
+		t.Error("nginx service was not generated for an unfronted (default) stack — this would be a regression for every existing project")
+	}
+}

--- a/internal/compose/generator.go
+++ b/internal/compose/generator.go
@@ -147,7 +147,12 @@ func (g *Generator) buildDockerCompose() (*DockerCompose, error) {
 	}
 
 	// Nginx — profile-gated (always last — depends on other services).
-	if p.Nginx {
+	// Skipped entirely when NGINX_FRONTED_BY names another stack's nginx as
+	// this project's ingress: this project's own nginx container could never
+	// bind 80/443 (the fronting stack's nginx already holds them) and would
+	// sit forever as an unhealthy container `nself status` can never clear.
+	// See NginxConfig.FrontedBy.
+	if p.Nginx && g.cfg.Nginx.FrontedBy == "" {
 		dc.AddService("nginx", g.buildNginxService(dc))
 	}
 

--- a/internal/config/loader_known_vars_core.go
+++ b/internal/config/loader_known_vars_core.go
@@ -133,6 +133,11 @@ var knownEnvVarsCore = []string{
 	"NGINX_SSL_PORT",
 	"NGINX_CLIENT_MAX_BODY_SIZE",
 	"NGINX_BIND_IP",
+	// Names the stack whose nginx fronts this project's domains, when
+	// this project has no ingress nginx of its own — see
+	// NginxConfig.FrontedBy. Listed here so setting it does not emit a
+	// false "unknown env var" warning on every build.
+	"NGINX_FRONTED_BY",
 	// Per-zone rate limit overrides — read by parseEnvToConfig into
 	// NginxConfig.RateLimitAPI/RateLimitAuth/RateLimitAI but were missing from
 	// this schema list (pre-existing gap, fixed alongside gap #1).

--- a/internal/config/loader_parse_env_core.go
+++ b/internal/config/loader_parse_env_core.go
@@ -120,6 +120,7 @@ func parseEnvCore(cfg *Config) {
 		RateLimitAPI:  os.Getenv("RATE_LIMIT_API_RPS"),
 		RateLimitAuth: os.Getenv("RATE_LIMIT_AUTH_RPS"),
 		RateLimitAI:   os.Getenv("RATE_LIMIT_AI_RPS"),
+		FrontedBy:     os.Getenv("NGINX_FRONTED_BY"),
 	}
 
 	// ── SSL ──────────────────────────────────────────────────────────

--- a/internal/config/nginx_fronted_by_test.go
+++ b/internal/config/nginx_fronted_by_test.go
@@ -1,0 +1,48 @@
+package config
+
+// nginx_fronted_by_test.go — coverage for NGINX_FRONTED_BY, the env var that
+// declares this project's ingress as another stack's nginx (2026-09-03
+// staging incident: ntask was fronted by nself-web's nginx but still
+// generated an nginx service that could never bind 80/443).
+//
+// Purpose: prove the var is parsed into NginxConfig.FrontedBy and is
+// registered in knownEnvVars, so setting it does not make every build print
+// a false "unknown env var" warning.
+// Inputs: the process environment (t.Setenv) and the knownEnvVars list.
+// Outputs: pass/fail on parse and on schema registration.
+// Constraints: parseEnvCore reads os.Getenv directly, so this exercises it
+// through t.Setenv rather than a fixture file.
+
+import "testing"
+
+// TestFrontedByParsedFromEnv verifies NGINX_FRONTED_BY reaches
+// NginxConfig.FrontedBy, and that leaving it unset yields the empty default
+// every existing project relies on.
+func TestFrontedByParsedFromEnv(t *testing.T) {
+	t.Setenv("NGINX_FRONTED_BY", "nself-web")
+	cfg := &Config{}
+	parseEnvCore(cfg)
+	if cfg.Nginx.FrontedBy != "nself-web" {
+		t.Errorf("Nginx.FrontedBy = %q, want %q", cfg.Nginx.FrontedBy, "nself-web")
+	}
+
+	t.Setenv("NGINX_FRONTED_BY", "")
+	unset := &Config{}
+	parseEnvCore(unset)
+	if unset.Nginx.FrontedBy != "" {
+		t.Errorf("Nginx.FrontedBy = %q with the var unset, want empty", unset.Nginx.FrontedBy)
+	}
+}
+
+// TestFrontedByIsAKnownEnvVar guards the half of the change that is easy to
+// forget: a var the loader reads but knownEnvVars does not list makes
+// warnUnknownEnvVars print a warning for correct configuration on every
+// single build.
+func TestFrontedByIsAKnownEnvVar(t *testing.T) {
+	for _, k := range knownEnvVars {
+		if k == "NGINX_FRONTED_BY" {
+			return
+		}
+	}
+	t.Error("NGINX_FRONTED_BY is read by parseEnvCore but is missing from knownEnvVars — every build that sets it would print a false unknown-var warning")
+}

--- a/internal/config/types_datastores.go
+++ b/internal/config/types_datastores.go
@@ -89,6 +89,32 @@ type NginxConfig struct {
 	RateLimitAPI  string `env:"RATE_LIMIT_API_RPS"`         // 30
 	RateLimitAuth string `env:"RATE_LIMIT_AUTH_RPS"`        // 5
 	RateLimitAI   string `env:"RATE_LIMIT_AI_RPS"`          // 10
+
+	// FrontedBy names the stack whose nginx fronts this project's domains
+	// (e.g. "nself-web"), when this project has no ingress nginx of its own.
+	// Empty (the default) means this stack runs its own nginx, unchanged
+	// from every prior release.
+	//
+	// When set, `nself build` omits the nginx service from
+	// docker-compose.yml entirely and excludes it from the service counts
+	// `nself status`/`nself start` expect. Without this, a stack meant to
+	// sit behind another stack's nginx still generates and tries to start
+	// its own nginx container, which fails to bind 80/443 (already held by
+	// the fronting stack's nginx via docker-proxy) and then sits forever as
+	// one unhealthy service nself status can never clear ("6/7" on ntask's
+	// staging deploy, 2026-09-03, fronted by nself-web).
+	//
+	// This flag only removes the container that can never run. It does NOT
+	// wire this project's containers onto the fronting stack's Docker
+	// network — the fronting nginx's `resolver 127.0.0.11` can only reach
+	// container names on a network it is attached to, so making
+	// auth.task.staging.nself.org resolve ntask_auth still requires the
+	// operator to attach the two projects' networks (or declare one as
+	// external in both compose files) by hand. That is a bigger, riskier
+	// change — automatically rewriting a Docker network topology from a
+	// per-project flag — and belongs in a follow-up once the desired shape
+	// of that wiring is decided.
+	FrontedBy string `env:"NGINX_FRONTED_BY"`
 }
 
 // RedisConfig holds Redis cache/queue configuration.


### PR DESCRIPTION
From the 2026-09-03 staging report (`167.235.233.65`). Staging runs **ntask behind nself-web's nginx**, and `nself start` had no way to express that.

> **Correction (force-pushed):** the first push of this branch contained only the tests and docs — I ran `git checkout HEAD -- internal/` to undo a negative-proof revert while `HEAD` was still `origin/main` (nothing committed on the branch yet), which wiped the implementation instead of restoring it. Vet was correctly red. All six source files are now in the commit, the negative proof has been redone with `HEAD` holding the fix, and `git status` was verified clean before pushing.

## Failure mode

Ports 80 and 443 can be held once per host. `nself build` always generated an nginx service, so a project meant to sit behind another project's nginx still got one. Two consequences, both live on staging:

1. **`nself start` fails outright.** The generated compose publishes 80/443, which the fronting stack's `docker-proxy` already holds, so the port-availability check (Step 3) refuses to start the stack.
2. **`nself status` reports 6/7 forever.** `RunAllChecks` sizes its total directly off `len(DetectServices(cfg))`, which unconditionally included `"nginx"`. The stack is counted against a container that compose never generates and that could never bind its ports — a permanently unhealthy phantom service nothing can clear.

## Fix

`NGINX_FRONTED_BY` names the stack that fronts this one:

```bash
# .env — this project is served by the nself-web stack's nginx
NGINX_FRONTED_BY=nself-web
```

| File | Change |
|---|---|
| `internal/config/types_datastores.go` | `NginxConfig.FrontedBy` field |
| `internal/config/loader_parse_env_core.go` | parses `NGINX_FRONTED_BY` |
| `internal/config/loader_known_vars_core.go` | registers it, so setting it does not warn |
| `internal/compose/generator.go` | nginx service not added to the compose file |
| `internal/build/detection.go` | `"nginx"` dropped from the list that sizes the health check |
| `internal/build/manifest_resolve.go` | same, for plugin resolution |

Unset — the default, and every existing project — is unchanged. Each behavioral change has a negative-control test asserting exactly that.

**The port check needed no change.** It already reads the ports this stack will actually bind from the resolved compose config rather than a fixed default list (`checkStartPorts` → `docker.DeclaredHostPorts`), so removing the nginx service removes 80/443 from what it checks. Failure mode 1 closes as a consequence of fixing the compose-generation defect, not by special-casing the check.

## Scope — what this deliberately does NOT do

**This removes the container that can never run. It does not wire this project's containers onto the fronting stack's Docker network.**

The fronting nginx resolves upstreams through Docker's embedded DNS at `127.0.0.11`, which only answers for container names on a network nginx is attached to. Routing `auth.task.staging.nself.org` to this project's `auth` container still requires the two projects to share a Docker network — declared `external` in both compose files, or attached by hand, exactly as the operator did manually on staging.

Automating that is a larger design decision than a flag: it changes what `nself build` may assume about networks it does not own, and needs a decision on whether the shared network is declared by the fronted project, the fronting project, or both. I did not guess. The limitation is stated in the generated docs so nobody sets this flag and expects routing to work by itself.

## Negative-test proof

Reverted the five behavioral files to `origin/main`, keeping only the `FrontedBy` struct field so the tests still compile (a struct field alone has no behavior):

```
--- FAIL: TestDetectServices_ExcludesNginxWhenFronted
    DetectServices returned nginx despite FrontedBy being set: [postgres hasura auth nginx redis]
--- FAIL: TestExpectedCoreServices_ExcludesNginxWhenFronted
    expectedCoreServices returned nginx despite FrontedBy being set: [postgres hasura auth nginx]
--- FAIL: TestFrontedStackOmitsOwnNginx
    nginx service was generated despite NGINX_FRONTED_BY being set — it can never bind 80/443 and will sit unhealthy forever
--- FAIL: TestFrontedByParsedFromEnv
    Nginx.FrontedBy = "", want "nself-web"
--- FAIL: TestFrontedByIsAKnownEnvVar
    NGINX_FRONTED_BY is read by parseEnvCore but is missing from knownEnvVars — every build that sets it would print a false unknown-var warning
```

All five pass with the fix restored; `git status` and `git diff HEAD` were both verified empty afterward. The two negative controls (`TestDetectServices_IncludesNginxByDefault`, `TestUnfrontedStackKeepsOwnNginx`) pass in **both** states, which is what makes them controls rather than duplicates.

`TestFrontedByIsAKnownEnvVar` guards the half of a new env var that is easy to forget: a var the loader reads but `knownEnvVars` does not list makes `warnUnknownEnvVars` print a warning for *correct* configuration on every single build.

## Gates

`make fmt-check`, `make vet`, `make build`, `make test` (full suite) — all green on the pushed tree. No flag added, so `command-inventory.json` is unaffected. Docs updated in `Config-Env-Vars.md` and `Config-Nginx.md`, which the doc-sync workflow requires for any change under `internal/config/`.

## Overlap check

Rebased on current `origin/main` at push time. This branch does **not** touch `normalizeComposeNetworkAliases()`, so it should not collide with `p6/fix-plugin-install-and-plus-union`. The compose-side change is a single added condition on the existing `if p.Nginx` guard in `buildDockerCompose`. If network-alias behavior is later needed for the fronted case it belongs in a separate function, not that symbol.

## Related finding, not fixed here

`NGINX_MODE=shared` is documented in `Config-Nginx.md` as enabling "multi-project mode, where a single Nginx instance routes traffic for multiple ɳSelf projects on the same host" — describing this exact topology — but it is implemented nowhere; its only occurrence in the tree is the known-env-var allowlist. `NGINX_FRONTED_BY` covers the *fronted* side; `NGINX_MODE` as documented describes the *fronting* side. Someone should decide whether to implement it or delete the claim, and whether the two should be one mechanism.