### PR TITLE
fix(plugin): resolve a slug served twice by entitlement, not first-match

### DIFF
--- a/.github/command-inventory.json
+++ b/.github/command-inventory.json
@@ -1651,6 +1651,7 @@
           "--preview",
           "--show-graph",
           "--skip-sbom-check",
+          "--tier",
           "--version",
           "--with-optional",
           "--yes"
@@ -1678,6 +1679,7 @@
         "short": "List available and installed plugins",
         "hidden": false,
         "flags": [
+          "--available",
           "--category",
           "--detailed",
           "--installed",

--- a/.github/wiki/cmd-plugin.md
+++ b/.github/wiki/cmd-plugin.md
@@ -50,6 +50,18 @@ The event body contains one field: `instanceId`, which is an opaque SHA-256 hash
 
 To opt out, set `NSELF_DISABLE_TELEMETRY=1` in your environment or `.env.local`.
 
+## A slug served as both free and pro
+
+A small number of plugins (`cron`, `notify`) ship as a genuine free/pro pair: the same product, listed twice in the registry under one slug. `nself plugin install cron` resolves which entry to install like this:
+
+- If your license entitles the bundle the pro entry belongs to (checked via the same bundle-entitlement path `nself bundle install` uses), you get **pro**.
+- Otherwise, or with no license key configured, you get **free**. Free never requires a key.
+- Pass `--tier free` or `--tier pro` to force a side. `--tier free` always succeeds. `--tier pro` still runs the entitlement check — it is a way to *ask* for pro, not a way to bypass licensing — and fails with a clear "buy the bundle" error if you're not entitled.
+
+Run `nself plugin list --available` to see every tier of every such slug side by side, with the tier a plain `nself plugin install <name>` would resolve to today marked in the `Default` column.
+
+Any *other* slug collision — two unrelated registry entries that happen to share a name, not a declared tier pair — is refused outright with an error naming both entries. The CLI never silently installs "whichever one came first" for an ambiguous slug.
+
 ## Official by name, third-party by URL
 
 `nself plugin install <name>` resolves against the official plugins.nself.org registry: license-checked for pro tiers, and its tarball is Ed25519-signature-verified against a registry-pinned author key.
@@ -185,6 +197,16 @@ nself plugin install livekit --key nself_pro_xxxxx...
 
 # Install a specific version
 nself plugin install recording --version 1.2.0
+
+# See both tiers of a slug served twice (e.g. cron: free + pro), with the
+# resolved default marked
+nself plugin list --available
+
+# Force the free entry of a free/pro slug, ignoring entitlement
+nself plugin install cron --tier free
+
+# Ask for the pro entry explicitly (still requires an entitled license)
+nself plugin install cron --tier pro
 
 # Remove a plugin
 nself plugin remove ai

--- a/cmd/commands/plugin.go
+++ b/cmd/commands/plugin.go
@@ -132,9 +132,11 @@ func init() {
 	pluginListCmd.Flags().Bool("detailed", false, "Show detailed information")
 	pluginListCmd.Flags().String("category", "", "Filter by category")
 	pluginListCmd.Flags().Bool("show-eol", false, "Include EOL plugins in listing (hidden by default)") // S58-T03
+	pluginListCmd.Flags().Bool("available", false, "List every registry tier of a slug served twice (free+pro pairs), marking the resolved default")
 
 	// Flags on install.
 	pluginInstallCmd.Flags().String("key", "", "License key for pro plugins")
+	pluginInstallCmd.Flags().String("tier", "", `Force "free" or "pro" for a slug served as both (e.g. cron, notify); default resolves by license entitlement`)
 	pluginInstallCmd.Flags().String("version", "", "Install a specific version")
 	pluginInstallCmd.Flags().Bool("force", false, "Required when using NSELF_LICENSE_SKIP_VERIFY; explicit acknowledgment of skipped validation")
 	pluginInstallCmd.Flags().Bool("allow-eol", false, "Allow installing an EOL plugin (not recommended)") // S58-T03

--- a/cmd/commands/plugin_install.go
+++ b/cmd/commands/plugin_install.go
@@ -35,6 +35,22 @@ func runPluginInstall(cmd *cobra.Command, args []string) error {
 	showGraph, _ := cmd.Flags().GetBool("show-graph")
 	yes, _ := cmd.Flags().GetBool("yes")
 	checksum, _ := cmd.Flags().GetString("checksum")
+	tier, _ := cmd.Flags().GetString("tier")
+
+	// --tier overrides entitlement-based resolution for a slug served as both
+	// free and pro (OWNER-ACTIONS.md item 15). Threaded via env var, matching
+	// the existing NSELF_SKIP_SBOM_CHECK / NSELF_PLUGIN_LICENSE_KEY convention
+	// so plugin.installLocked (and its dependency-install recursion) sees it
+	// without widening plugin.Install's signature.
+	tier = strings.ToLower(strings.TrimSpace(tier))
+	if tier != "" && tier != "free" && tier != "pro" {
+		return fmt.Errorf(`invalid --tier %q: must be "free" or "pro"`, tier)
+	}
+	if tier != "" {
+		if err := os.Setenv("NSELF_PLUGIN_INSTALL_TIER", tier); err != nil {
+			return fmt.Errorf("setting tier override: %w", err)
+		}
+	}
 
 	// CLI-R16: "official by name, third-party by URL" — split the requested
 	// refs up front so registry-only flows (preview/show-graph/dry-run, the

--- a/cmd/commands/plugin_query.go
+++ b/cmd/commands/plugin_query.go
@@ -26,7 +26,12 @@ func runPluginList(cmd *cobra.Command, args []string) error {
 	installed, _ := cmd.Flags().GetBool("installed")
 	detailed, _ := cmd.Flags().GetBool("detailed")
 	category, _ := cmd.Flags().GetString("category")
-	showEOL, _ := cmd.Flags().GetBool("show-eol") // S58-T03
+	showEOL, _ := cmd.Flags().GetBool("show-eol")    // S58-T03
+	available, _ := cmd.Flags().GetBool("available") // OWNER-ACTIONS.md item 15
+
+	if available {
+		return runPluginListAvailable(cmd, category)
+	}
 
 	pluginDir := resolvePluginDir()
 
@@ -96,6 +101,42 @@ func runPluginList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	return nil
+}
+
+// runPluginListAvailable implements `nself plugin list --available`
+// (OWNER-ACTIONS.md item 15): every registry entry for a slug served more
+// than once (a declared free/pro tier pair or, for anything else, a
+// registry-data collision `nself plugin install` refuses to resolve), with
+// the entitlement-resolved default marked so an operator can see the split
+// before installing.
+func runPluginListAvailable(cmd *cobra.Command, category string) error {
+	rows, err := plugin.ListAvailableWithTiers(cmd.Context(), nil)
+	if err != nil {
+		return fmt.Errorf("listing available plugin tiers: %w", err)
+	}
+	if len(rows) == 0 {
+		fmt.Println("No plugins found in registry.")
+		return nil
+	}
+
+	tbl := ui.NewTable("Name", "Tier", "Version", "Default")
+	for _, r := range rows {
+		if category != "" && !strings.EqualFold(r.Category, category) {
+			continue
+		}
+		def := ""
+		if r.IsDefault {
+			def = "✓"
+		}
+		tier := r.Tier
+		if tier == "" {
+			tier = "-"
+		}
+		tbl.AddRow(r.Name, tier, r.Version, def)
+	}
+	tbl.Render()
+	fmt.Println("\nDefault = what a plain 'nself plugin install <name>' resolves to today (license entitlement for a tier pair, otherwise its only entry). Override with --tier free|pro.")
 	return nil
 }
 

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -57,6 +57,8 @@ var (
 	ErrCircularDependency        = errors.New("circular plugin dependency detected")
 	ErrPluginUnsigned            = errors.New("stable plugin is missing required signature — install refused")
 	ErrPluginMissingChecksum     = errors.New("stable plugin is missing required checksum — install refused")
+	ErrDuplicatePluginSlug       = errors.New("plugin slug is served by more than one unrelated registry entry")
+	ErrTierNotEntitled           = errors.New("license does not entitle the pro tier of this plugin")
 
 	// SSL
 	ErrMkcertNotFound      = errors.New("mkcert not installed — falling back to OpenSSL")

--- a/internal/plugin/installer_locked.go
+++ b/internal/plugin/installer_locked.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/nself-org/cli/internal/audit"
 	"github.com/nself-org/cli/internal/config"
-	"github.com/nself-org/cli/internal/errs"
 	"github.com/nself-org/cli/internal/plugin/verify"
 	"github.com/nself-org/cli/internal/version"
 )
@@ -40,9 +39,16 @@ func installLocked(ctx context.Context, cfg *config.Config, name string, pluginD
 		return fmt.Errorf("fetching registry: %w", err)
 	}
 
-	manifest, found := findPlugin(reg, name)
-	if !found {
-		return errs.ErrPluginNotFound
+	// Tier resolution (OWNER-ACTIONS.md item 15): a slug served twice (a
+	// genuine free/pro pair) no longer silently first-matches to free.
+	// --tier is threaded down as an env var by the cmd layer, matching the
+	// existing NSELF_SKIP_SBOM_CHECK / NSELF_PLUGIN_LICENSE_KEY convention so
+	// every recursive installLocked call (dependencies) and every caller of
+	// plugin.Install (including bundle/installer.go, which never sets this
+	// var and so always gets the entitlement-based default) shares one path.
+	manifest, err := ResolvePlugin(ctx, reg, name, os.Getenv("NSELF_PLUGIN_INSTALL_TIER"), nil)
+	if err != nil {
+		return err
 	}
 
 	// Status check: lifecycle policy enforcement (S58-T01, S58-T02, S58-T03).

--- a/internal/plugin/interfaces.go
+++ b/internal/plugin/interfaces.go
@@ -183,6 +183,21 @@ type PluginManifest struct {
 	Tier     string `json:"tier,omitempty"`
 	Checksum string `json:"checksum,omitempty"`
 
+	// TierPair marks a genuine free/pro pair of the SAME product sharing one
+	// slug (e.g. cron, notify) — set true in BOTH the free and pro registry
+	// entries by the plugins/plugins-pro registry authors. Install-time
+	// resolution (tier_resolve.go) uses this to tell a real tier pair from an
+	// unrelated registry-data collision, which is a hard error instead
+	// (OWNER-ACTIONS.md item 15).
+	TierPair bool `json:"tier_pair,omitempty"`
+
+	// Bundles lists the bundles.json slugs this specific registry entry
+	// belongs to (e.g. cron's pro entry: ["claw"]). Used by tier_resolve.go
+	// to decide entitlement for a TierPair's pro entry via
+	// license.BundleEntitled. Empty for free entries and for pro plugins sold
+	// standalone rather than through a bundle.
+	Bundles []string `json:"bundles,omitempty"`
+
 	// PublishStatus is the plugin's lifecycle status from the registry (S58-T01).
 	// Valid values: "experimental" | "planned" | "beta" | "stable" | "deprecated" | "eol"
 	// Missing status defaults to "stable" for backwards compatibility (CR-A).

--- a/internal/plugin/registry_cache.go
+++ b/internal/plugin/registry_cache.go
@@ -115,6 +115,8 @@ func (r Registry) MarshalJSON() ([]byte, error) {
 			Tags:            p.Tags,
 			Tables:          p.Tables,
 			Port:            p.Port,
+			TierPair:        p.TierPair,
+			Bundles:         p.Bundles,
 			Dependencies:    rawDeps,
 			APIEndpoints:    rawEPs,
 			Compat:          p.Compat,

--- a/internal/plugin/registry_json.go
+++ b/internal/plugin/registry_json.go
@@ -144,6 +144,8 @@ func entryToManifest(e pluginEntry) PluginManifest {
 		RequiresLicense: e.RequiresLicense,
 		Tables:          e.Tables,
 		Port:            port,
+		TierPair:        e.TierPair,
+		Bundles:         e.Bundles,
 		Dependencies:    parseDependencies(e.Dependencies),
 		APIEndpoints:    parseAPIEndpoints(e.APIEndpoints),
 		Language:        language,

--- a/internal/plugin/registry_parse.go
+++ b/internal/plugin/registry_parse.go
@@ -82,6 +82,11 @@ type pluginEntry struct {
 	Tags            []string `json:"tags"`
 	Tables          []string `json:"tables,omitempty"`
 	Port            int      `json:"port,omitempty"`
+	// TierPair and Bundles support install-time tier resolution for a slug
+	// served twice (free + pro) as one product — see PluginManifest's doc
+	// comments (interfaces.go) and tier_resolve.go.
+	TierPair bool     `json:"tier_pair,omitempty"`
+	Bundles  []string `json:"bundles,omitempty"`
 	// Dependencies is raw JSON because the registry format is not stable.
 	// Accepted shapes:
 	//   ["redis","auth"]                            (legacy string array)

--- a/internal/plugin/tier_list.go
+++ b/internal/plugin/tier_list.go
@@ -1,0 +1,76 @@
+package plugin
+
+// tier_list.go — `nself plugin list --available` support.
+//
+// Purpose: surface every registry entry for a slug served more than once
+// (OWNER-ACTIONS.md item 15), marking which tier a plain
+// `nself plugin install <name>` (no --tier override) currently resolves to,
+// so an operator can see the free/pro split and the license-driven default
+// before installing rather than being surprised by it.
+// Inputs: none beyond the fetched Registry (via FetchRegistry) and an
+// EntitlementFunc (nil selects defaultEntitlement, same as ResolvePlugin).
+// Outputs: one TieredPluginInfo per registry entry, grouped by slug and
+// ordered by first appearance in the registry.
+// Constraints: never collapses an unresolved (non-tier_pair) duplicate down
+// to one row — both entries are listed with IsDefault=false, matching
+// ResolvePlugin's refusal to guess at install time.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// TieredPluginInfo describes one registry entry as shown by
+// `nself plugin list --available`.
+type TieredPluginInfo struct {
+	Name      string
+	Tier      string
+	Version   string
+	Category  string
+	TierPair  bool
+	IsDefault bool // true if ResolvePlugin(ctx, reg, Name, "", entitled) picks this exact entry
+}
+
+// ListAvailableWithTiers fetches the registry and returns every entry,
+// grouped by case-insensitive slug in first-seen order, with IsDefault set on
+// whichever entry a tier-override-free install would currently resolve to.
+func ListAvailableWithTiers(ctx context.Context, entitled EntitlementFunc) ([]TieredPluginInfo, error) {
+	cacheDir := defaultCacheDir()
+	reg, err := FetchRegistry(ctx, "", cacheDir)
+	if err != nil {
+		return nil, fmt.Errorf("fetching registry: %w", err)
+	}
+
+	order := make([]string, 0, len(reg.Plugins))
+	groups := make(map[string][]*PluginManifest, len(reg.Plugins))
+	for i := range reg.Plugins {
+		key := strings.ToLower(reg.Plugins[i].Name)
+		if _, seen := groups[key]; !seen {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], &reg.Plugins[i])
+	}
+
+	out := make([]TieredPluginInfo, 0, len(reg.Plugins))
+	for _, key := range order {
+		entries := groups[key]
+
+		var defaultEntry *PluginManifest
+		if resolved, rerr := ResolvePlugin(ctx, reg, entries[0].Name, "", entitled); rerr == nil {
+			defaultEntry = resolved
+		}
+
+		for _, e := range entries {
+			out = append(out, TieredPluginInfo{
+				Name:      e.Name,
+				Tier:      e.Tier,
+				Version:   e.Version,
+				Category:  e.Category,
+				TierPair:  e.TierPair,
+				IsDefault: defaultEntry == e,
+			})
+		}
+	}
+	return out, nil
+}

--- a/internal/plugin/tier_resolve.go
+++ b/internal/plugin/tier_resolve.go
@@ -1,0 +1,184 @@
+package plugin
+
+// tier_resolve.go — install-time resolution for a plugin slug served more
+// than once by the registry.
+//
+// Purpose: OWNER-ACTIONS.md item 15 (2026-09-04, decision (b)) found that
+// `nself plugin install cron` silently installed the FREE plugin even for a
+// customer entitled to the pro tier, because findPlugin/GetPlugin return the
+// first registry match and the served registry lists cron and notify twice
+// (free then pro). This file replaces that first-match behaviour for any
+// name with more than one registry entry: a genuine free/pro pair of the
+// same product (TierPair: true on BOTH entries) resolves by license
+// entitlement; any other same-slug collision is refused as a registry-data
+// error rather than silently picking one.
+// Inputs: the fetched Registry, the requested plugin name, an optional
+// explicit --tier override ("", "free", or "pro"), and an EntitlementFunc
+// (defaultEntitlement in production, a fixture in tests).
+// Outputs: the single PluginManifest to install, or errs.ErrDuplicatePluginSlug
+// / errs.ErrTierNotEntitled / errs.ErrPluginNotFound.
+// Constraints: never falls back to first-match on an unresolved ambiguity —
+// that is the exact bug this file exists to close.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nself-org/cli/internal/errs"
+	"github.com/nself-org/cli/internal/license"
+)
+
+// EntitlementFunc reports whether the operator's current license entitles at
+// least one of the given bundles.nself.org slugs. Production callers use
+// defaultEntitlement; tests inject a fixture so resolution logic is
+// verifiable without a live ping_api call.
+type EntitlementFunc func(ctx context.Context, bundles []string) (bool, error)
+
+// defaultEntitlement checks bundle-level entitlement via the same
+// license.BundleEntitled call the bundle installer uses (bundle/installer.go
+// Phase 1), reusing the operator's already-configured license key. A plugin
+// entry with no Bundles (a standalone pro plugin, not part of a bundle) is
+// never entitled by this path — install falls through to the ordinary
+// per-plugin checkLicense flow for that case.
+func defaultEntitlement(ctx context.Context, bundles []string) (bool, error) {
+	if len(bundles) == 0 {
+		return false, nil
+	}
+	key := license.CollectLicenseKey()
+	if key == "" {
+		return false, nil
+	}
+	var lastErr error
+	for _, b := range bundles {
+		ok, err := license.BundleEntitled(ctx, key, b)
+		if ok {
+			return true, nil
+		}
+		if err != nil {
+			lastErr = err
+		}
+	}
+	return false, lastErr
+}
+
+// findPluginEntries returns every registry entry whose name case-insensitively
+// matches name, in registry order. Unlike findPlugin/GetPlugin this does not
+// stop at the first match — it is the primitive tier resolution is built on.
+func findPluginEntries(reg *Registry, name string) []*PluginManifest {
+	var out []*PluginManifest
+	for i := range reg.Plugins {
+		if strings.EqualFold(reg.Plugins[i].Name, name) {
+			out = append(out, &reg.Plugins[i])
+		}
+	}
+	return out
+}
+
+// splitTierPair separates a two-entry match into its free and pro manifests.
+// Returns ok=false — a registry-data error, not a resolvable ambiguity —
+// unless BOTH entries declare TierPair: true and they occupy the two
+// different tiers exactly once each (one free, one pro).
+func splitTierPair(entries []*PluginManifest) (free, pro *PluginManifest, ok bool) {
+	if len(entries) != 2 {
+		return nil, nil, false
+	}
+	a, b := entries[0], entries[1]
+	if !a.TierPair || !b.TierPair {
+		return nil, nil, false
+	}
+	switch {
+	case a.Tier == "free" && b.Tier == "pro":
+		return a, b, true
+	case a.Tier == "pro" && b.Tier == "free":
+		return b, a, true
+	default:
+		return nil, nil, false
+	}
+}
+
+// duplicateSlugError formats the hard-error report for a same-slug collision
+// that is NOT a declared tier pair — every entry is named so the operator (or
+// the registry maintainer) can see exactly what collided, per OWNER-ACTIONS.md
+// item 15's "never silent first-match" rule.
+func duplicateSlugError(name string, entries []*PluginManifest) error {
+	descs := make([]string, len(entries))
+	for i, e := range entries {
+		descs[i] = fmt.Sprintf("%s@%s (tier=%s)", e.Name, e.Version, e.Tier)
+	}
+	return fmt.Errorf("%w: %q resolves to %d registry entries that are not a declared tier_pair: %s",
+		errs.ErrDuplicatePluginSlug, name, len(entries), strings.Join(descs, ", "))
+}
+
+// ResolvePlugin picks the single registry entry `nself plugin install <name>`
+// (or a bundle's own install loop) should install.
+//
+//   - Zero matches: errs.ErrPluginNotFound.
+//   - One match: returned as-is; tierOverride is validated against its own
+//     tier and rejected if it disagrees (e.g. --tier pro for a plugin that
+//     only has a free entry).
+//   - Two matches that are a declared tier pair (TierPair: true on both):
+//     tierOverride "free"/"pro" picks that entry directly ("pro" still runs
+//     the entitlement check below — an override never bypasses licensing);
+//     no override resolves by entitlement, defaulting to free when the
+//     entitlement check is false, erroring, or the operator has no key.
+//   - Two-or-more matches that are NOT a declared tier pair: duplicateSlugError
+//     — a registry-data problem, never resolved by picking one.
+func ResolvePlugin(ctx context.Context, reg *Registry, name, tierOverride string, entitled EntitlementFunc) (*PluginManifest, error) {
+	if entitled == nil {
+		entitled = defaultEntitlement
+	}
+	tierOverride = strings.ToLower(strings.TrimSpace(tierOverride))
+	if tierOverride != "" && tierOverride != "free" && tierOverride != "pro" {
+		return nil, fmt.Errorf("invalid --tier %q: must be \"free\" or \"pro\"", tierOverride)
+	}
+
+	entries := findPluginEntries(reg, name)
+	switch len(entries) {
+	case 0:
+		return nil, errs.ErrPluginNotFound
+	case 1:
+		only := entries[0]
+		if tierOverride != "" && only.Tier != "" && only.Tier != tierOverride {
+			return nil, fmt.Errorf("plugin %q only has a %q entry in the registry, not %q", name, only.Tier, tierOverride)
+		}
+		return only, nil
+	}
+
+	free, pro, ok := splitTierPair(entries)
+	if !ok {
+		return nil, duplicateSlugError(name, entries)
+	}
+
+	switch tierOverride {
+	case "free":
+		return free, nil
+	case "pro":
+		ok, err := entitled(ctx, pro.Bundles)
+		if err != nil {
+			return nil, fmt.Errorf("checking entitlement for %q pro tier: %w", name, err)
+		}
+		if !ok {
+			return nil, notEntitledError(name, pro)
+		}
+		return pro, nil
+	default:
+		ok, err := entitled(ctx, pro.Bundles)
+		if err != nil || !ok {
+			// Fail closed to free, never to an error: the operator asked for
+			// "cron", not specifically the pro tier, and free always installs.
+			return free, nil
+		}
+		return pro, nil
+	}
+}
+
+// notEntitledError names the bundle the operator needs, matching the message
+// shape bundle/installer.go's Phase 1 check already uses.
+func notEntitledError(name string, pro *PluginManifest) error {
+	if len(pro.Bundles) == 0 {
+		return fmt.Errorf("%w: plugin %q (pro tier requires a plugin-level license, run 'nself license set <key>')", errs.ErrTierNotEntitled, name)
+	}
+	return fmt.Errorf("%w: plugin %q pro tier requires the %s bundle (or ɳSelf+) — buy at https://nself.org/pricing or run 'nself license set <key>'",
+		errs.ErrTierNotEntitled, name, strings.Join(pro.Bundles, "/"))
+}

--- a/internal/plugin/tier_resolve_test.go
+++ b/internal/plugin/tier_resolve_test.go
@@ -1,0 +1,202 @@
+package plugin
+
+// tier_resolve_test.go — table-driven coverage for install-time tier
+// resolution (OWNER-ACTIONS.md item 15). Fixture registry: a genuine tier
+// pair (cron: free + pro, both TierPair:true, pro belongs to bundle "claw"),
+// a plain free-only plugin (webhooks-free-only, single entry), a plain
+// pro-only plugin (search-pro-only, single entry), and a bad duplicate
+// (search-collision: two entries, same slug, neither TierPair) matching the
+// "distinct products sharing a slug" case OWNER-ACTIONS.md flags for search
+// before the plugins-pro rename lands.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/errs"
+)
+
+func fixtureRegistry() *Registry {
+	return &Registry{
+		Plugins: []PluginManifest{
+			{Name: "cron", Version: "1.0.0", Tier: "free", TierPair: true},
+			{Name: "cron", Version: "1.1.2", Tier: "pro", TierPair: true, Bundles: []string{"claw"}},
+
+			{Name: "webhooks-free-only", Version: "1.0.0", Tier: "free"},
+
+			{Name: "search-pro-only", Version: "1.0.0", Tier: "pro", Bundles: []string{"claw"}},
+
+			// Bad duplicate: same slug, neither side flagged tier_pair — must
+			// hard-error, never silently resolve to the first entry.
+			{Name: "search-collision", Version: "1.0.0", Tier: "free"},
+			{Name: "search-collision", Version: "1.0.0", Tier: "pro"},
+		},
+	}
+}
+
+func alwaysEntitled(ctx context.Context, bundles []string) (bool, error) { return true, nil }
+func neverEntitled(ctx context.Context, bundles []string) (bool, error)  { return false, nil }
+func entitlementErrors(ctx context.Context, bundles []string) (bool, error) {
+	return false, errors.New("ping_api unreachable")
+}
+
+func TestResolvePlugin_TierPair_EntitledDefaultsToPro(t *testing.T) {
+	reg := fixtureRegistry()
+	m, err := ResolvePlugin(context.Background(), reg, "cron", "", alwaysEntitled)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Tier != "pro" || m.Version != "1.1.2" {
+		t.Fatalf("expected pro 1.1.2, got tier=%s version=%s", m.Tier, m.Version)
+	}
+}
+
+func TestResolvePlugin_TierPair_NotEntitledDefaultsToFree(t *testing.T) {
+	reg := fixtureRegistry()
+	m, err := ResolvePlugin(context.Background(), reg, "cron", "", neverEntitled)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Tier != "free" || m.Version != "1.0.0" {
+		t.Fatalf("expected free 1.0.0, got tier=%s version=%s", m.Tier, m.Version)
+	}
+}
+
+func TestResolvePlugin_TierPair_EntitlementCheckErrorFailsClosedToFree(t *testing.T) {
+	reg := fixtureRegistry()
+	m, err := ResolvePlugin(context.Background(), reg, "cron", "", entitlementErrors)
+	if err != nil {
+		t.Fatalf("unexpected error (should fail closed to free, not error): %v", err)
+	}
+	if m.Tier != "free" {
+		t.Fatalf("expected fail-closed free, got tier=%s", m.Tier)
+	}
+}
+
+func TestResolvePlugin_TierPair_ExplicitFreeOverrideIgnoresEntitlement(t *testing.T) {
+	reg := fixtureRegistry()
+	// Even with an entitled license, --tier free must still return free.
+	m, err := ResolvePlugin(context.Background(), reg, "cron", "free", alwaysEntitled)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Tier != "free" {
+		t.Fatalf("expected free override, got tier=%s", m.Tier)
+	}
+}
+
+func TestResolvePlugin_TierPair_ExplicitProOverrideStillChecksEntitlement(t *testing.T) {
+	reg := fixtureRegistry()
+	_, err := ResolvePlugin(context.Background(), reg, "cron", "pro", neverEntitled)
+	if err == nil {
+		t.Fatal("expected an error: --tier pro without entitlement must not silently succeed")
+	}
+	if !errors.Is(err, errs.ErrTierNotEntitled) {
+		t.Fatalf("expected errs.ErrTierNotEntitled, got: %v", err)
+	}
+}
+
+func TestResolvePlugin_TierPair_ExplicitProOverrideSucceedsWhenEntitled(t *testing.T) {
+	reg := fixtureRegistry()
+	m, err := ResolvePlugin(context.Background(), reg, "cron", "pro", alwaysEntitled)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Tier != "pro" {
+		t.Fatalf("expected pro override, got tier=%s", m.Tier)
+	}
+}
+
+func TestResolvePlugin_SingleFreeEntry_NoOverride(t *testing.T) {
+	reg := fixtureRegistry()
+	m, err := ResolvePlugin(context.Background(), reg, "webhooks-free-only", "", neverEntitled)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Tier != "free" {
+		t.Fatalf("expected the plugin's only entry (free), got tier=%s", m.Tier)
+	}
+}
+
+func TestResolvePlugin_SingleFreeEntry_ProOverrideRejected(t *testing.T) {
+	reg := fixtureRegistry()
+	_, err := ResolvePlugin(context.Background(), reg, "webhooks-free-only", "pro", alwaysEntitled)
+	if err == nil {
+		t.Fatal("expected an error: this slug has no pro entry")
+	}
+}
+
+func TestResolvePlugin_SingleProEntry_NoOverrideDoesNotRequireEntitlement(t *testing.T) {
+	// A standalone pro plugin (not a tier pair) is resolved by findPlugin's
+	// original single-entry path — its own checkLicense gate (installLocked
+	// Step 1) is what enforces licensing, not ResolvePlugin.
+	reg := fixtureRegistry()
+	m, err := ResolvePlugin(context.Background(), reg, "search-pro-only", "", neverEntitled)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Tier != "pro" {
+		t.Fatalf("expected the plugin's only entry (pro), got tier=%s", m.Tier)
+	}
+}
+
+func TestResolvePlugin_NonTierPairDuplicate_HardErrorsNamingBothEntries(t *testing.T) {
+	reg := fixtureRegistry()
+	_, err := ResolvePlugin(context.Background(), reg, "search-collision", "", alwaysEntitled)
+	if err == nil {
+		t.Fatal("expected errs.ErrDuplicatePluginSlug, got nil (silent first-match regression)")
+	}
+	if !errors.Is(err, errs.ErrDuplicatePluginSlug) {
+		t.Fatalf("expected errs.ErrDuplicatePluginSlug, got: %v", err)
+	}
+	// Both entries must be named in the message — never resolved by picking one.
+	msg := err.Error()
+	if !strings.Contains(msg, "search-collision") {
+		t.Fatalf("error should name the colliding slug: %v", err)
+	}
+}
+
+func TestResolvePlugin_NotFound(t *testing.T) {
+	reg := fixtureRegistry()
+	_, err := ResolvePlugin(context.Background(), reg, "does-not-exist", "", alwaysEntitled)
+	if !errors.Is(err, errs.ErrPluginNotFound) {
+		t.Fatalf("expected errs.ErrPluginNotFound, got: %v", err)
+	}
+}
+
+func TestResolvePlugin_InvalidTierFlagRejected(t *testing.T) {
+	reg := fixtureRegistry()
+	_, err := ResolvePlugin(context.Background(), reg, "cron", "enterprise", alwaysEntitled)
+	if err == nil {
+		t.Fatal("expected an error for an unrecognised --tier value")
+	}
+}
+
+// TestSplitTierPair_DirectUnit covers splitTierPair in isolation (order
+// independence and the "not a real pair" branches) since ResolvePlugin's
+// table above only exercises it indirectly.
+func TestSplitTierPair_DirectUnit(t *testing.T) {
+	free := &PluginManifest{Name: "cron", Tier: "free", TierPair: true}
+	pro := &PluginManifest{Name: "cron", Tier: "pro", TierPair: true, Bundles: []string{"claw"}}
+
+	if f, p, ok := splitTierPair([]*PluginManifest{free, pro}); !ok || f != free || p != pro {
+		t.Fatalf("free-then-pro: expected ok with (free,pro), got ok=%v f=%v p=%v", ok, f, p)
+	}
+	if f, p, ok := splitTierPair([]*PluginManifest{pro, free}); !ok || f != free || p != pro {
+		t.Fatalf("pro-then-free: expected ok with (free,pro), got ok=%v f=%v p=%v", ok, f, p)
+	}
+
+	notPair := &PluginManifest{Name: "search-collision", Tier: "free"}
+	notPair2 := &PluginManifest{Name: "search-collision", Tier: "pro"}
+	if _, _, ok := splitTierPair([]*PluginManifest{notPair, notPair2}); ok {
+		t.Fatal("neither entry declares TierPair — must not resolve as a pair")
+	}
+
+	twoFree := &PluginManifest{Name: "x", Tier: "free", TierPair: true}
+	twoFreeB := &PluginManifest{Name: "x", Tier: "free", TierPair: true}
+	if _, _, ok := splitTierPair([]*PluginManifest{twoFree, twoFreeB}); ok {
+		t.Fatal("two free entries is not a valid tier pair")
+	}
+}


### PR DESCRIPTION
## What / why

OWNER-ACTIONS.md item 15 (decision (b), 2026-09-04): the served registry lists `cron` and `notify` twice (free then pro). `findPlugin`/`GetPlugin` returned the first match, so `nself plugin install cron` silently installed the free tier even for a customer entitled to pro.

## Changes

- `internal/plugin/interfaces.go`, `registry_parse.go`, `registry_json.go`, `registry_cache.go`: `PluginManifest`/`pluginEntry` gain `TierPair bool` (`tier_pair`) and `Bundles []string` (`bundles`), wired through parsing and the cache round-trip so `TestRegistryRoundTripLosesNoField` continues to guard them.
- `internal/plugin/tier_resolve.go` (new): `ResolvePlugin` — a declared tier pair (`TierPair: true` on both entries) resolves by `license.BundleEntitled` against the pro entry's `Bundles`, defaulting to free on no entitlement / no key / network error. Any other same-slug duplicate is refused (`errs.ErrDuplicatePluginSlug`), naming every colliding entry — never a silent first-match.
- `internal/plugin/installer_locked.go`: Step 2 now calls `ResolvePlugin` instead of `findPlugin`.
- `nself plugin install <slug> --tier free|pro`: explicit override. `--tier free` always succeeds; `--tier pro` still runs the entitlement check (`errs.ErrTierNotEntitled`) — an override is a request, not a licensing bypass. Threaded via `NSELF_PLUGIN_INSTALL_TIER`, matching the existing `NSELF_SKIP_SBOM_CHECK` / `NSELF_PLUGIN_LICENSE_KEY` env-var convention (no signature change to `plugin.Install`).
- `internal/plugin/tier_list.go` (new) + `nself plugin list --available`: shows every tier of every multi-entry slug with the resolved default marked.
- `bundle/installer.go`'s `plugin.Install` call sites never set the override, so a bundle's `tier_pair` members resolve by entitlement automatically — no bundle-side change needed.
- `.github/wiki/cmd-plugin.md` + `.github/command-inventory.json`: new "A slug served as both free and pro" section, examples, and regenerated flag inventory (`--tier`, `--available`).

## Acceptance evidence

- `go build ./...` — clean.
- `go vet ./internal/plugin/... ./cmd/commands/...` — clean.
- `gofmt -l .` — empty.
- `go test ./internal/plugin/...` — 358 passed (includes 13 new table-driven `ResolvePlugin`/`splitTierPair` cases: entitled pro default, not-entitled free default, entitlement-check-error fails closed to free, `--tier free` override, `--tier pro` override with/without entitlement, single free/pro entries with and without an override, non-tier_pair duplicate hard error naming both entries, not-found, invalid `--tier` value).
- `go test ./internal/bundle/...` — 46 passed (unaffected).
- `go test ./cmd/commands/...` — 903 passed.
- Rebased onto main after #365 merged (squash): `git rebase --onto origin/main <old-FIX-CLI-base> p6/plugin-tier-resolution` — clean, no conflicts, exactly this branch's 2 commits on top of main.
- Live probe confirmed the fixture matches production shape: `curl -s "https://plugins.nself.org/registry.json?tier=pro"` shows `cron`/`notify` pro entries with `"bundles": ["claw"]` (served registry does not yet carry `tier_pair: true` — that lands with plugins#77 / plugins-pro#121, still open; `ResolvePlugin` degrades to the non-tier_pair duplicate hard error until then, which is correct, not a regression).

## Test plan

- [x] Unit tests above
- [ ] Once plugins#77 + plugins-pro#121 (tier_pair markers) merge: live-verify `nself plugin install cron` resolves to pro with an entitled ɳClaw/ɳSelf+ key and to free without one