### PR TITLE
fix(bundle): actionable error when a bundle is not installable as a unit

### DIFF
--- a/internal/bundle/installer.go
+++ b/internal/bundle/installer.go
@@ -90,7 +90,7 @@ func Install(ctx context.Context, bundleSlug string, opts InstallOpts) (*Install
 		return nil, UnknownBundleError(bundleSlug)
 	}
 	if !b.IsInstallable() {
-		return nil, fmt.Errorf("bundle %q is not installable as a unit (meta or free)", b.Slug)
+		return nil, notInstallableError(b)
 	}
 
 	result := &InstallResult{

--- a/internal/bundle/installer_helpers.go
+++ b/internal/bundle/installer_helpers.go
@@ -87,6 +87,35 @@ func printPlan(out io.Writer, b Bundle, ch Channel, planned []string, pins Versi
 	}
 }
 
+// notInstallableError builds an actionable error for a bundle that
+// IsInstallable() rejected. The ɳSelf+ meta-bundle and the free Task Bundle
+// are deliberately not installable as a unit (design confirmed, Ruling 2 +
+// P6-E4-W3-S3-T10): ɳSelf+ has no SKU of its own (it's the union of every
+// paid bundle's entitlements) and free bundles need no license, so their
+// plugins install directly via `nself plugin install`, one at a time, with
+// zero license gate. Rather than a bare "not installable" message, name the
+// exact commands the operator should run instead so the refusal is
+// actionable, not a dead end.
+func notInstallableError(b Bundle) error {
+	if b.Slug == selfPlusSlug {
+		return fmt.Errorf(
+			"bundle %q is not installable as a unit: ɳSelf+ is a meta-bundle (the union of every paid bundle's entitlements, not its own SKU).\nInstall one of the paid bundles directly instead, e.g. 'nself bundle install claw', or install individual plugins via 'nself plugin install <name>'",
+			b.Slug,
+		)
+	}
+	if len(b.Plugins) == 0 {
+		return fmt.Errorf("bundle %q is not installable as a unit: it has no plugins", b.Slug)
+	}
+	cmds := make([]string, 0, len(b.Plugins))
+	for _, p := range b.Plugins {
+		cmds = append(cmds, "  nself plugin install "+p)
+	}
+	return fmt.Errorf(
+		"bundle %q is not installable as a unit: it is a free bundle, and its plugins need no license — install each one directly instead:\n%s",
+		b.Slug, strings.Join(cmds, "\n"),
+	)
+}
+
 // defaultLicenseChecker validates every paid plugin in the bundle has license
 // coverage BEFORE the installer touches the filesystem. Implementation
 // strategy: rely on plugin.Install's internal license gate by NOT bypassing,

--- a/internal/bundle/installer_test.go
+++ b/internal/bundle/installer_test.go
@@ -38,6 +38,39 @@ func TestInstall_MetaBundleNotInstallable(t *testing.T) {
 	if !strings.Contains(err.Error(), "not installable") {
 		t.Errorf("error %v missing 'not installable'", err)
 	}
+	if !strings.Contains(err.Error(), "nself bundle install claw") {
+		t.Errorf("error %v should point at a paid bundle to install instead, got: %v", err, err)
+	}
+}
+
+// TestInstall_TaskBundleNotInstallable_ListsPerPluginCommands proves the free
+// Task Bundle's refusal is actionable: design-confirmed (Ruling 2 +
+// P6-E4-W3-S3-T10 — free bundles install their plugins individually, not as
+// a unit), the error must name the exact `nself plugin install <name>`
+// command for every plugin in bundles.json's task.plugins list rather than a
+// bare "not installable" dead end.
+func TestInstall_TaskBundleNotInstallable_ListsPerPluginCommands(t *testing.T) {
+	ctx := context.Background()
+	_, err := Install(ctx, "task", InstallOpts{DryRun: true, Out: &bytes.Buffer{}})
+	if err == nil {
+		t.Fatal("expected error: task is not installable as a unit")
+	}
+	if !strings.Contains(err.Error(), "not installable") {
+		t.Errorf("error %v missing 'not installable'", err)
+	}
+	taskBundle, ok := Get("task")
+	if !ok {
+		t.Fatal("fixture missing task bundle")
+	}
+	if len(taskBundle.Plugins) == 0 {
+		t.Fatal("fixture task bundle has no plugins to assert against")
+	}
+	for _, p := range taskBundle.Plugins {
+		want := "nself plugin install " + p
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing per-plugin command %q; got: %v", want, err)
+		}
+	}
 }
 
 func TestInstall_DryRunWithMockedRegistry(t *testing.T) {


### PR DESCRIPTION
## What / why

`nself bundle install task` (and `nself bundle install nself-plus`) refuses with a bare
`bundle "task" is not installable as a unit (meta or free)` and no next step. The
exclusion itself is deliberate — free bundles need no license, so their plugins install
individually via `nself plugin install <name>` (Ruling 2 / P6-E4-W3-S3-T10, already
implemented and tested: `TestInstall_MetaBundleNotInstallable`,
`bundles_test.go`'s `{"task", true, "task", false}` case) — but the refusal was a dead
end for the operator.

This adds `notInstallableError()` (`internal/bundle/installer_helpers.go`), which:
- for a free bundle (e.g. `task`): lists one `nself plugin install <plugin>` line per
  plugin in the bundle's `bundles.json` plugin list
- for the `nself-plus` meta-bundle: points at installing a paid bundle directly or
  individual plugins (it has no SKU of its own)

## Ticket

P6-E4-W2-S2-T4 (FREE-BUNDLE-INSTALL unit). Dispatched to investigate making
`nself bundle install task` install directly (skip `IsInstallable()`'s exclusion + the
`/bundle/entitled` network call for free bundles). Investigation found that exclusion is
intentional, already documented in `IsInstallable()`'s doc comment, and covered by an
existing test — not a bug. This PR makes the existing, intentional refusal actionable
instead of changing the install path.

## Evidence

- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test ./internal/bundle/... ./internal/plugin/... ./cmd/commands/...` — all pass
  (`ok internal/bundle 0.958s`, `ok internal/plugin 0.561s`, `ok cmd/commands 32.911s`)
- New test `TestInstall_TaskBundleNotInstallable_ListsPerPluginCommands` asserts the
  error names every plugin in the fixture's `task.plugins` list
- `TestInstall_MetaBundleNotInstallable` extended to assert the nself-plus message
  points at a concrete paid-bundle install command

Local gate only — GitHub Actions billing is ignored per standing rule; ran locally on
this Mac.