### PR TITLE
fix(nginx): fail the build on a duplicate server_name, naming both files

### DIFF
--- a/internal/build/nginx_server_blocks.go
+++ b/internal/build/nginx_server_blocks.go
@@ -1,0 +1,144 @@
+package build
+
+// nginx_server_blocks.go — a minimal reader for the generated nginx site
+// configs, used to detect two server blocks claiming one FQDN on one port.
+//
+// Purpose: split rendered nginx config text into server blocks and report
+// the listen ports and server_names each one declares.
+// Inputs: the text of a .conf file under nginx/sites/.
+// Outputs: []nginxServerBlock, one per `server { ... }` in the file.
+// Constraints: a targeted reader for nginx site configs, not a general
+// nginx parser — it tokenizes on { } ; and reads two directives, and does
+// not evaluate includes, maps, or upstreams. It works on both the
+// multi-line form this repo generates and the compact single-line form a
+// hand-written or plugin-shipped conf may use, because it tokenizes rather
+// than matching at the start of a line. Anything it cannot interpret it
+// ignores, so the worst case is a missed conflict, never a fabricated one.
+
+import (
+	"strconv"
+	"strings"
+)
+
+// nginxServerBlock is one `server { ... }` block: the ports it listens on
+// and the names it answers for.
+type nginxServerBlock struct {
+	Ports       []string
+	ServerNames []string
+}
+
+// defaultListenPort is what nginx assumes when a server block declares a
+// server_name but no listen directive at all.
+const defaultListenPort = "80"
+
+// parseServerBlocks splits content into its `server { ... }` blocks.
+//
+// Directives are attributed to the block that encloses them, so a file with
+// an http-only block and an https block is read as two blocks rather than
+// one merged set. That distinction matters: nginx only calls it a conflict
+// when two blocks collide on the same name AND the same port.
+func parseServerBlocks(content string) []nginxServerBlock {
+	var blocks []nginxServerBlock
+	// stack of open blocks; the element is the index into blocks for a
+	// server block, or -1 for any other context (http, location, upstream).
+	var stack []int
+	var buf strings.Builder
+
+	flushHeader := func() string {
+		h := strings.TrimSpace(buf.String())
+		buf.Reset()
+		return h
+	}
+
+	for _, ch := range stripComments(content) {
+		switch ch {
+		case '{':
+			header := flushHeader()
+			idx := -1
+			if firstWord(header) == "server" {
+				blocks = append(blocks, nginxServerBlock{})
+				idx = len(blocks) - 1
+			}
+			stack = append(stack, idx)
+		case '}':
+			buf.Reset()
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		case ';':
+			directive := flushHeader()
+			// Attribute the directive to the nearest enclosing server block.
+			for i := len(stack) - 1; i >= 0; i-- {
+				if stack[i] < 0 {
+					continue
+				}
+				b := &blocks[stack[i]]
+				if names := serverNamesIn(directive); len(names) > 0 {
+					b.ServerNames = append(b.ServerNames, names...)
+				} else if port, ok := listenPortIn(directive); ok {
+					b.Ports = append(b.Ports, port)
+				}
+				break
+			}
+		default:
+			buf.WriteRune(ch)
+		}
+	}
+	return blocks
+}
+
+// stripComments removes `#` comments, which run to end of line in nginx.
+func stripComments(content string) string {
+	var out strings.Builder
+	for _, line := range strings.Split(content, "\n") {
+		if idx := strings.Index(line, "#"); idx != -1 {
+			line = line[:idx]
+		}
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+// firstWord returns the first whitespace-separated word of s.
+func firstWord(s string) string {
+	if f := strings.Fields(s); len(f) > 0 {
+		return f[0]
+	}
+	return ""
+}
+
+// serverNamesIn returns the domains declared by a `server_name` directive,
+// or nil if directive is something else. Multiple space-separated names are
+// handled; `server_names_hash_bucket_size` is not a match.
+func serverNamesIn(directive string) []string {
+	fields := strings.Fields(directive)
+	if len(fields) < 2 || fields[0] != "server_name" {
+		return nil
+	}
+	return fields[1:]
+}
+
+// listenPortIn returns the port from a `listen` directive. Handles the
+// forms this repo generates and the common hand-written ones: "listen 443
+// ssl", "listen [::]:443 ssl", "listen 80", "listen 0.0.0.0:8080
+// default_server". A unix socket, or an address with no port, returns
+// ok=false.
+func listenPortIn(directive string) (string, bool) {
+	fields := strings.Fields(directive)
+	if len(fields) < 2 || fields[0] != "listen" {
+		return "", false
+	}
+	addr := fields[1]
+	if strings.HasPrefix(addr, "unix:") {
+		return "", false
+	}
+	// "[::]:443" and "0.0.0.0:8080" — the port follows the last colon.
+	if idx := strings.LastIndex(addr, ":"); idx != -1 {
+		addr = addr[idx+1:]
+	}
+	if _, err := strconv.Atoi(addr); err != nil {
+		return "", false
+	}
+	return addr, true
+}

--- a/internal/build/nginx_server_blocks_test.go
+++ b/internal/build/nginx_server_blocks_test.go
@@ -1,0 +1,109 @@
+package build
+
+// nginx_server_blocks_test.go — coverage for the shared nginx site-config
+// reader that both server_name conflict checks are built on.
+//
+// Purpose: prove the reader attributes listen/server_name to the right
+// block, reads the compact single-line form as well as the generated
+// multi-line form, and does not mistake `upstream`/`location` blocks or
+// `server_names_hash_bucket_size` for a server block or a server_name.
+// A conflict check is only as good as this parser: anything it fails to
+// read is a conflict that ships silently.
+
+import "testing"
+
+func TestParseServerBlocks_MultiLineAndCompactAgree(t *testing.T) {
+	multi := `
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name api.example.com;
+    location / {
+        proxy_pass http://hasura:8080;
+    }
+}
+`
+	compact := `server { listen 443 ssl; listen [::]:443 ssl; server_name api.example.com; location / { proxy_pass http://hasura:8080; } }`
+
+	for label, content := range map[string]string{"multi-line": multi, "compact": compact} {
+		blocks := parseServerBlocks(content)
+		if len(blocks) != 1 {
+			t.Errorf("%s: got %d server blocks, want 1: %+v", label, len(blocks), blocks)
+			continue
+		}
+		if len(blocks[0].ServerNames) != 1 || blocks[0].ServerNames[0] != "api.example.com" {
+			t.Errorf("%s: ServerNames = %v, want [api.example.com]", label, blocks[0].ServerNames)
+		}
+		if len(blocks[0].Ports) != 2 || blocks[0].Ports[0] != "443" || blocks[0].Ports[1] != "443" {
+			t.Errorf("%s: Ports = %v, want [443 443]", label, blocks[0].Ports)
+		}
+	}
+}
+
+func TestParseServerBlocks_SeparatesBlocks(t *testing.T) {
+	content := `
+upstream up_api {
+    server hasura:8080;
+}
+
+server {
+    listen 80;
+    server_name api.example.com;
+}
+
+server {
+    listen 443 ssl;
+    server_name docs.example.com;
+}
+`
+	blocks := parseServerBlocks(content)
+	if len(blocks) != 2 {
+		t.Fatalf("got %d blocks, want 2 (the upstream block must not count): %+v", len(blocks), blocks)
+	}
+	if blocks[0].ServerNames[0] != "api.example.com" || blocks[0].Ports[0] != "80" {
+		t.Errorf("block 0 = %+v, want api.example.com on 80", blocks[0])
+	}
+	if blocks[1].ServerNames[0] != "docs.example.com" || blocks[1].Ports[0] != "443" {
+		t.Errorf("block 1 = %+v, want docs.example.com on 443", blocks[1])
+	}
+}
+
+func TestParseServerBlocks_IgnoresLookalikes(t *testing.T) {
+	content := `
+http {
+    server_names_hash_bucket_size 128;
+    # server_name commented.example.com;
+    server {
+        server_name real.example.com;
+    }
+}
+`
+	blocks := parseServerBlocks(content)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1: %+v", len(blocks), blocks)
+	}
+	got := blocks[0].ServerNames
+	if len(got) != 1 || got[0] != "real.example.com" {
+		t.Errorf("ServerNames = %v, want [real.example.com] — a commented-out directive and server_names_hash_bucket_size must not register", got)
+	}
+}
+
+func TestListenPortIn(t *testing.T) {
+	cases := map[string]struct {
+		port string
+		ok   bool
+	}{
+		"listen 80":                          {"80", true},
+		"listen 443 ssl":                     {"443", true},
+		"listen [::]:443 ssl":                {"443", true},
+		"listen 0.0.0.0:8080 default_server": {"8080", true},
+		"listen unix:/var/run/n.sock":        {"", false},
+		"server_name api.example.com":        {"", false},
+	}
+	for directive, want := range cases {
+		port, ok := listenPortIn(directive)
+		if ok != want.ok || port != want.port {
+			t.Errorf("listenPortIn(%q) = (%q, %v), want (%q, %v)", directive, port, ok, want.port, want.ok)
+		}
+	}
+}

--- a/internal/build/plugin_nginx.go
+++ b/internal/build/plugin_nginx.go
@@ -2,30 +2,91 @@ package build
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/nself-org/cli/internal/config"
 )
 
-// checkPluginRouteConflict checks if a plugin's nginx route config conflicts
-// with an existing config in the sites directory or a core service route.
-func checkPluginRouteConflict(workdir string, pluginName string, destName string) error {
-	sitesDir := filepath.Join(workdir, "nginx", "sites")
+// claimsOf returns the set of "<port>|<server_name>" claims a rendered
+// nginx config makes, using the shared block parser in
+// nginx_server_blocks.go. Keying on port as well as name matches nginx's
+// own conflict rule: the same name served on :80 by one file and :443 by
+// another is a legitimate split, not a conflict.
+func claimsOf(content string) map[string]bool {
+	claims := make(map[string]bool)
+	for _, block := range parseServerBlocks(content) {
+		ports := block.Ports
+		if len(ports) == 0 {
+			ports = []string{defaultListenPort}
+		}
+		for _, name := range block.ServerNames {
+			if name == "_" {
+				continue // the catch-all default server, intentionally shared
+			}
+			for _, port := range ports {
+				claims[port+"|"+name] = true
+			}
+		}
+	}
+	return claims
+}
 
-	// Check if dest file already exists (not written by us in this run).
-	destPath := filepath.Join(sitesDir, destName)
-	if _, err := os.Stat(destPath); err == nil {
-		return fmt.Errorf("nginx route conflict: %s already exists in %s", destName, sitesDir)
+// checkServerNameConflict reports whether any server_name/port pair declared
+// in content is already claimed by a DIFFERENT .conf file already sitting in
+// sitesDir. destName is excluded from the scan so a plugin re-running
+// `nself build` and rewriting its own previously-injected file is not a
+// conflict with itself.
+//
+// Returns an error naming both files and the shared name so the build fails
+// loudly, instead of nginx silently picking one of two server blocks at
+// runtime (2026-09-03 staging: two generated site files both claimed
+// "api.staging.nself.org"; nginx logged "conflicting server name ...
+// ignored" and kept serving whichever loaded last).
+//
+// This is the early, precise check on the plugin-injection path.
+// checkServerNameUniqueness in postvalidate_nginx.go is the backstop that
+// sweeps the whole directory after every writer has run.
+func checkServerNameConflict(sitesDir, destName, content string) error {
+	newClaims := claimsOf(content)
+	if len(newClaims) == 0 {
+		return nil
 	}
 
-	// Check core service routes — files without the plugin prefix.
-	coreConf := filepath.Join(sitesDir, pluginName+".conf")
-	if _, err := os.Stat(coreConf); err == nil {
-		return fmt.Errorf("nginx route conflict: %s.conf already exists as a core service route", pluginName)
+	entries, err := os.ReadDir(sitesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", sitesDir, err)
 	}
 
+	// Sorted so the file named in the error is the same on every run;
+	// os.ReadDir order is not guaranteed across platforms.
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() && entry.Name() != destName {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		existing, readErr := os.ReadFile(filepath.Join(sitesDir, name))
+		if readErr != nil {
+			continue
+		}
+		existingClaims := claimsOf(string(existing))
+		for claim := range newClaims {
+			if !existingClaims[claim] {
+				continue
+			}
+			parts := strings.SplitN(claim, "|", 2)
+			return fmt.Errorf("nginx server_name conflict: %q on port %s is claimed by both %s and %s — nginx would silently ignore one of them (\"conflicting server name\"); rename one route or remove the duplicate", parts[1], parts[0], name, destName)
+		}
+	}
 	return nil
 }
 
@@ -63,6 +124,9 @@ func InjectPluginNginxRoutes(workdir, pluginDir string, cfg *config.Config) (int
 
 	count := 0
 	sitesDir := filepath.Join(workdir, "nginx", "sites")
+	if err := os.MkdirAll(sitesDir, 0755); err != nil {
+		return 0, fmt.Errorf("creating %s: %w", sitesDir, err)
+	}
 
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -98,10 +162,12 @@ func InjectPluginNginxRoutes(workdir, pluginDir string, cfg *config.Config) (int
 			destName := pluginName + "-" + filename
 			destPath := filepath.Join(sitesDir, destName)
 
-			// Warn on route conflicts but do not block — plugin may be
-			// replacing its own config on update.
-			if err := checkPluginRouteConflict(workdir, pluginName, destName); err != nil {
-				slog.Warn("plugin nginx route conflict — proceeding anyway", "plugin", pluginName, "err", err)
+			// A duplicate server_name across two site files is not a warning
+			// — nginx silently serves only one of them ("conflicting server
+			// name ... ignored"). Fail the build so the conflict is fixed
+			// before it ever reaches nginx, naming both sources.
+			if err := checkServerNameConflict(sitesDir, destName, rendered); err != nil {
+				return count, err
 			}
 
 			if err := os.WriteFile(destPath, []byte(rendered), 0644); err != nil {

--- a/internal/build/plugin_nginx_server_name_test.go
+++ b/internal/build/plugin_nginx_server_name_test.go
@@ -1,0 +1,317 @@
+package build
+
+// plugin_nginx_server_name_test.go — regression coverage for the 2026-09-03
+// staging incident: nginx logged `conflicting server name
+// "api.staging.nself.org" on 0.0.0.0:443, ignored` because two generated
+// site files under nginx/sites/ declared the same server_name. nginx does
+// not fail its config test over this — it silently serves whichever server
+// block loaded last, so the duplicate went unnoticed until a route behaved
+// unpredictably in production.
+//
+// Purpose: prove InjectPluginNginxRoutes refuses to write a plugin's nginx
+// route file when its server_name is already claimed by a different file in
+// nginx/sites/, and that this refusal is a hard error (fails the build),
+// not the warn-and-continue behavior it shipped with.
+// Inputs: a temp workdir with a pre-existing nginx/sites/ file and a temp
+// plugin directory with a conflicting/non-conflicting nginx/ route file.
+// Outputs: pass/fail on whether the conflict is caught and reported by name.
+// Constraints: exercises InjectPluginNginxRoutes exactly as orchestrator_build_ssl.go
+// calls it (Step 7.1), against a real filesystem via t.TempDir().
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+func minimalTestConfig(baseDomain string) *config.Config {
+	return &config.Config{
+		ProjectName: "testproj",
+		BaseDomain:  baseDomain,
+	}
+}
+
+// writeExistingSite writes a pre-existing nginx/sites/<name> file declaring
+// server_name serverName, simulating a core/optional/custom route the
+// nginx.Generator already wrote earlier in the same `nself build`.
+func writeExistingSite(t *testing.T, workdir, name, serverName string) {
+	t.Helper()
+	sitesDir := filepath.Join(workdir, "nginx", "sites")
+	if err := os.MkdirAll(sitesDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := "server {\n    listen 443 ssl;\n    server_name " + serverName + ";\n}\n"
+	if err := os.WriteFile(filepath.Join(sitesDir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// writePluginNginxRoute creates pluginDir/<pluginName>/nginx/<fileName>
+// declaring server_name serverName, simulating an installed plugin that
+// ships its own nginx route config.
+func writePluginNginxRoute(t *testing.T, pluginDir, pluginName, fileName, serverName string) {
+	t.Helper()
+	nginxDir := filepath.Join(pluginDir, pluginName, "nginx")
+	if err := os.MkdirAll(nginxDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := "server {\n    listen 443 ssl;\n    server_name " + serverName + ";\n}\n"
+	if err := os.WriteFile(filepath.Join(nginxDir, fileName), []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// TestInjectPluginNginxRoutes_RejectsDuplicateServerName reproduces the
+// staging incident directly: a core route (hasura.conf) already claims
+// "api.staging.nself.org" and a plugin ships a route that claims the exact
+// same server_name. InjectPluginNginxRoutes must fail the build and name
+// both files, not silently write the duplicate and warn.
+func TestInjectPluginNginxRoutes_RejectsDuplicateServerName(t *testing.T) {
+	workdir := t.TempDir()
+	pluginDir := t.TempDir()
+
+	writeExistingSite(t, workdir, "hasura.conf", "api.staging.nself.org")
+	writePluginNginxRoute(t, pluginDir, "gateway", "route.conf", "api.staging.nself.org")
+
+	cfg := minimalTestConfig("staging.nself.org")
+
+	count, err := InjectPluginNginxRoutes(workdir, pluginDir, cfg)
+	if err == nil {
+		t.Fatalf("expected an error for duplicate server_name \"api.staging.nself.org\", got nil (count=%d)", count)
+	}
+
+	for _, want := range []string{"api.staging.nself.org", "hasura.conf", "gateway-route.conf"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message %q does not name %q — a conflict must name both sources so it can be fixed", err.Error(), want)
+		}
+	}
+
+	// The conflicting file must NOT have been written — a rejected route
+	// must not land in nginx/sites/ half-applied.
+	if _, statErr := os.Stat(filepath.Join(workdir, "nginx", "sites", "gateway-route.conf")); statErr == nil {
+		t.Error("gateway-route.conf was written despite the server_name conflict — the build should have failed before the write")
+	}
+}
+
+// TestInjectPluginNginxRoutes_AllowsDistinctServerNames is the negative
+// control: two different server_names must inject cleanly with no error.
+func TestInjectPluginNginxRoutes_AllowsDistinctServerNames(t *testing.T) {
+	workdir := t.TempDir()
+	pluginDir := t.TempDir()
+
+	writeExistingSite(t, workdir, "hasura.conf", "api.staging.nself.org")
+	writePluginNginxRoute(t, pluginDir, "gateway", "route.conf", "gateway.staging.nself.org")
+
+	cfg := minimalTestConfig("staging.nself.org")
+
+	count, err := InjectPluginNginxRoutes(workdir, pluginDir, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error for distinct server_names: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+	if _, statErr := os.Stat(filepath.Join(workdir, "nginx", "sites", "gateway-route.conf")); statErr != nil {
+		t.Errorf("gateway-route.conf was not written: %v", statErr)
+	}
+}
+
+// TestInjectPluginNginxRoutes_SelfUpdateNotAConflict verifies that a plugin
+// re-running `nself build` and rewriting its own previously-injected file is
+// NOT treated as a conflict with itself.
+func TestInjectPluginNginxRoutes_SelfUpdateNotAConflict(t *testing.T) {
+	workdir := t.TempDir()
+	pluginDir := t.TempDir()
+
+	writePluginNginxRoute(t, pluginDir, "gateway", "route.conf", "gateway.staging.nself.org")
+	cfg := minimalTestConfig("staging.nself.org")
+
+	if _, err := InjectPluginNginxRoutes(workdir, pluginDir, cfg); err != nil {
+		t.Fatalf("first inject: unexpected error: %v", err)
+	}
+	// Second run: same plugin, same file, same server_name — must not
+	// conflict with the file it is about to overwrite.
+	if _, err := InjectPluginNginxRoutes(workdir, pluginDir, cfg); err != nil {
+		t.Fatalf("second inject (self-update): unexpected error: %v", err)
+	}
+}
+
+// ── Whole-directory sweep ────────────────────────────────────────────────
+//
+// The plugin-injection check above catches only one of three writers into
+// nginx/sites/. The nginx generator (Step 7) and the api-docs site conf
+// (Step 11) also write there, and neither can see the others' output.
+// checkServerNameUniqueness runs after all of them, so it is the check that
+// actually covers the reported staging failure.
+
+// writeSite is a small helper for the post-validate sweep tests.
+func writeSite(t *testing.T, sitesDir, name, body string) {
+	t.Helper()
+	if err := os.MkdirAll(sitesDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sitesDir, name), []byte(body), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// TestCheckServerNameUniqueness_ReportsDuplicate reproduces the staging
+// finding: two generated site files both claim api.staging.nself.org.
+// `nginx -t` calls that "syntax is ok" and merely logs that it ignored one,
+// so post-build validation has to be the thing that fails the build — and
+// it has to name BOTH files, or the operator cannot tell which route died.
+func TestCheckServerNameUniqueness_ReportsDuplicate(t *testing.T) {
+	sitesDir := filepath.Join(t.TempDir(), "sites")
+	writeSite(t, sitesDir, "hasura.conf", "server {\n    server_name api.staging.nself.org;\n}\n")
+	writeSite(t, sitesDir, "ir-gateway.conf", "server {\n    server_name api.staging.nself.org;\n}\n")
+
+	result := PostValidateResult{NginxValid: true}
+	checkServerNameUniqueness(sitesDir, &result)
+
+	if len(result.Errors) != 1 {
+		t.Fatalf("Errors = %d (%v), want exactly 1 for one duplicated server_name", len(result.Errors), result.Errors)
+	}
+	if result.NginxValid {
+		t.Error("NginxValid stayed true despite a duplicate server_name — the build would not fail")
+	}
+	for _, want := range []string{"api.staging.nself.org", "hasura.conf", "ir-gateway.conf"} {
+		if !strings.Contains(result.Errors[0], want) {
+			t.Errorf("error %q does not name %q", result.Errors[0], want)
+		}
+	}
+}
+
+// TestCheckServerNameUniqueness_Deterministic verifies the reported "first"
+// file does not depend on directory iteration order, which os.ReadDir does
+// not guarantee across platforms. A conflict that names a different file on
+// each run is not actionable.
+func TestCheckServerNameUniqueness_Deterministic(t *testing.T) {
+	var first string
+	for i := 0; i < 5; i++ {
+		sitesDir := filepath.Join(t.TempDir(), "sites")
+		writeSite(t, sitesDir, "zzz-last.conf", "server { server_name api.example.com; }\n")
+		writeSite(t, sitesDir, "aaa-first.conf", "server { server_name api.example.com; }\n")
+
+		result := PostValidateResult{NginxValid: true}
+		checkServerNameUniqueness(sitesDir, &result)
+		if len(result.Errors) != 1 {
+			t.Fatalf("run %d: Errors = %v, want 1", i, result.Errors)
+		}
+		if i == 0 {
+			first = result.Errors[0]
+			continue
+		}
+		if result.Errors[0] != first {
+			t.Fatalf("conflict message is not deterministic:\n  run 0: %s\n  run %d: %s", first, i, result.Errors[0])
+		}
+	}
+	if !strings.Contains(first, "both aaa-first.conf and zzz-last.conf") {
+		t.Errorf("conflict message does not report the files in a stable sorted order: %s", first)
+	}
+}
+
+// TestCheckServerNameUniqueness_CleanDirectory is the negative control:
+// distinct server_names, plus the catch-all default server which every
+// deployment legitimately has, must produce no findings.
+func TestCheckServerNameUniqueness_CleanDirectory(t *testing.T) {
+	sitesDir := filepath.Join(t.TempDir(), "sites")
+	writeSite(t, sitesDir, "hasura.conf", "server { server_name api.example.com; }\n")
+	writeSite(t, sitesDir, "auth.conf", "server { server_name auth.example.com; }\n")
+	writeSite(t, sitesDir, "a-default.conf", "server { server_name _; }\n")
+	writeSite(t, sitesDir, "b-default.conf", "server { server_name _; }\n")
+
+	result := PostValidateResult{NginxValid: true}
+	checkServerNameUniqueness(sitesDir, &result)
+
+	if len(result.Errors) != 0 {
+		t.Errorf("Errors = %v, want none for distinct server_names plus the catch-all default", result.Errors)
+	}
+	if !result.NginxValid {
+		t.Error("NginxValid was cleared with no actual conflict")
+	}
+}
+
+// TestCheckServerNameUniqueness_NoSitesDir verifies a missing sites/
+// directory is not a finding — a stack fronted by another stack's nginx
+// legitimately generates none.
+func TestCheckServerNameUniqueness_NoSitesDir(t *testing.T) {
+	result := PostValidateResult{NginxValid: true}
+	checkServerNameUniqueness(filepath.Join(t.TempDir(), "nginx"), &result)
+	if len(result.Errors) != 0 || !result.NginxValid {
+		t.Errorf("a missing sites/ directory produced findings: %v", result.Errors)
+	}
+}
+
+// TestCheckServerNameUniqueness_DifferentPortsNotAConflict is the check
+// that keeps this gate from being worse than the bug. nginx's own rule is
+// per listen port — it reports `conflicting server name "x" on 0.0.0.0:443`
+// — so the same name served on :80 by one file and :443 by another is a
+// legitimate split. Failing a build over that would be a false positive on
+// correct configuration.
+func TestCheckServerNameUniqueness_DifferentPortsNotAConflict(t *testing.T) {
+	sitesDir := filepath.Join(t.TempDir(), "sites")
+	writeSite(t, sitesDir, "redirect.conf", "server {\n    listen 80;\n    server_name api.example.com;\n}\n")
+	writeSite(t, sitesDir, "hasura.conf", "server {\n    listen 443 ssl;\n    server_name api.example.com;\n}\n")
+
+	result := PostValidateResult{NginxValid: true}
+	checkServerNameUniqueness(sitesDir, &result)
+
+	if len(result.Errors) != 0 {
+		t.Errorf("Errors = %v, want none: the same name on :80 and :443 is a legitimate http/https split, not a conflict", result.Errors)
+	}
+}
+
+// TestCheckServerNameUniqueness_SamePortIsAConflict is its counterpart:
+// once the ports match, it must fail.
+func TestCheckServerNameUniqueness_SamePortIsAConflict(t *testing.T) {
+	sitesDir := filepath.Join(t.TempDir(), "sites")
+	writeSite(t, sitesDir, "a.conf", "server {\n    listen 443 ssl;\n    server_name api.example.com;\n}\n")
+	writeSite(t, sitesDir, "b.conf", "server {\n    listen 443 ssl;\n    server_name api.example.com;\n}\n")
+
+	result := PostValidateResult{NginxValid: true}
+	checkServerNameUniqueness(sitesDir, &result)
+
+	if len(result.Errors) != 1 {
+		t.Fatalf("Errors = %v, want exactly 1", result.Errors)
+	}
+	if !strings.Contains(result.Errors[0], "port 443") {
+		t.Errorf("error does not name the port it conflicts on: %s", result.Errors[0])
+	}
+}
+
+// TestPostValidate_FailsOnDuplicateServerName is the end-to-end proof that
+// the sweep is actually WIRED INTO the build, not merely present in the
+// package. orchestrator_build_finish turns any PostValidateResult.Errors
+// into a failed build, so a check that exists but is never called from
+// PostValidate would leave the defect shipping exactly as before.
+func TestPostValidate_FailsOnDuplicateServerName(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	if err := os.WriteFile(composePath, []byte("services:\n  postgres:\n    image: postgres:16\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	sitesDir := filepath.Join(dir, "nginx", "sites")
+	// Two generated site files claiming one FQDN on one port: the core
+	// Hasura route and an api-docs route that landed on the same name.
+	writeSite(t, sitesDir, "hasura.conf", "server {\n    listen 443 ssl;\n    server_name api.staging.nself.org;\n}\n")
+	writeSite(t, sitesDir, "api-docs.conf", "server {\n    listen 443 ssl;\n    server_name api.staging.nself.org;\n}\n")
+
+	result := PostValidate(composePath, sitesDir)
+
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "api.staging.nself.org") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("PostValidate did not report the duplicate server_name — the check is not wired into the build. Errors: %v", result.Errors)
+	}
+	if result.NginxValid {
+		t.Error("NginxValid = true despite a duplicate server_name; the build would not fail")
+	}
+}

--- a/internal/build/postvalidate.go
+++ b/internal/build/postvalidate.go
@@ -53,6 +53,12 @@ func PostValidate(composePath, nginxConfDir string) PostValidateResult {
 	// ── Service name uniqueness ──────────────────────────────────────
 	checkNameUniqueness(services, &result)
 
+	// ── Nginx server_name uniqueness ─────────────────────────────────
+	// Must run before the syntax check: `nginx -t` reports "syntax is ok"
+	// for a duplicate server_name and only logs that it ignored one of the
+	// blocks, so it cannot catch this.
+	checkServerNameUniqueness(nginxConfDir, &result)
+
 	// ── Nginx syntax check ───────────────────────────────────────────
 	checkNginxSyntax(nginxConfDir, &result)
 

--- a/internal/build/postvalidate_nginx.go
+++ b/internal/build/postvalidate_nginx.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -17,6 +18,88 @@ import (
 // *PostValidateResult to append findings to.
 // Outputs: appends to result.Errors/Warnings; never returns a Go error.
 // Constraints: skips (warn, not fail) when nginx is not installed locally.
+
+// checkServerNameUniqueness reports every FQDN claimed by more than one
+// server block, on the same listen port, across the generated
+// nginx/sites/ directory — naming both source files.
+//
+// nginx does not treat this as a config error. It logs
+// `conflicting server name "x" on 0.0.0.0:443, ignored`, keeps whichever
+// block it loaded last, and still prints "syntax is ok" — so
+// checkNginxSyntax below passes and one of the two routes is silently
+// dead. That is how api.staging.nself.org ended up served by an
+// unintended block on 2026-09-03.
+//
+// Three separate writers populate nginx/sites/ in one build — the nginx
+// generator (Step 7), plugin route injection (Step 7.1), and the api-docs
+// site conf (Step 11) — and none can see the others' output. This runs
+// after all of them, the only point where the whole directory is visible.
+//
+// The check is keyed on port AND name because that is nginx's own rule: a
+// name served on :80 by one file and on :443 by another is a legitimate
+// split, not a conflict, and failing a build over it would be worse than
+// the bug being fixed.
+func checkServerNameUniqueness(nginxConfDir string, result *PostValidateResult) {
+	sitesDir := nginxConfDir
+	if filepath.Base(sitesDir) != "sites" {
+		sitesDir = filepath.Join(nginxConfDir, "sites")
+	}
+
+	entries, err := os.ReadDir(sitesDir)
+	if err != nil {
+		// No generated sites directory is not a finding — a stack fronted
+		// by another stack's nginx legitimately generates none.
+		return
+	}
+
+	// Sorted so the file reported as the first claimant, and therefore the
+	// exact wording of the error, is identical on every machine and run.
+	// os.ReadDir order is not guaranteed across platforms, and a conflict
+	// that names a different file each run is not actionable.
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".conf") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+
+	// claimedBy maps "<port>|<server_name>" to the first file to claim it.
+	claimedBy := make(map[string]string)
+
+	for _, name := range names {
+		data, readErr := os.ReadFile(filepath.Join(sitesDir, name))
+		if readErr != nil {
+			continue
+		}
+		for _, block := range parseServerBlocks(string(data)) {
+			ports := block.Ports
+			if len(ports) == 0 {
+				ports = []string{defaultListenPort}
+			}
+			for _, serverName := range block.ServerNames {
+				if serverName == "_" {
+					continue // the catch-all default server, intentionally shared
+				}
+				for _, port := range ports {
+					key := port + "|" + serverName
+					first, dup := claimedBy[key]
+					if !dup {
+						claimedBy[key] = name
+						continue
+					}
+					if first == name {
+						continue // same file, e.g. its own :80 and :443 blocks
+					}
+					result.NginxValid = false
+					result.Errors = append(result.Errors, fmt.Sprintf(
+						"nginx server_name %q on port %s is claimed by both %s and %s — nginx logs \"conflicting server name\" and silently serves only one of them; rename one route or remove the duplicate",
+						serverName, port, first, name))
+				}
+			}
+		}
+	}
+}
 
 // checkNginxSyntax runs `nginx -t -c <nginx.conf>` if the nginx binary is
 // available in PATH and the main nginx.conf can be found. Skips with a


### PR DESCRIPTION
From the 2026-09-03 staging report: `nginx -t` on nself-web printed

```
conflicting server name "api.staging.nself.org" on 0.0.0.0:443, ignored
```

Two generated site files claimed one FQDN. nginx kept whichever it loaded last and the other route was silently dead.

## Why nothing caught it

**nginx does not treat a duplicate server_name as a config error.** It logs the conflict, ignores one block, and still prints `syntax is ok`. `checkNginxSyntax` — the only nginx check the build had — gates on exactly that string, so it passed. There was no gate on this at all.

**Three writers populate `nginx/sites/` during one build, and none can see the others' output:**

| Step | Writer | Conflict check before this PR |
|---|---|---|
| 7 | nginx generator | dedupes within its own batch only |
| 7.1 | plugin route injection | warned, then wrote the file anyway |
| 11 | api-docs site conf | none |

The plugin check also compared *filenames* (`<plugin>.conf` already exists?) rather than server names, so a core-vs-plugin or core-vs-api-docs collision was invisible to it even in principle. `nginx/sites/` is cleared at the start of Step 7, so stale files are not the source — these are all same-build collisions.

## Fix — two checks, one parser

- **`checkServerNameConflict`** (plugin injection) now **fails the build** before the conflicting file is written, naming both files. Previously `slog.Warn` + write.
- **`checkServerNameUniqueness`** (post-build validation) sweeps the whole generated directory after every writer has run — the only point where a core-vs-api-docs collision is visible — and appends to `PostValidateResult.Errors`, which `orchestrator_build_finish` already turns into a failed build.

Both key on **listen port AND server_name**, matching nginx's own rule (`conflicting server name X on 0.0.0.0:443`). The same name served on `:80` by one file and `:443` by another is a legitimate http/https split; failing a build over that would be a false positive on correct configuration, i.e. a gate worse than the bug. `TestCheckServerNameUniqueness_DifferentPortsNotAConflict` pins that.

Both report files in **sorted order**, so the message is byte-identical on every machine. `os.ReadDir` order is not guaranteed across platforms, and a conflict that names a different file on each run is not actionable. `TestCheckServerNameUniqueness_Deterministic` runs the check five times over freshly created temp dirs and asserts the message never changes.

### Why a new parser

`nginx_server_blocks.go` replaces a line-prefix scan that only matched a directive beginning a line, so it could not read the compact single-line form (`server { server_name x; }`) that a hand-written or plugin-shipped conf may use. **A missed conflict is a conflict that ships**, so the weaker parser was the wrong half to keep. The new one tokenizes on `{`, `}`, `;`, attributes each directive to its enclosing block, and ignores `upstream`/`location` blocks and `server_names_hash_bucket_size`. It is deliberately a targeted reader, not a general nginx parser — anything it cannot interpret it ignores, so its failure mode is a missed conflict, never a fabricated one.

## Negative-test proof

Each half reverted independently, tests kept:

**Half A — `plugin_nginx.go` back to warn-and-write:**
```
--- FAIL: TestInjectPluginNginxRoutes_RejectsDuplicateServerName
    expected an error for duplicate server_name "api.staging.nself.org", got nil (count=1)
```

**Half B — the sweep unwired from `PostValidate` (`postvalidate.go` reverted):**
```
--- FAIL: TestPostValidate_FailsOnDuplicateServerName
    PostValidate did not report the duplicate server_name — the check is not wired into the build. Errors: []
    NginxValid = true despite a duplicate server_name; the build would not fail
```

That second test exists specifically because a check that is present but never called from `PostValidate` would leave the defect shipping exactly as before — the function passing its own unit test proves nothing about the build. Both halves pass with the fix restored, and `git status` was verified clean afterward.

| Test | Asserts |
|---|---|
| `TestInjectPluginNginxRoutes_RejectsDuplicateServerName` | plugin injection fails, names both files, writes nothing |
| `TestInjectPluginNginxRoutes_AllowsDistinctServerNames` | control: distinct names inject cleanly |
| `TestInjectPluginNginxRoutes_SelfUpdateNotAConflict` | a plugin rewriting its own file is not a conflict with itself |
| `TestCheckServerNameUniqueness_ReportsDuplicate` | the sweep reports the staging case, naming both files |
| `TestCheckServerNameUniqueness_SamePortIsAConflict` | names the port in the message |
| `TestCheckServerNameUniqueness_DifferentPortsNotAConflict` | control: `:80` + `:443` split is not a conflict |
| `TestCheckServerNameUniqueness_Deterministic` | message stable across 5 runs, files sorted |
| `TestCheckServerNameUniqueness_CleanDirectory` | control: distinct names + shared `server_name _` produce nothing |
| `TestCheckServerNameUniqueness_NoSitesDir` | a fronted stack generating no sites/ is not a finding |
| `TestPostValidate_FailsOnDuplicateServerName` | the sweep is wired into the build |
| `TestParseServerBlocks_MultiLineAndCompactAgree` | both config forms read identically |
| `TestParseServerBlocks_SeparatesBlocks` | `upstream {}` is not a server block; ports/names not merged across blocks |
| `TestParseServerBlocks_IgnoresLookalikes` | comments and `server_names_hash_bucket_size` do not register |
| `TestListenPortIn` | `listen` forms incl. `[::]:443`, `0.0.0.0:8080`, unix sockets |

## Gates

`make fmt-check`, `make vet`, `make build`, `make test` (full suite), `golangci-lint run ./internal/build/...` (0 issues) — all green. No flag added, so `command-inventory.json` is unaffected. Touches only `internal/build/`, so no overlap with the other in-flight nginx branches.

## Behavior change worth a reviewer's attention

The plugin path went from **warn** to **hard error**. A project that today builds with a duplicate server_name — and is therefore silently serving only one of the two routes — will start failing `nself build` until the duplicate is removed. That is the intent (the current state is a route that does not work and says nothing), but it is a behavior change that could surface on an existing deployment at upgrade time rather than at config-edit time.

## Left alone deliberately

Within the nginx generator's own batch, `hasDomainConflict` still **silently skips** a route whose server_name was already claimed earlier in the same batch. That is deterministic first-wins dedupe, so it never produces the two-files-one-name state this PR is about, and it cannot reach the post-build sweep because the second file is never written. But it does mean a configured route can vanish with no message. Turning it into an error is a separate, riskier change — it would fail builds for any project that currently has an unnoticed duplicate CS/frontend route — and belongs in its own PR with its own blast-radius assessment.