### PR TITLE
fix(compose,start): forward HASURA_GRAPHQL_*/AUTH_* namespace, idempotent postgres start

### DIFF
--- a/.github/wiki/Config-Auth.md
+++ b/.github/wiki/Config-Auth.md
@@ -167,6 +167,22 @@ AUTH_PROVIDER_GITHUB_CLIENT_ID=Iv1.xxxxxxxxxxxxxxxx
 AUTH_PROVIDER_GITHUB_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
+---
+
+## Forwarding Any AUTH_* / HASURA_AUTH_* Engine Var
+
+Beyond `AUTH_PROVIDER_*`, **every other variable in hasura-auth's own `AUTH_*` and `HASURA_AUTH_*` namespaces set in any `.env` file is forwarded verbatim into the auth container** at `nself build` time, additive only, so it never overrides the curated values above (JWT secret, SMTP config, allowed redirect URLs, etc.). This covers hasura-auth engine flags ɳSelf does not wrap in its own typed setting, for example:
+
+```bash
+# .env.dev
+AUTH_ANONYMOUS_USERS_ENABLED=true
+AUTH_DISABLE_NEW_USERS=false
+AUTH_REQUIRE_EMAIL_VERIFICATION=true
+HASURA_AUTH_SMTP_HOST=smtp.example.com
+```
+
+Run `nself build` (or `nself restart`) after adding one of these for the regenerated compose to pick it up. See [[Config-Hasura]] for the equivalent `HASURA_GRAPHQL_*` forwarding rule.
+
 ### Setting Up Google Login
 
 1. Create OAuth 2.0 credentials in the [Google Cloud Console](https://console.cloud.google.com/)

--- a/.github/wiki/Config-Hasura.md
+++ b/.github/wiki/Config-Hasura.md
@@ -124,6 +124,31 @@ Slots with no `REMOTE_SCHEMA_N_NAME` set are silently skipped.
 
 ---
 
+## Forwarding Any HASURA_GRAPHQL_* Engine Tuning Var
+
+The table above lists the `HASURA_GRAPHQL_*` variables ɳSelf builds into a curated compose value (admin secret, JWT secret, console/dev-mode toggles, CORS, log level). Beyond that curated set, **every other `HASURA_GRAPHQL_*` variable you set in any `.env` file is forwarded verbatim into the Hasura container** at `nself build` time — you do not need to add support for it first.
+
+This covers real Hasura engine config surface that ɳSelf does not wrap in its own typed setting, for example:
+
+```bash
+# .env.dev — allow-list mode and engine limits
+HASURA_GRAPHQL_ENABLE_ALLOWLIST=true
+HASURA_GRAPHQL_NODE_LIMIT=5000
+HASURA_GRAPHQL_DEPTH_LIMIT=10
+HASURA_GRAPHQL_BATCH_SIZE=10
+HASURA_GRAPHQL_LIVE_QUERIES_MULTIPLEXED_BATCH_SIZE=100
+HASURA_GRAPHQL_LIVE_QUERIES_MULTIPLEXED_REFETCH_INTERVAL=1000
+```
+
+**Rules:**
+
+- The forward is additive only. If a variable is already curated by ɳSelf (`HASURA_GRAPHQL_ADMIN_SECRET`, `_JWT_SECRET`, `_ENABLE_CONSOLE`, `_DEV_MODE`, `_ENABLE_TELEMETRY`, `_CORS_DOMAIN`, `_LOG_LEVEL`, `_UNAUTHORIZED_ROLE`, `_DATABASE_URL`), your `.env` value is **ignored** for that key — use the dedicated variable (or the `HASURA_JWT_KEY`/`HASURA_JWT_TYPE` pair for JWT) instead, so it goes through validation.
+- Everything else in the `HASURA_GRAPHQL_*` namespace reaches the container untouched — no allow-list of names to keep in sync in the CLI itself.
+- Run `nself build` (or `nself restart`) after adding or changing one of these vars so the regenerated compose picks it up.
+- The same additive-forwarding rule applies to hasura-auth's own `AUTH_*`/`HASURA_AUTH_*` namespace — see [[Config-Auth]].
+
+---
+
 ## Accessing the Hasura Console
 
 The Hasura Console is a web UI for browsing your schema, running GraphQL queries, managing metadata, and configuring permissions.

--- a/cmd/commands/start_containers.go
+++ b/cmd/commands/start_containers.go
@@ -159,6 +159,29 @@ func startPostgresPhase(ctx context.Context, opts startOpts, cfg *config.Config,
 	// Phase 1: Start only postgres so schemas can be created before auth starts.
 	sp := ui.NewSpinner("Starting PostgreSQL...")
 	sp.Start()
+
+	// Idempotent-start guard: if a healthy postgres container for this
+	// project is already running, skip `docker compose up -d postgres`
+	// entirely instead of relying on Compose's own config-hash diff to be a
+	// no-op. On-disk docker-compose.yml can drift from what actually created
+	// the running container (regenerated on another host, edited .env since
+	// the last `nself build`, etc.); when that happens Compose treats it as
+	// a config change and attempts to recreate an already-healthy postgres,
+	// which can fail mid-recreate even though nothing was actually broken
+	// (found live 2026-09-03: `nself start` run a second time against an
+	// already-healthy postgres failed here; `docker compose up` — no
+	// service filter — succeeded immediately after as a workaround).
+	// --clean-start/--fresh already ran ComposeDown above, so postgres is
+	// never still healthy on those paths and this guard is a no-op for them.
+	if !opts.cleanStart && !opts.fresh {
+		containerName := fmt.Sprintf("%s_postgres", cfg.ProjectName)
+		health, healthErr := docker.GetHealthStatus(ctx, containerName)
+		if healthErr == nil && postgresAlreadyRunning(health) {
+			sp.Success("PostgreSQL container already running and healthy")
+			return compose, nil, nil
+		}
+	}
+
 	if err := compose.ComposeUp(ctx, projectDir, "postgres"); err != nil {
 		sp.Fail("Failed to start PostgreSQL")
 		ui.UXError(
@@ -176,6 +199,17 @@ func startPostgresPhase(ctx context.Context, opts startOpts, cfg *config.Config,
 	sp.Success("PostgreSQL container started")
 
 	return compose, nil, nil
+}
+
+// postgresAlreadyRunning reports whether a docker.GetHealthStatus result for
+// the project's postgres container means `nself start` can safely treat
+// PostgreSQL as already up — i.e. skip `docker compose up -d postgres` for
+// this run rather than asking Compose to reconcile it. Only "healthy" (the
+// container exists, has a healthcheck, and it is passing) qualifies:
+// "starting" may still fail its first probe, "unhealthy"/"none"/"not_found"
+// all mean the container needs a real compose-up to reach a good state.
+func postgresAlreadyRunning(healthStatus string) bool {
+	return healthStatus == "healthy"
 }
 
 // initializeDatabasePhase runs database initialization (Step 5). Must run

--- a/cmd/commands/start_containers_test.go
+++ b/cmd/commands/start_containers_test.go
@@ -1,0 +1,48 @@
+package commands
+
+// Purpose: Regression coverage for P6 FIX-CLI-2 (found 2026-09-03) — `nself
+// start`'s "Starting PostgreSQL" step ran `docker compose up -d postgres`
+// unconditionally on every invocation, even when a healthy postgres
+// container for the project was already running. Compose's own config-hash
+// diff normally makes that a no-op, but an on-disk docker-compose.yml that
+// drifted from what actually created the running container (regenerated
+// elsewhere, .env edited since the last `nself build`, etc.) makes Compose
+// treat it as a config change and attempt to recreate an already-healthy
+// postgres — which can fail mid-recreate. `nself start` run a second time
+// against a live, healthy stack hit exactly this; `docker compose up` (no
+// service filter) succeeded immediately after as a manual workaround.
+// startPostgresPhase (start_containers.go) now checks
+// docker.GetHealthStatus for the project's postgres container before
+// calling ComposeUp, and skips the compose-up call entirely when it is
+// already "healthy". postgresAlreadyRunning is the pure decision predicate
+// behind that guard.
+// Inputs: none (pure string-in/bool-out).
+// Outputs: pass/fail via testing.T.
+// Constraints: table-driven per every internal/docker.GetHealthStatus return
+//              value ("healthy", "unhealthy", "starting", "none",
+//              "not_found") plus an empty string for the zero value.
+
+import "testing"
+
+func TestPostgresAlreadyRunning(t *testing.T) {
+	tests := []struct {
+		name         string
+		healthStatus string
+		want         bool
+	}{
+		{"healthy container is treated as already running", "healthy", true},
+		{"unhealthy container still needs compose up", "unhealthy", false},
+		{"starting container has not passed its first probe yet", "starting", false},
+		{"none (no healthcheck configured) is not a positive signal", "none", false},
+		{"not_found (container does not exist) needs compose up", "not_found", false},
+		{"empty string (zero value / lookup error) needs compose up", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := postgresAlreadyRunning(tt.healthStatus); got != tt.want {
+				t.Errorf("postgresAlreadyRunning(%q) = %v, want %v", tt.healthStatus, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/compose/core_services.go
+++ b/internal/compose/core_services.go
@@ -140,18 +140,30 @@ func (g *Generator) buildHasuraService() (ServiceConfig, error) {
 		env[k] = v
 	}
 
-	// Passthrough: forward REMOTE_SCHEMA_* and HASURA_EXTRA_* from .env to the container.
-	// Hasura's url_from_env feature reads Remote Schema URLs directly from the container
-	// environment, so these vars must be present at runtime.
+	// Passthrough: forward REMOTE_SCHEMA_*, HASURA_EXTRA_*, and the rest of
+	// Hasura's own HASURA_GRAPHQL_* namespace from .env to the container.
+	// Hasura's url_from_env feature reads Remote Schema URLs directly from the
+	// container environment, so REMOTE_SCHEMA_*/HASURA_EXTRA_* must be
+	// present at runtime. The HASURA_GRAPHQL_* forward closes a gap where
+	// engine tuning vars declared in .env (HASURA_GRAPHQL_ENABLE_ALLOWLIST,
+	// _NODE_LIMIT, _DEPTH_LIMIT, _BATCH_SIZE, _LIVE_QUERIES_*, etc.) were
+	// recognized by the loader (loader_known_vars_core.go, to suppress
+	// unknown-var warnings) but never actually written into the generated
+	// compose file — additive only, so the curated values set above (admin
+	// secret, JWT secret, console/dev-mode substitution strings, ...) always
+	// win and are never clobbered by a raw .env echo of the same key.
 	if cfg.Passthrough != nil {
 		keys := make([]string, 0, len(cfg.Passthrough))
 		for k := range cfg.Passthrough {
-			if strings.HasPrefix(k, "REMOTE_SCHEMA_") || strings.HasPrefix(k, "HASURA_EXTRA_") {
+			if strings.HasPrefix(k, "REMOTE_SCHEMA_") || strings.HasPrefix(k, "HASURA_EXTRA_") || strings.HasPrefix(k, "HASURA_GRAPHQL_") {
 				keys = append(keys, k)
 			}
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
+			if _, exists := env[k]; exists {
+				continue
+			}
 			env[k] = cfg.Passthrough[k]
 		}
 	}

--- a/internal/compose/core_services_auth_nginx.go
+++ b/internal/compose/core_services_auth_nginx.go
@@ -67,16 +67,26 @@ func (g *Generator) buildAuthService() (ServiceConfig, error) {
 	// T07: Inject AUTH_ALLOWED_REDIRECT_URLS for OAuth and magic link support.
 	env["AUTH_ALLOWED_REDIRECT_URLS"] = computeAllowedRedirectURLs(cfg)
 
-	// Passthrough: iterate for AUTH_PROVIDER_* keys
+	// Passthrough: forward AUTH_PROVIDER_* (OAuth provider config) plus the
+	// rest of hasura-auth's own AUTH_*/HASURA_AUTH_* namespace from .env.
+	// Same curated-list gap as Hasura (see buildHasuraService): vars like
+	// AUTH_ANONYMOUS_USERS_ENABLED, AUTH_REQUIRE_EMAIL_VERIFICATION,
+	// AUTH_MODE, HASURA_AUTH_SMTP_*, etc. are recognized by the loader
+	// (loader_known_vars_core.go) but were never written into the generated
+	// compose env. Additive only — the curated values above (JWT secret,
+	// SMTP config, allowed redirect URLs, ...) always win.
 	if cfg.Passthrough != nil {
 		keys := make([]string, 0, len(cfg.Passthrough))
 		for k := range cfg.Passthrough {
-			if strings.HasPrefix(k, "AUTH_PROVIDER_") {
+			if strings.HasPrefix(k, "AUTH_") || strings.HasPrefix(k, "HASURA_AUTH_") {
 				keys = append(keys, k)
 			}
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
+			if _, exists := env[k]; exists {
+				continue
+			}
 			env[k] = cfg.Passthrough[k]
 		}
 	}

--- a/internal/compose/core_services_test.go
+++ b/internal/compose/core_services_test.go
@@ -207,6 +207,133 @@ func TestHasuraRemoteSchemaPassthrough(t *testing.T) {
 	}
 }
 
+// TestHasuraGraphqlNamespacePassthrough is a table-driven regression test for
+// a live defect (P6 FIX-CLI-2, found 2026-09-03): HASURA_GRAPHQL_* engine
+// tuning vars declared in .env (e.g. HASURA_GRAPHQL_ENABLE_ALLOWLIST) were
+// recognized by the loader as known vars (loader_known_vars_core.go, to
+// suppress unknown-var warnings) but never actually forwarded into the
+// generated docker-compose Hasura service env — silently dropped at `nself
+// build` time. Verifies both the specific reported var and an arbitrary
+// HASURA_GRAPHQL_* var land in the rendered compose, and that curated values
+// (admin secret) are never clobbered by a same-named passthrough entry.
+func TestHasuraGraphqlNamespacePassthrough(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		value     string
+		wantValue string // "" means: must equal the passthrough value verbatim
+	}{
+		{
+			name:      "reported defect: HASURA_GRAPHQL_ENABLE_ALLOWLIST",
+			key:       "HASURA_GRAPHQL_ENABLE_ALLOWLIST",
+			value:     "true",
+			wantValue: "true",
+		},
+		{
+			name:      "arbitrary HASURA_GRAPHQL_FOO tuning var",
+			key:       "HASURA_GRAPHQL_FOO",
+			value:     "bar",
+			wantValue: "bar",
+		},
+		{
+			name:      "engine limit var HASURA_GRAPHQL_NODE_LIMIT",
+			key:       "HASURA_GRAPHQL_NODE_LIMIT",
+			value:     "5000",
+			wantValue: "5000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := minimalConfig()
+			cfg.Passthrough = map[string]string{tt.key: tt.value}
+
+			g := NewGenerator(cfg)
+			svc, err := g.buildHasuraService()
+			if err != nil {
+				t.Fatalf("buildHasuraService() error: %v", err)
+			}
+
+			got, ok := svc.Environment[tt.key]
+			if !ok {
+				t.Fatalf("expected %q in Hasura environment, not found (dropped)", tt.key)
+			}
+			if got != tt.wantValue {
+				t.Errorf("%s = %q, want %q", tt.key, got, tt.wantValue)
+			}
+		})
+	}
+
+	// Curated values must never be clobbered by a same-named passthrough entry.
+	t.Run("curated ADMIN_SECRET wins over passthrough echo", func(t *testing.T) {
+		cfg := minimalConfig()
+		cfg.Passthrough = map[string]string{
+			"HASURA_GRAPHQL_ADMIN_SECRET": "raw-env-file-value-should-not-win",
+		}
+
+		g := NewGenerator(cfg)
+		svc, err := g.buildHasuraService()
+		if err != nil {
+			t.Fatalf("buildHasuraService() error: %v", err)
+		}
+		if got := svc.Environment["HASURA_GRAPHQL_ADMIN_SECRET"]; got != "secret" {
+			t.Errorf("HASURA_GRAPHQL_ADMIN_SECRET = %q, want curated %q (must not be clobbered by passthrough)", got, "secret")
+		}
+	})
+}
+
+// TestAuthNamespacePassthrough mirrors TestHasuraGraphqlNamespacePassthrough
+// for buildAuthService: hasura-auth's own AUTH_*/HASURA_AUTH_* env vars
+// (e.g. AUTH_ANONYMOUS_USERS_ENABLED) had the same curated-list gap as Hasura
+// — recognized by the loader, never forwarded into the generated compose env.
+func TestAuthNamespacePassthrough(t *testing.T) {
+	tests := []struct {
+		key   string
+		value string
+	}{
+		{"AUTH_ANONYMOUS_USERS_ENABLED", "true"},
+		{"AUTH_REQUIRE_EMAIL_VERIFICATION", "false"},
+		{"HASURA_AUTH_SMTP_HOST", "smtp.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			cfg := minimalConfig()
+			cfg.Passthrough = map[string]string{tt.key: tt.value}
+
+			g := NewGenerator(cfg)
+			svc, err := g.buildAuthService()
+			if err != nil {
+				t.Fatalf("buildAuthService() error: %v", err)
+			}
+
+			got, ok := svc.Environment[tt.key]
+			if !ok {
+				t.Fatalf("expected %q in Auth environment, not found (dropped)", tt.key)
+			}
+			if got != tt.value {
+				t.Errorf("%s = %q, want %q", tt.key, got, tt.value)
+			}
+		})
+	}
+
+	t.Run("curated AUTH_JWT_SECRET wins over passthrough echo", func(t *testing.T) {
+		cfg := minimalConfig()
+		cfg.Passthrough = map[string]string{
+			"AUTH_JWT_SECRET": "raw-env-file-value-should-not-win",
+		}
+
+		g := NewGenerator(cfg)
+		svc, err := g.buildAuthService()
+		if err != nil {
+			t.Fatalf("buildAuthService() error: %v", err)
+		}
+		if got := svc.Environment["AUTH_JWT_SECRET"]; got != "testsecretkey12345678901234567890" {
+			t.Errorf("AUTH_JWT_SECRET = %q, want curated cfg.Hasura.JWTKey value (must not be clobbered by passthrough)", got)
+		}
+	})
+}
+
 // TestAuthPortFromConfig verifies T04: cfg.Auth.Port controls both host and container ports.
 // nhost/hasura-auth binds on the port set by AUTH_PORT env var (= cfg.Auth.Port).
 // Setting Auth.Port = 4001 must produce "127.0.0.1:4001:4001".

--- a/internal/compose/snapshot_test.go
+++ b/internal/compose/snapshot_test.go
@@ -273,6 +273,36 @@ func TestSnapshot_ComposeV5PidsLimitInDeploy(t *testing.T) {
 	}
 }
 
+// TestSnapshot_HasuraGraphqlEnvVarForwarding is the end-to-end fixture
+// regression test for P6 FIX-CLI-2 (2026-09-03): a full `nself build`-style
+// Generate() run, with HASURA_GRAPHQL_ENABLE_ALLOWLIST and an arbitrary
+// HASURA_GRAPHQL_* var set via cfg.Passthrough (mirroring what the loader
+// populates from a real .env file — see internal/config/loader_helpers.go),
+// must land both vars verbatim in the rendered docker-compose YAML under the
+// hasura service. This is the "diffed against a golden fixture" check for
+// the fix: rather than a byte-for-byte golden file (this package deliberately
+// avoids those — see file header — because generated secrets make output
+// non-deterministic), it follows the established golden-fragment convention
+// and asserts the exact rendered fragment is present.
+func TestSnapshot_HasuraGraphqlEnvVarForwarding(t *testing.T) {
+	cfg := snapshotConfig()
+	cfg.Passthrough = map[string]string{
+		"HASURA_GRAPHQL_ENABLE_ALLOWLIST": "true",
+		"HASURA_GRAPHQL_FOO":              "bar",
+	}
+	yaml := generateYAML(t, cfg)
+
+	hasuraBlock := extractServiceBlock(yaml, "hasura")
+	for _, frag := range []string{
+		"HASURA_GRAPHQL_ENABLE_ALLOWLIST: \"true\"",
+		"HASURA_GRAPHQL_FOO: bar",
+	} {
+		if !strings.Contains(hasuraBlock, frag) {
+			t.Errorf("snapshot: expected %q in generated hasura service block but not found, block:\n%s", frag, hasuraBlock)
+		}
+	}
+}
+
 // extractServiceBlock is a debug helper that returns the lines in the YAML that
 // start at "  <name>:" and continue until the next top-level-indented service.
 // Used only for test failure messages — not part of the assertion logic.

--- a/internal/config/loader_helpers.go
+++ b/internal/config/loader_helpers.go
@@ -22,14 +22,29 @@ import (
 )
 
 // collectPassthrough scans the full environment for dynamic env vars matching
-// known prefixes (AUTH_PROVIDER_*, REMOTE_SCHEMA_*, HASURA_EXTRA_*) and returns
-// them as a key-value map. These variables cannot be predefined in structs
-// because users add them dynamically for OAuth providers, remote schemas, etc.
+// known prefixes (AUTH_*, REMOTE_SCHEMA_*, HASURA_EXTRA_*, HASURA_GRAPHQL_*)
+// and returns them as a key-value map. These variables cannot be predefined in
+// structs because users add them dynamically for OAuth providers, remote
+// schemas, etc.
+//
+// HASURA_GRAPHQL_* and AUTH_* are namespace-wide prefixes (not single vars):
+// loader_known_vars_core.go recognizes a superset of Hasura/Auth engine
+// tuning vars (HASURA_GRAPHQL_ENABLE_ALLOWLIST, HASURA_GRAPHQL_NODE_LIMIT,
+// AUTH_ANONYMOUS_USERS_ENABLED, etc.) purely to suppress "unknown env var"
+// warnings, but buildHasuraService/buildAuthService only ever wrote a curated
+// subset into the generated compose env — every other var in Hasura's/Auth's
+// own namespace was silently dropped at `nself build` time even though it was
+// present in .env (found live: HASURA_GRAPHQL_ENABLE_ALLOWLIST never reached
+// the container). Capturing the full namespace here and merging it
+// additively in the compose builders (existing curated keys always win) is
+// safe because these are Hasura's/hasura-auth's own env vars — forwarding
+// them through is exactly what the operator asked for by setting them.
 func collectPassthrough(environ []string) map[string]string {
 	prefixes := []string{
-		"AUTH_PROVIDER_",
+		"AUTH_",
 		"REMOTE_SCHEMA_",
 		"HASURA_EXTRA_",
+		"HASURA_GRAPHQL_",
 	}
 	result := make(map[string]string)
 	for _, env := range environ {


### PR DESCRIPTION
## What / Why

Two live CLI defects found tonight (P6 FIX-CLI-2):

**1. Hasura/Auth engine env vars silently dropped at `nself build` time.**
`loader_known_vars_core.go` lists `HASURA_GRAPHQL_ENABLE_ALLOWLIST` and sibling
Hasura tuning vars (`_NODE_LIMIT`, `_DEPTH_LIMIT`, `_BATCH_SIZE`,
`_LIVE_QUERIES_*`) purely to suppress "unknown env var" warnings — none were
ever written into the generated `docker-compose.yml`. Confirmed via
`docker inspect` on a generated stack + reading the template. Same
curated-list gap exists in hasura-auth's own `AUTH_*`/`HASURA_AUTH_*`
namespace (`AUTH_ANONYMOUS_USERS_ENABLED`, `AUTH_REQUIRE_EMAIL_VERIFICATION`,
`HASURA_AUTH_SMTP_*`, etc.).

Fix: `collectPassthrough` (`internal/config/loader_helpers.go`) now captures
the full `HASURA_GRAPHQL_*` and `AUTH_*` namespaces from the env cascade
(previously only `AUTH_PROVIDER_*`/`REMOTE_SCHEMA_*`/`HASURA_EXTRA_*`).
`buildHasuraService`/`buildAuthService` merge their namespace **additively**
— curated values (admin secret, JWT secret, console/dev-mode toggles, SMTP,
allowed redirect URLs, ...) always win over a same-named passthrough entry,
proven by a dedicated "curated value wins" test in each.

**2. `nself start`'s "Starting PostgreSQL" step could fail against an
already-healthy postgres.** Could not reproduce the literal compose-up
failure in two clean fixture attempts (local macOS + a scratch project on
staging — plain `nself start` run twice succeeded both times). Found the
likely real trigger by inspection: staging's
`/opt/nself-web/backend/docker-compose.yml` is dated May 13 while its
`.env`/`.env.staging` are from today — an on-disk compose file that drifted
from what actually created the live container makes Compose treat the next
`up -d postgres` as a config change and attempt a recreate, which can fail
mid-recreate against a container that was never actually broken (matches
the reported symptom: plain `docker compose up`, no service filter,
succeeded immediately after as a workaround).

Fix: `startPostgresPhase` now checks `docker.GetHealthStatus` for
`<project>_postgres` before calling `ComposeUp`, and short-circuits with a
success message when it is already `"healthy"` — never attempts to touch an
already-healthy postgres. Skipped for `--clean-start`/`--fresh`, which
already tear the container down first.

## Acceptance evidence

- Table-driven test `TestHasuraGraphqlNamespacePassthrough` (reported var +
  arbitrary `HASURA_GRAPHQL_FOO` + curated-value-wins case) and
  `TestAuthNamespacePassthrough` (mirror for the auth service) in
  `internal/compose/core_services_test.go`.
- End-to-end fixture/golden-fragment test `TestSnapshot_HasuraGraphqlEnvVarForwarding`
  in `internal/compose/snapshot_test.go`, following this package's existing
  golden-fragment convention (no byte-for-byte golden file — this package
  deliberately avoids those because generated secrets make output
  non-deterministic, see file header).
- Live verification: built the CLI from this branch, ran `nself build` in a
  fresh fixture project with `HASURA_GRAPHQL_ENABLE_ALLOWLIST=true` and
  `AUTH_ANONYMOUS_USERS_ENABLED=true` set, confirmed both land verbatim in
  the rendered `docker-compose.yml`.
- Table-driven test `TestPostgresAlreadyRunning` (every `docker.GetHealthStatus`
  return value) in new `cmd/commands/start_containers_test.go`.
- Live verification: built the CLI from this branch, started a fixture
  stack, then ran `nself start` again against the already-healthy stack —
  output shows `✓ PostgreSQL container already running and healthy` and the
  Starting-PostgreSQL step is skipped instead of calling compose-up.
- `go build ./...`, `go vet ./...`, `go test ./...` all green locally under
  `~/bin/heavy-lock` (repo-wide, all packages `ok`).

## Docs

- `.github/wiki/Config-Hasura.md` — new "Forwarding Any HASURA_GRAPHQL_*
  Engine Tuning Var" section.
- `.github/wiki/Config-Auth.md` — new "Forwarding Any AUTH_* /
  HASURA_AUTH_* Engine Var" section.

## Scope note

A third item (refuse Hasura/Auth placeholder secrets outside dev) was
proposed mid-task and then retracted by the coordinator — it's owned by a
sibling session in `internal/config/validator.go`. Not touched here.

Ticket: P6 FIX-CLI-2