### PR TITLE
nginx: drop stale LazyResolve comment in nginx.conf.tmpl

### DIFF
--- a/internal/nginx/templates/nginx.conf.tmpl
+++ b/internal/nginx/templates/nginx.conf.tmpl
@@ -33,10 +33,11 @@ http {
     # Docker's embedded DNS (127.0.0.11) resolves container names on the
     # user-defined bridge network. valid=10s keeps the cache short so a
     # recreated container (new IP) is picked up on the next request instead
-    # of causing 502s until a manual `nginx -s reload`. Only takes effect
-    # for proxy_pass targets expressed via an nginx variable (see
-    # service.conf.tmpl LazyResolve) — static `upstream {}` blocks resolve
-    # once at load time regardless of this directive.
+    # of causing 502s until a manual `nginx -s reload`. Every proxy_pass in the
+    # generated site configs goes through an nginx variable
+    # (`set $up_x ...; proxy_pass $up_x`, see service.conf.tmpl), so this
+    # resolver governs all of them; static `upstream {}` blocks, which resolve
+    # once at load time, were removed in #364.
     resolver 127.0.0.11 valid=10s ipv6=off;
     resolver_timeout 5s;
 


### PR DESCRIPTION
Comment-only. #364 removed `LazyResolve` and the static `upstream {}` branch; `nginx.conf.tmpl` still described the old opt-in behaviour. Replaced with what the generator actually does now (request-time `set $up_x; proxy_pass $up_x` with the resolver). No generated output changes; template tests unaffected.