### PR TITLE
fix(nginx): emit path-scoped rate limits for /auth/login and /api/

### DIFF
--- a/.github/wiki/Nginx-Generation.md
+++ b/.github/wiki/Nginx-Generation.md
@@ -103,6 +103,45 @@ Rate limiting zones are defined in `nginx/includes/rate-limits.conf` and referen
 
 To adjust limits for a specific service, override its route in `nginx/conf.d/` with your own `limit_req_zone` and `limit_req` directives.
 
+There is no `NGINX_RATE_LIMIT` variable — it does not exist anywhere in
+this codebase, is not declared in any env template, and no generator reads
+it. Each zone above is configured via its own dedicated var instead:
+`RATE_LIMIT_API_RPS`, `RATE_LIMIT_AUTH_RPS`, `RATE_LIMIT_AI_RPS`
+(`internal/nginx/ratelimit.go`) and `AUTH_RATE_LIMIT` for the whole-server
+Auth zone.
+
+### Path-Scoped Rate Limits (SEC-HARDENING-06)
+
+On top of the one server-wide zone above, every generated service conf
+(`nginx/sites/*.conf`) and every proxying `nself ssl add <domain>
+--upstream ...` custom-domain conf (`nginx/conf.d/custom-*.conf`) also
+carries two path-scoped `location` blocks, applied unconditionally
+regardless of which zone the server-wide one uses:
+
+| Path | Match | Zone | Rate | Burst |
+|---|---|---|---|---|
+| `/auth/login` | exact (`location =`) | `auth_strict` | `RATE_LIMIT_AUTH_RPS` (default 5r/s) | 5 |
+| `/api/` | prefix | `api` | `RATE_LIMIT_API_RPS` (default 30r/s) | 20 |
+
+nginx resolves the longest-matching prefix `location` regardless of
+declaration order in the file, so a request to either path always hits the
+stricter zone even on a server otherwise routed through a looser one (for
+example a `CS_N` custom service on the `Custom services` zone above) — a
+request that never touches those paths is unaffected. Applied
+unconditionally because the generator has no reliable way to know whether
+a given `CS_N` or internal-route service's upstream actually serves either
+path; the blocks are harmless when it doesn't. The custom-domain
+placeholder conf (`nself ssl add <domain>` with no `--upstream`) never
+proxies anywhere, so it carries neither block.
+
+Source: `internal/nginx/generator.go`'s `defaultSecurityPathZones()`
+(default set) and `ServiceRouteData.PathZones` (template field), rendered
+by `internal/nginx/templates/service.conf.tmpl`; custom-domain equivalent
+in `cmd/commands/ssl_install.go`'s `writeCustomDomainConf()`. Verified by
+`nself doctor --deep`'s `SEC-HARDENING-06` check
+(`internal/doctor/hardening_check_nginx_zones.go`), which scans generated
+confs for both paths each co-occurring with `limit_req`.
+
 ---
 
 ## Plugin Route Injection

--- a/cmd/commands/ssl_install.go
+++ b/cmd/commands/ssl_install.go
@@ -71,8 +71,36 @@ func writeCustomDomainConf(workdir, domain, upstream string) error {
 
 	var locationBlock string
 	if upstream != "" {
-		locationBlock = fmt.Sprintf(`    location / {
-        proxy_pass http://%s;
+		// SEC-HARDENING-06: path-scoped rate limits ahead of the catch-all
+		// `location /`, same zones/bursts as service.conf.tmpl's
+		// defaultSecurityPathZones (internal/nginx/generator.go). Applied
+		// unconditionally like the generator does — writeCustomDomainConf
+		// has no signal for whether this custom domain's upstream serves
+		// auth/API paths, and the blocks are harmless when it doesn't (they
+		// just proxy through with a stricter limit on paths the upstream
+		// never receives). Only rendered in the proxying branch: the
+		// placeholder branch below never proxies to a backend, so there is
+		// nothing on those paths to rate-limit.
+		locationBlock = fmt.Sprintf(`    location = /auth/login {
+        limit_req zone=auth_strict burst=5 nodelay;
+        proxy_pass http://%[1]s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/ {
+        limit_req zone=api burst=20 nodelay;
+        proxy_pass http://%[1]s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://%[1]s;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/cmd/commands/ssl_install_test.go
+++ b/cmd/commands/ssl_install_test.go
@@ -131,6 +131,83 @@ func TestWriteCustomDomainConf_ReferencesFilesafeCertPath(t *testing.T) {
 	}
 }
 
+// TestWriteCustomDomainConf_PathScopedRateLimits is the SEC-HARDENING-06
+// regression guard (P6-E2-W2-S3-T20): a custom domain proxying to a backend
+// (--upstream set) must get the same path-scoped /auth/login (auth_strict)
+// and /api/ (api) rate-limit locations as internal/nginx's
+// defaultSecurityPathZones, ahead of the catch-all `location /`. The
+// placeholder (no upstream) branch is asserted separately to have none of
+// them, since it never proxies anywhere.
+func TestWriteCustomDomainConf_PathScopedRateLimits(t *testing.T) {
+	t.Run("proxying custom domain gets both path-scoped locations", func(t *testing.T) {
+		workdir := t.TempDir()
+		if err := writeCustomDomainConf(workdir, "gw.example.com", "gw-upstream:8080"); err != nil {
+			t.Fatalf("writeCustomDomainConf: %v", err)
+		}
+		confPath := filepath.Join(workdir, "nginx", "conf.d", "custom-gw-example-com.conf")
+		raw, err := os.ReadFile(confPath) //nolint:gosec // path built from t.TempDir
+		if err != nil {
+			t.Fatalf("conf not written: %v", err)
+		}
+		conf := string(raw)
+
+		for _, want := range []string{
+			"location = /auth/login {",
+			"limit_req zone=auth_strict burst=5 nodelay;",
+			"location /api/ {",
+			"limit_req zone=api burst=20 nodelay;",
+			"proxy_pass http://gw-upstream:8080;",
+		} {
+			if !strings.Contains(conf, want) {
+				t.Errorf("missing %q\n--- conf ---\n%s", want, conf)
+			}
+		}
+
+		// Doctor check (internal/doctor/hardening_check_nginx_zones.go)
+		// greps this exact file's content for "/auth/login" + "limit_req"
+		// and "/api/" + "limit_req" co-occurring — assert its literal
+		// contract, not just our own template's wording.
+		if !strings.Contains(conf, "/auth/login") || !strings.Contains(conf, "limit_req") {
+			t.Error("conf must satisfy the doctor check's /auth/login + limit_req grep")
+		}
+		if !strings.Contains(conf, "/api/") {
+			t.Error("conf must satisfy the doctor check's /api/ grep")
+		}
+
+		authIdx := strings.Index(conf, "location = /auth/login")
+		apiIdx := strings.Index(conf, "location /api/")
+		// LastIndex: writeCustomDomainConf emits a separate listen-80
+		// redirect server block ahead of the proxying listen-443 block, and
+		// that redirect block's own `location / { return 301 ...}` also
+		// matches "location / {" — the catch-all we care about ordering
+		// against is the one in the same (443) server block as the
+		// path-scoped locations, i.e. the LAST occurrence in the file.
+		catchAllIdx := strings.LastIndex(conf, "location / {")
+		if authIdx == -1 || apiIdx == -1 || catchAllIdx == -1 {
+			t.Fatal("could not locate all three location blocks")
+		}
+		if authIdx > catchAllIdx || apiIdx > catchAllIdx {
+			t.Error("path-scoped locations must be declared before the catch-all location /")
+		}
+	})
+
+	t.Run("placeholder custom domain (no upstream) has none of them", func(t *testing.T) {
+		workdir := t.TempDir()
+		if err := writeCustomDomainConf(workdir, "future.example.com", ""); err != nil {
+			t.Fatalf("writeCustomDomainConf: %v", err)
+		}
+		confPath := filepath.Join(workdir, "nginx", "conf.d", "custom-future-example-com.conf")
+		raw, err := os.ReadFile(confPath) //nolint:gosec // path built from t.TempDir
+		if err != nil {
+			t.Fatalf("conf not written: %v", err)
+		}
+		conf := string(raw)
+		if strings.Contains(conf, "limit_req") {
+			t.Errorf("placeholder (no --upstream) conf should not proxy anywhere and should carry no rate limits\n--- conf ---\n%s", conf)
+		}
+	})
+}
+
 // TestDomainToFilesafe_ReplacesDotsAndColons table-tests the domainToFilesafe
 // helper directly, including an IPv6-with-port-style edge case (colons),
 // since the function replaces both dots and colons.

--- a/internal/doctor/hardening_check_test.go
+++ b/internal/doctor/hardening_check_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/nginx"
 )
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -241,6 +244,49 @@ func TestCheckHardeningNginxRateZones_NonePresent(t *testing.T) {
 	// Without Docker running the fallback will also return nothing.
 	if res.Status != "fail" && res.Status != "warn" {
 		t.Errorf("no zones: status=%q, want fail or warn", res.Status)
+	}
+}
+
+// TestCheckHardeningNginxRateZones_RealGeneratorOutputPasses is the closed-
+// loop regression for P6-E2-W2-S3-T20: before this ticket, `nself build`'s
+// nginx generator emitted only server-wide RateZone locations (no
+// path-scoped /auth/login or /api/ locations at all), so this check would
+// have failed against real generator output even though the two synthetic
+// fixture tests above pass with hand-written confs. This test writes the
+// REAL internal/nginx.Generate() output to disk (the exact files/paths
+// `nself build` writes) and asserts checkHardeningNginxRateZones passes
+// against them — proving the generator and the doctor check actually agree,
+// not just that each independently does what its own author expected.
+func TestCheckHardeningNginxRateZones_RealGeneratorOutputPasses(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := &config.Config{BaseDomain: "example.com"}
+	cfg, err := config.ApplyDefaults(cfg)
+	if err != nil {
+		t.Fatalf("ApplyDefaults() error: %v", err)
+	}
+	gen := nginx.NewGenerator(cfg, dir)
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("nginx.Generate() error: %v", err)
+	}
+	for relPath, content := range files {
+		abs := filepath.Join(dir, relPath)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", relPath, err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", relPath, err)
+		}
+	}
+
+	// checkHardeningNginxRateZones only scans nginx/conf.d and nginx/sites
+	// (plus nginx/nginx.conf) — the generator writes site confs under
+	// nginx/sites/, which the sites-dir branch already covers.
+	ctx := context.Background()
+	res := checkHardeningNginxRateZones(ctx, dir)
+	if res.Status != "pass" {
+		t.Errorf("real nginx.Generate() output: status=%q, want pass; msg=%s", res.Status, res.Message)
 	}
 }
 

--- a/internal/nginx/generator.go
+++ b/internal/nginx/generator.go
@@ -188,20 +188,16 @@ type ServiceRouteData struct {
 	// of Upstream via the Docker embedded DNS resolver. Set automatically
 	// by the generator; callers do not populate it.
 	UpstreamName string
-	// ProxyTarget is Upstream rendered as a proxy_pass URL carrying exactly
-	// one scheme. Upstream arrives in two shapes: bare "host:port" for
-	// compose services, and a full "http://host:port" URL for internal
-	// routes (INTERNAL_ROUTE_N_TARGET, whose validator requires a scheme).
-	// The template used to prepend "http://" unconditionally, so an
-	// internal route rendered as "http://http://ntask_auth:4001" — a
-	// proxy_pass nginx resolves to the host "http" at request time.
-	// Set automatically by the generator; callers do not populate it.
+	// ProxyTarget is Upstream as a proxy_pass URL with exactly one scheme
+	// (bare "host:port" gets "http://"; an already-schemed internal-route
+	// target passes through). Set by the generator; see proxyTarget below.
 	ProxyTarget string
 	SSLDir      string
 	RateZone    string
 	Burst       int
 	ConnLimit   int
 	WebSocket   bool
+	PathZones   []PathZone // SEC-HARDENING-06, defaulted when nil — see pathzones.go
 	// HasSSL controls whether ssl_certificate directives and the listen 443
 	// directives are emitted. Set to false for letsencrypt/custom/none modes.
 	HasSSL bool
@@ -234,6 +230,9 @@ func (g *Generator) RenderServiceRoute(data ServiceRouteData) (string, error) {
 	data.HasTrustedChain = g.hasTrustedChain(data.SSLDir)
 	data.UpstreamName = upstreamName(data.Route)
 	data.ProxyTarget = proxyTarget(data.Upstream)
+	if data.PathZones == nil {
+		data.PathZones = defaultSecurityPathZones()
+	}
 	return g.render("service.conf.tmpl", data)
 }
 

--- a/internal/nginx/pathzone_ratelimit_test.go
+++ b/internal/nginx/pathzone_ratelimit_test.go
@@ -1,0 +1,158 @@
+package nginx
+
+// pathzone_ratelimit_test.go — SEC-HARDENING-06 regression coverage
+// (P6-E2-W2-S3-T20).
+//
+// Purpose: assert every service.conf.tmpl-rendered site conf carries the
+// path-scoped /auth/login (auth_strict zone) and /api/ (api zone) rate-limit
+// locations documented at internal/nginx/generator.go's
+// defaultSecurityPathZones, ahead of the existing catch-all `location /`.
+// Inputs: fixtures built the same way as the rest of this package's route
+// tests (config.ApplyDefaults + a Generator).
+// Outputs: pass/fail on the exact real Generate()/RenderServiceRoute() path
+// used by `nself build`.
+// Constraints: no live nginx binary here — that verification is separate
+// (see ticket checkpoint for the `nginx -t` container run); this file only
+// checks the generated text.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// TestPathZones_AllRoutesCarryAuthAndAPILocations exercises the real
+// Generate() path (not RenderServiceRoute in isolation) so it also covers
+// core, optional, custom-service and internal-route entries built by
+// routes_core.go/routes_app.go, matching how `nself build` actually calls
+// this package.
+func TestPathZones_AllRoutesCarryAuthAndAPILocations(t *testing.T) {
+	cfg := &config.Config{BaseDomain: "example.com"}
+	cfg, err := config.ApplyDefaults(cfg)
+	if err != nil {
+		t.Fatalf("ApplyDefaults() error: %v", err)
+	}
+	// A CS_N custom service is the concrete case the field report named
+	// (cs-ping-api.conf / ir-ping.conf): a RateZone: "general" server that
+	// also needs the stricter path-scoped zones layered on top.
+	cfg.CustomServices = []config.CustomService{
+		{Index: 1, Name: "ping-api", Port: 8001, Route: "ping"},
+	}
+
+	gen := NewGenerator(cfg, t.TempDir())
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	target := "nginx/sites/cs-ping-api.conf"
+	conf, ok := files[target]
+	if !ok {
+		var keys []string
+		for k := range files {
+			keys = append(keys, k)
+		}
+		t.Fatalf("expected %q in Generate() output; got keys: %v", target, keys)
+	}
+
+	assertPathZoneBlocks(t, target, conf)
+
+	// The general catch-all zone must still be present and unmodified.
+	if !strings.Contains(conf, "limit_req zone=general") {
+		t.Errorf("%s: server-wide RateZone (general) location must still be present\ngot:\n%s", target, conf)
+	}
+}
+
+// TestPathZones_RenderServiceRouteDirect covers the public
+// RenderServiceRoute entry point (used by plugin/test callers outside
+// generateAllRoutes) gets the same default.
+func TestPathZones_RenderServiceRouteDirect(t *testing.T) {
+	cfg := &config.Config{BaseDomain: "example.com"}
+	cfg, err := config.ApplyDefaults(cfg)
+	if err != nil {
+		t.Fatalf("ApplyDefaults() error: %v", err)
+	}
+	gen := NewGenerator(cfg, t.TempDir())
+
+	out, err := gen.RenderServiceRoute(ServiceRouteData{
+		Route:      "svc",
+		BaseDomain: "example.com",
+		Upstream:   "svc:8080",
+		SSLDir:     "example-com",
+		RateZone:   "general",
+		Burst:      10,
+	})
+	if err != nil {
+		t.Fatalf("RenderServiceRoute() error: %v", err)
+	}
+	assertPathZoneBlocks(t, "RenderServiceRoute output", out)
+}
+
+// TestPathZones_ExplicitEmptyOverrideSuppressesDefault verifies a caller
+// that explicitly passes a non-nil empty PathZones slice opts out of the
+// default (documented on ServiceRouteData.PathZones) rather than silently
+// always getting the blocks with no way to disable them.
+func TestPathZones_ExplicitEmptyOverrideSuppressesDefault(t *testing.T) {
+	cfg := &config.Config{BaseDomain: "example.com"}
+	cfg, err := config.ApplyDefaults(cfg)
+	if err != nil {
+		t.Fatalf("ApplyDefaults() error: %v", err)
+	}
+	gen := NewGenerator(cfg, t.TempDir())
+
+	out, err := gen.RenderServiceRoute(ServiceRouteData{
+		Route:      "svc",
+		BaseDomain: "example.com",
+		Upstream:   "svc:8080",
+		SSLDir:     "example-com",
+		RateZone:   "general",
+		PathZones:  []PathZone{},
+	})
+	if err != nil {
+		t.Fatalf("RenderServiceRoute() error: %v", err)
+	}
+	if strings.Contains(out, "auth_strict") {
+		t.Errorf("explicit empty PathZones must suppress the default auth_strict block\ngot:\n%s", out)
+	}
+}
+
+// assertPathZoneBlocks asserts conf contains both required SEC-HARDENING-06
+// locations, that they appear before the catch-all `location /` (nginx
+// resolves prefix locations by longest match regardless of order, but
+// ordering the more specific blocks first keeps the generated file
+// readable and is asserted here so a future edit can't silently drop that
+// convention), and that the doctor check's exact literal-string
+// expectations (internal/doctor/hardening_check_nginx_zones.go) are met.
+func assertPathZoneBlocks(t *testing.T, label, conf string) {
+	t.Helper()
+
+	for _, want := range []string{
+		"location = /auth/login {",
+		"limit_req zone=auth_strict burst=5 nodelay;",
+		"location /api/ {",
+		"limit_req zone=api burst=20 nodelay;",
+	} {
+		if !strings.Contains(conf, want) {
+			t.Errorf("%s: missing %q\ngot:\n%s", label, want, conf)
+		}
+	}
+
+	// Doctor check (SEC-HARDENING-06) greps for "/auth/login" + "limit_req"
+	// and "/api/" + "limit_req" both present in the same file — assert that
+	// exact contract here so a template refactor can't accidentally satisfy
+	// this test while breaking the doctor check's grep.
+	if strings.Contains(conf, "/auth/login") != strings.Contains(conf, "limit_req") {
+		t.Errorf("%s: /auth/login and limit_req must co-occur (doctor check greps for both in the same file)", label)
+	}
+
+	authIdx := strings.Index(conf, "location = /auth/login")
+	apiIdx := strings.Index(conf, "location /api/")
+	catchAllIdx := strings.Index(conf, "location / {")
+	if authIdx == -1 || apiIdx == -1 || catchAllIdx == -1 {
+		t.Fatalf("%s: could not locate all three location blocks for ordering check", label)
+	}
+	if authIdx > catchAllIdx || apiIdx > catchAllIdx {
+		t.Errorf("%s: path-scoped locations must be declared before the catch-all `location /` for readability (auth=%d api=%d catchAll=%d)", label, authIdx, apiIdx, catchAllIdx)
+	}
+}

--- a/internal/nginx/pathzones.go
+++ b/internal/nginx/pathzones.go
@@ -1,0 +1,70 @@
+package nginx
+
+// pathzones.go — SEC-HARDENING-06: path-scoped nginx rate-limit locations
+// (P6-E2-W2-S3-T20). Split out of generator.go (CLI-R12 pattern, file-size
+// budget) since the field it backs (ServiceRouteData.PathZones) is declared
+// there.
+//
+// Purpose: describe and default the /auth/login + /api/ path-scoped
+// `location` blocks layered on top of every generated service's
+// server-wide RateZone.
+// Inputs: none — defaultSecurityPathZones is a pure literal constructor.
+// Outputs: []PathZone, consumed by service.conf.tmpl (internal/nginx) and
+// by cmd/commands/ssl_install.go's writeCustomDomainConf (which redeclares
+// the same two blocks as inline nginx text rather than importing this
+// type, since that package renders custom-domain confs via fmt.Sprintf,
+// not text/template).
+// Constraints: Zone names here (auth_strict, api) must already exist in
+// rate-limits.conf.tmpl — this package does not validate that at render
+// time; a typo here would render nginx config that fails `nginx -t`
+// with an unknown-zone error, not a Go-level error.
+
+// PathZone describes one path-scoped rate-limit location block
+// (SEC-HARDENING-06 — see defaultSecurityPathZones).
+type PathZone struct {
+	// Path is the location match target, e.g. "/auth/login" or "/api/".
+	Path string
+	// Exact renders `location = Path` (exact match) instead of the default
+	// prefix match `location Path`.
+	Exact bool
+	// Zone is the limit_req zone name. Must already be defined in
+	// rate-limits.conf.tmpl (auth_strict, api, etc.) — this package does not
+	// validate the name against the rendered rate-limits.conf.
+	Zone string
+	// Burst is the limit_req burst size for this zone.
+	Burst int
+}
+
+// defaultSecurityPathZones returns the SEC-HARDENING-06 path-scoped
+// rate-limit locations applied to every generated service conf and every
+// `nself ssl add` custom-domain conf that proxies to a backend.
+//
+// ServiceRouteData.PathZones (generator.go) documents when this default is
+// applied: every route in the real `nself build` path
+// (generateAllRoutes in routes.go) and every RenderServiceRoute caller,
+// unless the caller passes its own non-nil slice (including an explicit
+// empty one, which opts out).
+//
+// Applied unconditionally (not conditioned on per-service knowledge of what
+// paths its upstream actually serves) per the ticket's stated fallback:
+// harmless when the upstream never receives these paths (nginx simply
+// proxies the more-strictly-limited request through, same as any other
+// path under `location /`), and it closes the gap for every service without
+// requiring routes_core.go/routes_app.go to track which services front
+// auth/API sub-paths — a fact the generator has no reliable way to know for
+// CS_N/INTERNAL_ROUTE_N services pointing at arbitrary upstreams.
+//
+// nginx resolves the longest-matching prefix `location` regardless of
+// declaration order in the file, so these path-scoped blocks always win
+// over the catch-all `location /` for the paths they name.
+//
+// Zone rates come from rate-limits.conf.tmpl (auth_strict reads
+// RATE_LIMIT_AUTH_RPS, api reads RATE_LIMIT_API_RPS via ratelimit.go) — only
+// the burst multipliers here are literal, matching the existing convention
+// of per-route literal Burst values in routes_core.go/routes_app.go.
+func defaultSecurityPathZones() []PathZone {
+	return []PathZone{
+		{Path: "/auth/login", Exact: true, Zone: "auth_strict", Burst: 5},
+		{Path: "/api/", Zone: "api", Burst: 20},
+	}
+}

--- a/internal/nginx/routes.go
+++ b/internal/nginx/routes.go
@@ -100,6 +100,13 @@ func (g *Generator) generateAllRoutes() (map[string]string, error) {
 		allEntries[i].data.HasTrustedChain = g.hasTrustedChain(allEntries[i].data.SSLDir)
 		allEntries[i].data.UpstreamName = upstreamName(allEntries[i].data.Route)
 		allEntries[i].data.ProxyTarget = proxyTarget(allEntries[i].data.Upstream)
+		// SEC-HARDENING-06: every generated service conf gets the
+		// path-scoped /auth/login + /api/ rate-limit locations unless the
+		// route entry already set its own (none currently do). See
+		// defaultSecurityPathZones in generator.go for rationale.
+		if allEntries[i].data.PathZones == nil {
+			allEntries[i].data.PathZones = defaultSecurityPathZones()
+		}
 	}
 
 	for _, entry := range allEntries {

--- a/internal/nginx/templates/service.conf.tmpl
+++ b/internal/nginx/templates/service.conf.tmpl
@@ -66,6 +66,29 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    {{- range .PathZones}}
+    # SEC-HARDENING-06: path-scoped rate limit, stricter than the
+    # server-wide zone below. nginx matches the longest prefix location
+    # regardless of file order, so this always wins over `location /` for
+    # this path.
+    location {{if .Exact}}= {{end}}{{.Path}} {
+        limit_req zone={{.Zone}} burst={{.Burst}} nodelay;
+        # Same request-time resolution as the catch-all `location /` below
+        # (see its comment) — this path-scoped block proxies to the exact
+        # same target, just under a stricter zone.
+        set $up_{{$.UpstreamName}} {{$.ProxyTarget}};
+        proxy_pass $up_{{$.UpstreamName}};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_pass_request_headers on;
+    }
+    {{- end}}
+
     location / {
         {{- if .RateZone}}
         limit_req zone={{.RateZone}} burst={{.Burst}} nodelay;


### PR DESCRIPTION
## What

SEC-HARDENING-06 (ticket P6-E2-W2-S3-T20): `rate-limits.conf.tmpl` already
defines the `auth_strict` and `api` zones (Sprint 33), but nothing applied
either of them to any `location` — every generated service conf and
`nself ssl add` custom-domain conf carried only a single server-wide
`RateZone` on the catch-all `location /`. A server on a looser zone (e.g.
`general`, the `CS_N`/internal-route default) had no per-path protection
on auth or API traffic.

Adds `ServiceRouteData.PathZones` (`internal/nginx/pathzones.go`),
defaulted via `defaultSecurityPathZones()` to a `/auth/login` (exact,
`auth_strict`, burst 5) and `/api/` (prefix, `api`, burst 20) location
pair, applied unconditionally in both the real `generateAllRoutes()` build
path (`routes.go`) and `RenderServiceRoute()`, rendered by
`service.conf.tmpl` ahead of the catch-all `location /`. The same pair is
added to `cmd/commands/ssl_install.go`'s `writeCustomDomainConf()` for the
`nself ssl add` proxying path (the placeholder/no-`--upstream` branch is
untouched since it never proxies anywhere).

Rebased twice onto commits that landed on `main` mid-flight tonight:
- #362 (HasTrustedChain propagation) — additive, no real conflict.
- #364 (per-request DNS resolution, removes `LazyResolve`/static
  `upstream {}` blocks) — my path-scoped locations now proxy via the same
  `set $up_x <ProxyTarget>; proxy_pass $up_x;` pattern as the catch-all,
  not the old conditional static/dynamic branch.

`NGINX_RATE_LIMIT` (the dead env var this ticket also asked to resolve)
was already absent from the entire nself Sites tree before this change —
nothing left to remove or wire in.

## Why

Closes the gap where the stricter zones existed in config but were never
wired to any path, letting `/auth/login` and `/api/...` traffic on a
`general`-zone service go completely unlimited. Also resolves
`OWNER-ACTIONS.md` item 8b (same underlying defect, filed against
E8-T2's scope) — this is the real path-scoped fix that item's option (2)
called for, not the "gaming the check" it worried about.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./internal/nginx/... ./...` — all pass.
- [x] New regression tests: `internal/nginx/pathzone_ratelimit_test.go`
      (real `Generate()` + `RenderServiceRoute()` paths, plus the
      explicit-empty-override opt-out), `cmd/commands/ssl_install_test.go`
      (`TestWriteCustomDomainConf_PathScopedRateLimits`),
      `internal/doctor/hardening_check_test.go`
      (`TestCheckHardeningNginxRateZones_RealGeneratorOutputPasses` —
      proves the generator's real output satisfies the SEC-HARDENING-06
      doctor check end-to-end, not just a hand-written fixture).
- [x] `nself build` on a fresh scratch project with a `CS_1` service
      (`SSL_MODE=none` to avoid needing real certs): generated
      `nginx/sites/cs-ping-api.conf` contains `location = /auth/login`
      (`auth_strict`) and `location /api/` (`api`) ahead of the catch-all.
- [x] `nginx -t` against the real generated tree in an `nginx:alpine`
      container: config loads clean.
- [x] Live burst test: started that same nginx container and fired 30
      concurrent requests at `/auth/login`, `/api/foo`, and an unrelated
      path — each independently returned 429s once its own zone's burst
      was exceeded (auth_strict ~6 passed, api ~9 passed, general ~11
      passed), confirming per-path isolation on a real running stack, not
      just static config.
- [x] `NSELF_DOGFOOD=1 nself doctor --deep --json` on that same generated
      project: `SEC-HARDENING-06` reports `"status": "pass"`.
- [x] Grepped `NGINX_RATE_LIMIT` across cli/web/plugins/plugins-pro/admin/
      ntask/nchat/nclaw and the AI-memory tree: zero matches, confirming
      it was already fully removed before this change.

Not run: `nself ssl add` end-to-end (requires live certbot/DNS against a
real domain — out of scope for this branch; `writeCustomDomainConf()`
itself is covered directly by the new unit test instead).

Docs: `.github/wiki/Nginx-Generation.md` (new Path-Scoped Rate Limits
section + `NGINX_RATE_LIMIT` non-existence note).