### PR TITLE
fix: refuse placeholder/example secrets in non-dev environments

### DIFF
--- a/internal/config/registry_test.go
+++ b/internal/config/registry_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 )
 
-// TestRegistryLength asserts that at least 7 validators are registered.
+// TestRegistryLength asserts that at least 8 validators are registered.
 // This test acts as a regression guard: if a validator is accidentally
 // removed from an init() call, the count drops and this test fails.
 //
-// Current expected registrations (all from validator.go init()):
+// Current expected registrations (all from validator.go init(), plus
+// placeholder-secrets from validator_placeholder_secrets.go):
 //   - env
 //   - passwords
 //   - cors
@@ -16,7 +17,8 @@ import (
 //   - port-conflicts
 //   - duplicate-routes
 //   - minio-credentials
-const minValidatorCount = 7
+//   - placeholder-secrets
+const minValidatorCount = 8
 
 func TestRegistryLength(t *testing.T) {
 	if len(registry) < minValidatorCount {
@@ -36,6 +38,7 @@ func TestRegistryNames(t *testing.T) {
 		"port-conflicts",
 		"duplicate-routes",
 		"minio-credentials",
+		"placeholder-secrets",
 	}
 
 	registered := make(map[string]bool, len(registry))

--- a/internal/config/validator_placeholder_secrets.go
+++ b/internal/config/validator_placeholder_secrets.go
@@ -1,0 +1,124 @@
+package config
+
+// Purpose: fail-closed refusal of known placeholder/example secret values
+// (POSTGRES_PASSWORD, HASURA_GRAPHQL_ADMIN_SECRET, AUTH_JWT_SECRET, and the
+// same optional secrets validatePasswords already treats as critical) in any
+// non-dev environment.
+// Inputs: a *Config populated by the loader, after ApplyDefaults has already
+// normalized Env (empty becomes "dev"; aliases collapse to dev/staging/prod).
+// Outputs: an error naming the offending variable and environment, or nil.
+// Constraints: deliberately broader than validatePasswords/validateJWT's
+// literal Env=="staging"||"prod" gate — it fires for ANY Env that is not
+// exactly "dev", so an unrecognized deploy tier gets no free pass. It is also
+// independent of checkPassword's length/pattern gates: a placeholder that
+// happens to be long enough, or that predates isInsecurePassword's pattern
+// list, is still caught here by exact substring match.
+//
+// Live finding (verified 2026-09-03): nself-web's Hasura ran in BOTH staging
+// and production with HASURA_GRAPHQL_ADMIN_SECRET set to the public
+// nself-dev-admin-secret-change-in-prod .env.example placeholder; /v1/metadata
+// export succeeded with it. Security-Always-Free doctrine treats a placeholder
+// secret in a non-dev environment as a critical finding that blocks deploy.
+// This validator does not rotate anything — fixing a live deployment is an
+// owner action (rotate the secret, then redeploy).
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nself-org/cli/internal/errs"
+)
+
+func init() {
+	register("placeholder-secrets", validateNoPlaceholderSecrets)
+}
+
+// knownPlaceholderSecrets are substrings that, found case-insensitively
+// anywhere in a secret value, mark it as an unrotated example/placeholder
+// rather than a real credential. Covers the generic CHANGE_ME family in all
+// its casing/separator variants plus the specific nself-dev-admin-secret-
+// change-in-prod value shipped in web's public .env.example (the
+// "change-in-prod" substring alone is enough to catch that one and any
+// future sibling placeholder following the same naming convention).
+var knownPlaceholderSecrets = []string{
+	"change_me",
+	"changeme",
+	"change-me",
+	"change-in-prod",
+}
+
+// placeholderSecretField pairs an env-var name with its resolved value for
+// placeholder/empty checking.
+type placeholderSecretField struct {
+	name  string
+	value string
+}
+
+// validateNoPlaceholderSecrets refuses to proceed when cfg.Env is not "dev"
+// and any critical secret is empty or matches a known placeholder value.
+// Dev is exempt: placeholders there are expected and must keep working
+// exactly as today.
+func validateNoPlaceholderSecrets(cfg *Config) error {
+	if cfg.Env == "dev" {
+		return nil
+	}
+
+	// Always-required secrets: reuse the same three fields validatePasswords
+	// treats as critical regardless of environment (POSTGRES_PASSWORD,
+	// HASURA_GRAPHQL_ADMIN_SECRET) plus AUTH_JWT_SECRET, which loader_parse_env.go
+	// aliases onto cfg.Hasura.JWTKey (see loader_parse_env.go:94).
+	required := []placeholderSecretField{
+		{"POSTGRES_PASSWORD", cfg.Postgres.Password},
+		{"HASURA_GRAPHQL_ADMIN_SECRET", cfg.Hasura.AdminSecret},
+		{"AUTH_JWT_SECRET", cfg.Hasura.JWTKey},
+	}
+	for _, f := range required {
+		if f.value == "" {
+			return fmt.Errorf("%s is empty in %s environment — set a unique value in .env: %w",
+				f.name, cfg.Env, errs.ErrPlaceholderSecret)
+		}
+		if isPlaceholderSecret(f.value) {
+			return fmt.Errorf("%s is a known placeholder value in %s environment — set a unique value in .env: %w",
+				f.name, cfg.Env, errs.ErrPlaceholderSecret)
+		}
+	}
+
+	// Optional secrets: only checked when their service is enabled, mirroring
+	// validatePasswords' own conditions. Empty is left alone here (an empty
+	// optional secret is validatePasswords' concern, e.g. Redis no-auth);
+	// this validator only refuses a placeholder VALUE, never an absent one,
+	// for these fields.
+	optional := []placeholderSecretField{}
+	if cfg.Redis.Enabled && cfg.Redis.Password != "" {
+		optional = append(optional, placeholderSecretField{"REDIS_PASSWORD", cfg.Redis.Password})
+	}
+	if cfg.Minio.Enabled && cfg.Minio.RootPassword != "" {
+		optional = append(optional, placeholderSecretField{"MINIO_ROOT_PASSWORD", cfg.Minio.RootPassword})
+	}
+	if cfg.Search.Enabled && strings.EqualFold(cfg.Search.Engine, "meilisearch") && cfg.Search.MeiliSearch.MasterKey != "" {
+		optional = append(optional, placeholderSecretField{"MEILISEARCH_MASTER_KEY", cfg.Search.MeiliSearch.MasterKey})
+	}
+	if cfg.Monitoring.Enabled && cfg.Monitoring.GrafanaAdminPassword != "" {
+		optional = append(optional, placeholderSecretField{"GRAFANA_ADMIN_PASSWORD", cfg.Monitoring.GrafanaAdminPassword})
+	}
+	for _, f := range optional {
+		if isPlaceholderSecret(f.value) {
+			return fmt.Errorf("%s is a known placeholder value in %s environment — set a unique value in .env: %w",
+				f.name, cfg.Env, errs.ErrPlaceholderSecret)
+		}
+	}
+
+	return nil
+}
+
+// isPlaceholderSecret reports whether value contains a known placeholder
+// substring, case-insensitively.
+func isPlaceholderSecret(value string) bool {
+	lower := strings.ToLower(value)
+	for _, p := range knownPlaceholderSecrets {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/validator_placeholder_secrets_test.go
+++ b/internal/config/validator_placeholder_secrets_test.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/errs"
+)
+
+// validPlaceholderTestConfig returns a *Config with strong, non-placeholder
+// values for every secret validateNoPlaceholderSecrets inspects, so a single
+// field can be overridden per test case without tripping on the others.
+// The values below deliberately avoid every substring in insecurePatterns
+// (validator.go) — "password", "secret", "admin", etc. — so a test built on
+// this base config also passes the pre-existing "passwords" validator when
+// run through runAll, isolating failures to the placeholder-secrets check
+// under test. They are also deliberately low-entropy (concatenated dictionary
+// words, no digit/case mixing) rather than random-looking strings, so they
+// read clearly as inert test fixtures and don't trip gitleaks' generic-api-key
+// entropy heuristic the way a random alnum string would.
+func validPlaceholderTestConfig(env string) *Config {
+	return &Config{
+		Env:         env,
+		ProjectName: "test-project",
+		BaseDomain:  "example.com",
+		Postgres: PostgresConfig{
+			Password: "actuallyuniquevalueforthisenvironmentnumberone",
+		},
+		Hasura: HasuraConfig{
+			AdminSecret: "totallydifferentvaluealtogetherforthisservice",
+			JWTKey:      "completelyseparatevalueforauthenticationtoken",
+		},
+	}
+}
+
+// TestValidateNoPlaceholderSecrets is the table-driven proof for the
+// fail-closed placeholder-secret gate: dev is exempt, every non-dev tier
+// refuses a known placeholder or an empty critical secret, and a real value
+// passes.
+func TestValidateNoPlaceholderSecrets(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(cfg *Config)
+		env     string
+		wantErr bool
+		wantVar string // substring the error must name, when wantErr is true
+	}{
+		{
+			name: "dev with CHANGE_ME placeholder passes untouched",
+			env:  "dev",
+			mutate: func(cfg *Config) {
+				cfg.Postgres.Password = "CHANGE_ME"
+				cfg.Hasura.AdminSecret = "CHANGE_ME"
+				cfg.Hasura.JWTKey = "CHANGE_ME"
+			},
+			wantErr: false,
+		},
+		{
+			name: "staging with the live nself-web placeholder fails naming the var",
+			env:  "staging",
+			mutate: func(cfg *Config) {
+				cfg.Hasura.AdminSecret = "nself-dev-admin-secret-change-in-prod"
+			},
+			wantErr: true,
+			wantVar: "HASURA_GRAPHQL_ADMIN_SECRET",
+		},
+		{
+			name: "prod with empty POSTGRES_PASSWORD fails",
+			env:  "prod",
+			mutate: func(cfg *Config) {
+				cfg.Postgres.Password = ""
+			},
+			wantErr: true,
+			wantVar: "POSTGRES_PASSWORD",
+		},
+		{
+			name:    "prod with real values passes",
+			env:     "prod",
+			mutate:  func(cfg *Config) {},
+			wantErr: false,
+		},
+		{
+			name: "staging with a change-in-prod substring fails even without an exact match",
+			env:  "staging",
+			mutate: func(cfg *Config) {
+				cfg.Hasura.JWTKey = "some-other-service-secret-change-in-prod-suffix"
+			},
+			wantErr: true,
+			wantVar: "AUTH_JWT_SECRET",
+		},
+		{
+			name: "unrecognized non-dev tier still refuses a placeholder (fail-closed)",
+			env:  "canary",
+			mutate: func(cfg *Config) {
+				cfg.Postgres.Password = "changeme"
+			},
+			wantErr: true,
+			wantVar: "POSTGRES_PASSWORD",
+		},
+		{
+			name: "staging with CHANGE_ME (underscore, uppercase) fails",
+			env:  "staging",
+			mutate: func(cfg *Config) {
+				cfg.Postgres.Password = "CHANGE_ME"
+			},
+			wantErr: true,
+			wantVar: "POSTGRES_PASSWORD",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validPlaceholderTestConfig(tc.env)
+			tc.mutate(cfg)
+
+			err := validateNoPlaceholderSecrets(cfg)
+
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if tc.wantErr {
+				if !errors.Is(err, errs.ErrPlaceholderSecret) {
+					t.Errorf("error does not wrap errs.ErrPlaceholderSecret: %v", err)
+				}
+				if tc.wantVar != "" && !strings.Contains(err.Error(), tc.wantVar) {
+					t.Errorf("error %q does not name expected variable %q", err.Error(), tc.wantVar)
+				}
+				if !strings.Contains(err.Error(), tc.env) {
+					t.Errorf("error %q does not name the environment %q", err.Error(), tc.env)
+				}
+			}
+		})
+	}
+}
+
+// TestIsPlaceholderSecret exercises the substring matcher directly across
+// casing and separator variants, plus a real-looking value that must NOT match.
+func TestIsPlaceholderSecret(t *testing.T) {
+	placeholders := []string{
+		"CHANGE_ME",
+		"changeme",
+		"Change-Me",
+		"change-me",
+		"nself-dev-admin-secret-change-in-prod",
+		"prefix-CHANGE_ME-suffix",
+		"something-CHANGE-IN-PROD-value",
+	}
+	for _, v := range placeholders {
+		if !isPlaceholderSecret(v) {
+			t.Errorf("isPlaceholderSecret(%q) = false, want true", v)
+		}
+	}
+
+	real := []string{
+		"totallydifferentvaluealtogetherforthisservice",
+		"completelyseparatevalueforauthenticationtoken",
+		"",
+	}
+	for _, v := range real {
+		if isPlaceholderSecret(v) {
+			t.Errorf("isPlaceholderSecret(%q) = true, want false", v)
+		}
+	}
+}
+
+// TestValidateNoPlaceholderSecretsWiredIntoRunAll proves the check actually
+// runs as part of the full validator registry (the path nself start/deploy
+// invoke via config.Validate), not just as a standalone function.
+func TestValidateNoPlaceholderSecretsWiredIntoRunAll(t *testing.T) {
+	cfg := validPlaceholderTestConfig("staging")
+	cfg.Hasura.AdminSecret = "nself-dev-admin-secret-change-in-prod"
+
+	err := runAll(cfg)
+	if err == nil {
+		t.Fatal("expected runAll to fail for a staging config with a placeholder Hasura admin secret")
+	}
+	if !strings.Contains(err.Error(), "placeholder-secrets") {
+		t.Errorf("runAll error %q does not attribute the failure to the placeholder-secrets validator", err.Error())
+	}
+	if !strings.Contains(err.Error(), "HASURA_GRAPHQL_ADMIN_SECRET") {
+		t.Errorf("runAll error %q does not name HASURA_GRAPHQL_ADMIN_SECRET", err.Error())
+	}
+}

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -41,6 +41,7 @@ var (
 	ErrInsecurePassword   = errors.New("password matches insecure pattern")
 	ErrInvalidProjectName = errors.New("invalid project name format")
 	ErrInvalidCORS        = errors.New("CORS wildcards not allowed in production")
+	ErrPlaceholderSecret  = errors.New("secret is empty or matches a known placeholder value")
 
 	// Health
 	ErrServiceUnhealthy = errors.New("service health check failed")

--- a/internal/errs/errs_test.go
+++ b/internal/errs/errs_test.go
@@ -22,6 +22,7 @@ func TestSentinelErrors_NonNil(t *testing.T) {
 		{"ErrInsecurePassword", ErrInsecurePassword},
 		{"ErrInvalidProjectName", ErrInvalidProjectName},
 		{"ErrInvalidCORS", ErrInvalidCORS},
+		{"ErrPlaceholderSecret", ErrPlaceholderSecret},
 		// Health
 		{"ErrServiceUnhealthy", ErrServiceUnhealthy},
 		{"ErrHealthTimeout", ErrHealthTimeout},


### PR DESCRIPTION
## Live finding

Verified live tonight: nself-web's Hasura on **both** staging and production is running with

```
HASURA_GRAPHQL_ADMIN_SECRET=nself-dev-admin-secret-change-in-prod
```

— the public placeholder from web's `.env.example`. An unauthenticated `/v1/metadata` export against that secret returned 200 on both servers. This CLI's own `cmd/commands/.env.example` ships the same class of placeholder (`POSTGRES_PASSWORD=CHANGE_ME`, `HASURA_GRAPHQL_ADMIN_SECRET=CHANGE_ME`), and nothing in `internal/`/`cmd/` refused these values in a non-dev environment before this PR (`grep -r "change-in-prod\|CHANGE_ME" internal/ cmd/` outside tests: zero hits).

## The rule this closes

Under the project's Security-Always-Free doctrine (`cli/.claude/docs/doctrines/security-always-free.md`), a critical finding blocks deploy. A placeholder secret running in a non-dev environment is exactly that.

This PR adds a fail-closed validator, `placeholder-secrets`, registered alongside the existing `passwords`/`jwt`/`cors` validators in `internal/config`:

- **Scope:** fires whenever `cfg.Env != "dev"` — broader than the existing `passwords`/`jwt` checks, which only gate on the literal strings `"staging"`/`"prod"`. Any unrecognized deploy tier now gets no free pass either.
- **Checks:** `POSTGRES_PASSWORD`, `HASURA_GRAPHQL_ADMIN_SECRET`, `AUTH_JWT_SECRET` (aliased onto `cfg.Hasura.JWTKey` by the loader) must be non-empty and must not match a known placeholder. The same optional secrets `validatePasswords` already treats as critical when their service is enabled (`REDIS_PASSWORD`, `MINIO_ROOT_PASSWORD`, `MEILISEARCH_MASTER_KEY`, `GRAFANA_ADMIN_PASSWORD`) are checked for placeholder values too.
- **Placeholder match:** case-insensitive substring match on `change_me`, `changeme`, `change-me`, `change-in-prod` — the last one alone catches `nself-dev-admin-secret-change-in-prod` and any future sibling following the same naming convention, independent of length.
- **Dev is untouched:** the function returns `nil` immediately when `cfg.Env == "dev"`, so `CHANGE_ME` placeholders keep working exactly as they do today.
- **Wiring:** no new call site was needed. `config.Validate` → `runAll` already runs every registered validator, and it's already invoked from `internal/build/orchestrator.go:164` (the path both `nself build` and `nself deploy` — via its `nself build` subprocess call — go through) and directly from `cmd/commands/start.go:266` (`nself start`).
- **Error message** names the variable and environment and tells the operator what to do: `nself secrets rotate` doesn't exist in this CLI (checked `cmd/commands/secrets*.go` — only `rotation-log`, `decrypt-on-deploy`, `audit`, `lint`, `rekey`), so the message says "set a unique value in .env" per the task's fallback instruction.

## Tests

`internal/config/validator_placeholder_secrets_test.go`, table-driven:

- dev + `CHANGE_ME` on all three critical secrets → passes untouched
- staging + the live `nself-dev-admin-secret-change-in-prod` value → fails, names `HASURA_GRAPHQL_ADMIN_SECRET`
- prod + empty `POSTGRES_PASSWORD` → fails, names the var
- prod + real (non-placeholder) values → passes
- staging + a value that merely *contains* `change-in-prod` as a substring (not an exact placeholder match) → fails, proving substring matching, not just equality
- an unrecognized non-dev tier (`"canary"`) + `changeme` → fails (proves the fail-closed scope is broader than the literal staging/prod gate)
- plus a direct `isPlaceholderSecret` unit test across casing/separator variants, and a `TestValidateNoPlaceholderSecretsWiredIntoRunAll` test proving the check actually fires through `runAll`, the same path `config.Validate` uses.

**Negative-test proof (teeth check):** temporarily replaced the validator body with an unconditional `return nil`, reran the suite — 7 of the new tests failed exactly as expected (5 table subtests + the parent + the runAll wiring test), confirming the tests actually exercise the guard rather than passing vacuously. Reverted before running the real gates.

## Gates run (all green)

- `make build` — clean
- `make fmt-check` — clean
- `make vet` — clean
- `make test` (full suite, all packages) — clean
- `golangci-lint run` (scoped + full) — clean
- `gitleaks detect` against the diff — clean (initial test fixture used random-looking high-entropy strings that tripped the `generic-api-key` heuristic; replaced with low-entropy dictionary-word concatenations, matching the style already used in `registry_test.go`)

## What this does NOT do

This PR does not rotate anything. It does not touch the live nself-web staging/prod Hasura admin secret, or any other credential currently deployed. Fixing the live exposure (rotating `HASURA_GRAPHQL_ADMIN_SECRET` on both servers and redeploying) is a separate owner action — this PR only makes the CLI refuse to let the same class of mistake happen again on the next `nself start`/`build`/`deploy`.

## Scope note

Per instruction, this branch does not touch `internal/nginx`, `internal/compose`, or `cmd/commands/start*.go` beyond what's shown above (no changes to those files at all — the existing `config.Validate` call sites already cover this). Changed files: `internal/config/validator_placeholder_secrets.go` (new), `internal/config/validator_placeholder_secrets_test.go` (new), `internal/config/registry_test.go`, `internal/errs/errs.go`, `internal/errs/errs_test.go`.
