### PR TITLE
fix(compose): honor CS_N_HEALTHCHECK, add CS_N_ENV_PASSTHROUGH allowlist

### DIFF
--- a/.github/wiki/Config-Custom-Services.md
+++ b/.github/wiki/Config-Custom-Services.md
@@ -79,9 +79,10 @@ All variables use the pattern `CS_N_*` where `N` is the slot number (1–10). Va
 | `CS_N_MEMORY` | string | `256m` | Docker memory limit |
 | `CS_N_CPU` | string | `0.5` | Docker CPU limit (fractional cores) |
 | `CS_N_REPLICAS` | int | `1` | Number of container instances to run |
-| `CS_N_HEALTHCHECK` | string | `/health` | Health endpoint path , used by Docker healthcheck and `nself status` |
+| `CS_N_HEALTHCHECK` | string | `/health` | Healthcheck override. A path (e.g. `/auth/health`) probes that path instead of `/health` on the service's own port. A full `CMD ...` / `CMD-SHELL ...` command is passed through verbatim (split on whitespace) for services that need curl, a non-HTTP probe, or a different port. `disabled` / `none` / `false` omits the healthcheck entirely. |
 | `CS_N_TABLE_PREFIX` | string | *(empty)* | Database table prefix for this service's migrations |
-| `CS_N_ENV` | string | *(empty)* | Additional env vars to inject, in `KEY=VALUE,KEY=VALUE` format |
+| `CS_N_ENV_PASSTHROUGH` | string | *(empty)* | Comma-separated allowlist of project `.env` var names to forward into this container in addition to the fixed core set. `CS_N_ENV` still wins on a name conflict. |
+| `CS_N_ENV` | string | *(empty)* | Additional env vars to inject, in `KEY=VALUE,KEY=VALUE` format. Always applied last — overrides both the fixed core set and `CS_N_ENV_PASSTHROUGH`. |
 
 All `CS_*` variables are automatically exempt from "unknown env var" warnings.
 
@@ -100,19 +101,38 @@ When a custom service container starts, ɳSelf automatically injects the followi
 | `ENV` | from project `.env` | `dev`, `staging`, or `prod` |
 | `CS_N_ENV` values | parsed from `CS_N_ENV` | Any additional vars you define for this slot |
 
-All variables from the project's `.env` that do not conflict with injected vars are also forwarded into the container. This means your service can read any project-level config it needs without extra wiring.
+**By design, that fixed set above is all a custom service receives from the
+project's `.env` — nothing is forwarded implicitly.** Each service's surface
+area is explicit and auditable rather than silently coupled to whatever
+another part of the stack happens to define. To pull in a specific project
+`.env` var, name it in `CS_N_ENV_PASSTHROUGH`; to define a new one outright,
+use `CS_N_ENV`.
 
 **Example, reading injected vars in a Go service:**
 
 ```go
 dbURL := os.Getenv("DATABASE_URL")            // injected by nSelf
 adminSecret := os.Getenv("HASURA_GRAPHQL_ADMIN_SECRET") // injected by nSelf
-apiKey := os.Getenv("MY_API_KEY")             // forwarded from .env
+apiKey := os.Getenv("MY_API_KEY")             // forwarded via CS_N_ENV_PASSTHROUGH
+```
+
+### Forwarding Project Vars
+
+Use `CS_N_ENV_PASSTHROUGH` to forward specific vars that already exist in the
+project's `.env` (a comma-separated allowlist of names, values are not
+repeated):
+
+```bash
+# .env
+MY_API_KEY=sk_live_...
+CS_2_ENV_PASSTHROUGH=MY_API_KEY,STRIPE_WEBHOOK_SECRET
 ```
 
 ### Adding Extra Vars
 
-Use `CS_N_ENV` to pass service-specific variables that aren't in the main `.env`:
+Use `CS_N_ENV` to pass service-specific variables that aren't in the main `.env`,
+or to override a value that was forwarded via `CS_N_ENV_PASSTHROUGH`
+(`CS_N_ENV` always wins on a name conflict):
 
 ```bash
 # .env
@@ -233,6 +253,7 @@ CS_2_REPLICAS=3
 
 - Custom service images are built from the scaffolded Dockerfile in `./services/{name}/`. To use a pre-built image instead, set `CS_N_IMAGE` directly (advanced usage, see [[Guide-Custom-Services]]).
 - The `CS_N_TABLE_PREFIX` variable is used by `nself migrate` to scope migrations to a subdirectory, keeping custom service migrations separate from core schema changes.
+- If a service's health endpoint isn't `/health` on its own port (e.g. an auth service serving `/auth/health`), set `CS_N_HEALTHCHECK=/auth/health` — otherwise Docker probes the wrong path and reports the service unhealthy forever regardless of its actual state.
 - Custom services participate in `nself backup`, the backup bundle includes a dump of any tables matching the `CS_N_TABLE_PREFIX`.
 - Logs from all custom service slots are included in `nself logs --all`.
 

--- a/.github/wiki/Config-Env-Vars.md
+++ b/.github/wiki/Config-Env-Vars.md
@@ -255,6 +255,8 @@ These boolean flags enable optional bundled services. Each defaults to `false`. 
 | `CS_N_CPU` | string | `0.5` | No | Docker CPU core limit. |
 | `CS_N_PUBLIC` | bool | `false` | No | When `true`, the service is reachable from outside the Docker network via Nginx. |
 | `CS_N_REPLICAS` | int | `1` | No | Number of container instances to run. |
+| `CS_N_HEALTHCHECK` | string | `/health` | No | Healthcheck override: a path, a full `CMD ...`/`CMD-SHELL ...` command, or `disabled`/`none`/`false` to omit it. See [[Config-Custom-Services]]. |
+| `CS_N_ENV_PASSTHROUGH` | string | *(empty)* | No | Comma-separated allowlist of project `.env` var names to forward into this service. `CS_N_ENV` wins on conflict. See [[Config-Custom-Services]]. |
 
 **Example** (from `web/`, `nself.org` infrastructure):
 

--- a/internal/compose/custom_service_test.go
+++ b/internal/compose/custom_service_test.go
@@ -430,6 +430,229 @@ func TestBuildCustomService_Network(t *testing.T) {
 	}
 }
 
+// ── CS_N_ENV_PASSTHROUGH ──────────────────────────────────────────────────────
+
+// TestCoreEnvVars_EnvPassthrough_Forwarded verifies that a var named in
+// CS_N_ENV_PASSTHROUGH and present in the process env is forwarded into the
+// service's Environment.
+func TestCoreEnvVars_EnvPassthrough_Forwarded(t *testing.T) {
+	t.Setenv("MY_API_KEY", "secret-value")
+
+	cfg := minimalConfigWithCS()
+	cs := testCS()
+	cs.EnvPassthrough = "MY_API_KEY"
+
+	env := coreEnvVars(cfg, cs)
+
+	if env["MY_API_KEY"] != "secret-value" {
+		t.Errorf("MY_API_KEY = %q, want %q", env["MY_API_KEY"], "secret-value")
+	}
+}
+
+// TestCoreEnvVars_EnvPassthrough_MultipleNames verifies that a
+// comma-separated allowlist forwards every named var, trimming whitespace.
+func TestCoreEnvVars_EnvPassthrough_MultipleNames(t *testing.T) {
+	t.Setenv("FOO_VAR", "foo")
+	t.Setenv("BAR_VAR", "bar")
+
+	cfg := minimalConfigWithCS()
+	cs := testCS()
+	cs.EnvPassthrough = "FOO_VAR, BAR_VAR"
+
+	env := coreEnvVars(cfg, cs)
+
+	if env["FOO_VAR"] != "foo" {
+		t.Errorf("FOO_VAR = %q, want %q", env["FOO_VAR"], "foo")
+	}
+	if env["BAR_VAR"] != "bar" {
+		t.Errorf("BAR_VAR = %q, want %q", env["BAR_VAR"], "bar")
+	}
+}
+
+// TestCoreEnvVars_EnvPassthrough_AbsentSkipped verifies that a name in the
+// allowlist that has no value in the process env is silently skipped, not
+// injected as an empty string and not an error.
+func TestCoreEnvVars_EnvPassthrough_AbsentSkipped(t *testing.T) {
+	cfg := minimalConfigWithCS()
+	cs := testCS()
+	cs.EnvPassthrough = "DOES_NOT_EXIST_VAR"
+
+	env := coreEnvVars(cfg, cs)
+
+	if _, ok := env["DOES_NOT_EXIST_VAR"]; ok {
+		t.Error("DOES_NOT_EXIST_VAR should not be present when unset in the process env")
+	}
+}
+
+// TestCoreEnvVars_EnvPassthrough_ExtraEnvWins verifies that CS_N_ENV still
+// overrides a value forwarded via CS_N_ENV_PASSTHROUGH (explicit override
+// beats allowlist forwarding).
+func TestCoreEnvVars_EnvPassthrough_ExtraEnvWins(t *testing.T) {
+	t.Setenv("SHARED_VAR", "from-passthrough")
+
+	cfg := minimalConfigWithCS()
+	cs := testCS()
+	cs.EnvPassthrough = "SHARED_VAR"
+	cs.ExtraEnv = "SHARED_VAR=from-extra-env"
+
+	env := coreEnvVars(cfg, cs)
+
+	if env["SHARED_VAR"] != "from-extra-env" {
+		t.Errorf("SHARED_VAR = %q, want %q (CS_N_ENV must win over CS_N_ENV_PASSTHROUGH)", env["SHARED_VAR"], "from-extra-env")
+	}
+}
+
+// TestCoreEnvVars_EnvPassthrough_Absent verifies that omitting
+// CS_N_ENV_PASSTHROUGH injects no extra vars beyond the fixed core set.
+func TestCoreEnvVars_EnvPassthrough_Absent(t *testing.T) {
+	cfg := minimalConfigWithCS()
+	cfg.Redis.Enabled = false
+	cfg.Minio.Enabled = false
+	cs := testCS()
+	cs.EnvPassthrough = ""
+
+	env := coreEnvVars(cfg, cs)
+
+	// The fixed core set only (PROJECT_NAME..TABLE_PREFIX), per coreEnvVars'
+	// documented design: no Redis/Minio (disabled) and no passthrough/extra-env.
+	const wantKeys = 17
+	if len(env) != wantKeys {
+		t.Errorf("got %d env keys with no passthrough/extra-env, want %d (fixed core set only): %v", len(env), wantKeys, env)
+	}
+}
+
+// ── buildHealthcheck / CS_N_HEALTHCHECK ───────────────────────────────────────
+
+// TestBuildHealthcheck is table-driven over the real generator function,
+// covering the default, custom path, custom CMD, and disabled cases.
+func TestBuildHealthcheck(t *testing.T) {
+	cases := []struct {
+		name       string
+		raw        string
+		port       int
+		wantNil    bool
+		wantTest   []string
+		wantSubstr string // substring the rendered Test command must contain
+	}{
+		{
+			name:       "default_empty_uses_slash_health",
+			raw:        "",
+			port:       8001,
+			wantTest:   []string{"CMD", "wget", "-qO-", "http://localhost:8001/health"},
+			wantSubstr: "/health",
+		},
+		{
+			name:       "custom_path_overrides_default",
+			raw:        "/auth/health",
+			port:       4002,
+			wantTest:   []string{"CMD", "wget", "-qO-", "http://localhost:4002/auth/health"},
+			wantSubstr: "/auth/health",
+		},
+		{
+			name:       "bare_path_without_leading_slash_normalized",
+			raw:        "status",
+			port:       9000,
+			wantTest:   []string{"CMD", "wget", "-qO-", "http://localhost:9000/status"},
+			wantSubstr: "/status",
+		},
+		{
+			name:       "full_cmd_override_passed_through",
+			raw:        "CMD-SHELL curl -f http://localhost:4002/status",
+			port:       4002,
+			wantTest:   []string{"CMD-SHELL", "curl", "-f", "http://localhost:4002/status"},
+			wantSubstr: "curl",
+		},
+		{
+			name:    "disabled_yields_no_healthcheck",
+			raw:     "disabled",
+			port:    8001,
+			wantNil: true,
+		},
+		{
+			name:    "none_case_insensitive_yields_no_healthcheck",
+			raw:     "None",
+			port:    8001,
+			wantNil: true,
+		},
+		{
+			name:    "false_yields_no_healthcheck",
+			raw:     "false",
+			port:    8001,
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := testCS()
+			cs.Port = tc.port
+			cs.HealthCheck = tc.raw
+
+			hc := buildHealthcheck(cs)
+
+			if tc.wantNil {
+				if hc != nil {
+					t.Fatalf("buildHealthcheck(%q) = %+v, want nil", tc.raw, hc)
+				}
+				return
+			}
+			if hc == nil {
+				t.Fatalf("buildHealthcheck(%q) = nil, want non-nil", tc.raw)
+			}
+			if len(tc.wantTest) > 0 && strings.Join(hc.Test, " ") != strings.Join(tc.wantTest, " ") {
+				t.Errorf("Test = %v, want %v", hc.Test, tc.wantTest)
+			}
+			if tc.wantSubstr != "" && !strings.Contains(strings.Join(hc.Test, " "), tc.wantSubstr) {
+				t.Errorf("Test = %v, want it to contain %q", hc.Test, tc.wantSubstr)
+			}
+			// Timing fields must stay the prior fixed defaults regardless of
+			// which healthcheck form was chosen.
+			if hc.Interval != "30s" || hc.Timeout != "10s" || hc.Retries != 3 || hc.StartPeriod != "60s" {
+				t.Errorf("timing fields changed: %+v", hc)
+			}
+		})
+	}
+}
+
+// TestBuildCustomService_HealthcheckDisabled is the golden-fragment
+// regression test for the generator entry point: CS_N_HEALTHCHECK=disabled
+// must render no healthcheck block on the generated ServiceConfig.
+func TestBuildCustomService_HealthcheckDisabled(t *testing.T) {
+	cfg := minimalConfigWithCS()
+	cs := testCS()
+	cs.HealthCheck = "disabled"
+
+	g := NewGenerator(cfg)
+	svc := g.buildCustomService(cs)
+
+	if svc.Healthcheck != nil {
+		t.Errorf("Healthcheck = %+v, want nil when CS_N_HEALTHCHECK=disabled", svc.Healthcheck)
+	}
+}
+
+// TestBuildCustomService_HealthcheckCustomPath is the golden-fragment
+// regression test for the case that motivated this ticket: a service whose
+// health endpoint is not the default /health (e.g. auth_server's /auth/health)
+// must be probed at the declared path, not silently reported unhealthy.
+func TestBuildCustomService_HealthcheckCustomPath(t *testing.T) {
+	cfg := minimalConfigWithCS()
+	cs := testCS()
+	cs.Port = 4002
+	cs.HealthCheck = "/auth/health"
+
+	g := NewGenerator(cfg)
+	svc := g.buildCustomService(cs)
+
+	if svc.Healthcheck == nil {
+		t.Fatal("buildCustomService: Healthcheck is nil")
+	}
+	want := "http://localhost:4002/auth/health"
+	hcStr := strings.Join(svc.Healthcheck.Test, " ")
+	if !strings.Contains(hcStr, want) {
+		t.Errorf("healthcheck must reference %q, got: %s", want, hcStr)
+	}
+}
+
 // TestBuildCustomService_CoreEnvInjected verifies that core env vars like
 // PROJECT_NAME and POSTGRES_HOST are present in the generated service Environment.
 func TestBuildCustomService_CoreEnvInjected(t *testing.T) {

--- a/internal/compose/custom_services.go
+++ b/internal/compose/custom_services.go
@@ -2,13 +2,26 @@ package compose
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/nself-org/cli/internal/config"
 )
 
 // coreEnvVars returns the standard env vars injected into every custom service.
-// User overrides via CS_N_ENV are applied last and win over defaults.
+//
+// By design, custom services receive only this fixed generic set (project
+// identity, Postgres, Hasura, Auth, and the optional Redis/Minio blocks) plus
+// whatever the service opts into via CS_N_ENV_PASSTHROUGH or CS_N_ENV — never
+// the full project .env. This keeps each service's declared surface area
+// explicit and auditable instead of silently coupling it to every var another
+// part of the stack happens to define. See
+// .github/wiki/Config-Custom-Services.md for the user-facing version of this
+// decision.
+//
+// Precedence (lowest to highest): fixed defaults → CS_N_ENV_PASSTHROUGH
+// (named allowlist forwarded from the project's resolved env) → CS_N_ENV
+// (explicit overrides, always win).
 func coreEnvVars(cfg *config.Config, svc config.CustomService) map[string]string {
 	env := map[string]string{
 		"PROJECT_NAME":      cfg.ProjectName,
@@ -43,6 +56,23 @@ func coreEnvVars(cfg *config.Config, svc config.CustomService) map[string]string
 		env["S3_SECRET_KEY"] = cfg.Minio.RootPassword
 		env["S3_BUCKET"] = cfg.Minio.DefaultBuckets
 	}
+	// CS_N_ENV_PASSTHROUGH — explicit allowlist of extra project env vars to
+	// forward into this container beyond the fixed core set above. Applied
+	// before CS_N_ENV so an explicit override still wins on conflict. Names
+	// not present in the resolved env are silently skipped (not an error) so
+	// an allowlist can be shared across environments where a var may be
+	// optional.
+	if svc.EnvPassthrough != "" {
+		for _, name := range strings.Split(svc.EnvPassthrough, ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			if val, ok := os.LookupEnv(name); ok {
+				env[name] = val
+			}
+		}
+	}
 	// CS_N_ENV overrides applied last — user wins
 	if svc.ExtraEnv != "" {
 		for _, pair := range strings.Split(svc.ExtraEnv, ",") {
@@ -53,6 +83,53 @@ func coreEnvVars(cfg *config.Config, svc config.CustomService) map[string]string
 		}
 	}
 	return env
+}
+
+// buildHealthcheck renders the Docker healthcheck for a custom service,
+// honoring CS_N_HEALTHCHECK. The raw value may be:
+//
+//   - empty                                — default: GET /health on the
+//     service's own port via wget (the prior hardcoded behavior).
+//   - a path (e.g. "/auth/health")         — GET that path instead of /health,
+//     still via wget on the service's own port.
+//   - a full command starting with "CMD"
+//     or "CMD-SHELL" (e.g. "CMD-SHELL curl
+//     -f http://localhost:4002/status")    — passed through verbatim as the
+//     compose healthcheck test, split on whitespace. Use this when the
+//     service needs curl, a non-HTTP probe, or a port other than its own.
+//   - "disabled" / "none" / "false"
+//     (case-insensitive)                   — no healthcheck is emitted.
+//
+// Without this, a service whose health endpoint isn't literally /health on
+// its own port (e.g. auth_server serving /auth/health) is reported unhealthy
+// forever regardless of its actual state.
+func buildHealthcheck(cs config.CustomService) *Healthcheck {
+	raw := strings.TrimSpace(cs.HealthCheck)
+	switch strings.ToLower(raw) {
+	case "disabled", "none", "false":
+		return nil
+	}
+
+	var test []string
+	if strings.HasPrefix(raw, "CMD") {
+		test = strings.Fields(raw)
+	} else {
+		path := raw
+		if path == "" {
+			path = "/health"
+		} else if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		test = []string{"CMD", "wget", "-qO-", fmt.Sprintf("http://localhost:%d%s", cs.Port, path)}
+	}
+
+	return &Healthcheck{
+		Test:        test,
+		Interval:    "30s",
+		Timeout:     "10s",
+		Retries:     3,
+		StartPeriod: "60s",
+	}
 }
 
 // buildCustomService returns the service configuration for a user-defined
@@ -81,13 +158,7 @@ func (g *Generator) buildCustomService(cs config.CustomService) ServiceConfig {
 		Ports: []string{
 			fmt.Sprintf("127.0.0.1:%d:%d", cs.Port, cs.Port),
 		},
-		Healthcheck: &Healthcheck{
-			Test:        []string{"CMD", "wget", "-qO-", fmt.Sprintf("http://localhost:%d/health", cs.Port)},
-			Interval:    "30s",
-			Timeout:     "10s",
-			Retries:     3,
-			StartPeriod: "60s",
-		},
+		Healthcheck: buildHealthcheck(cs),
 		Deploy: &DeployConfig{
 			Resources: &Resources{
 				Limits: &ResourceLimits{

--- a/internal/config/custom_services.go
+++ b/internal/config/custom_services.go
@@ -14,7 +14,8 @@ import (
 //
 // If port is omitted or zero, it auto-assigns 8000+N.
 // Per-service overrides are read from CS_N_PUBLIC, CS_N_MEMORY, CS_N_CPU,
-// CS_N_PORT, and CS_N_ROUTE environment variables.
+// CS_N_PORT, CS_N_ROUTE, CS_N_HEALTHCHECK, and CS_N_ENV_PASSTHROUGH
+// environment variables.
 func parseCustomServices() ([]CustomService, error) {
 	var services []CustomService
 	for i := 1; i <= 10; i++ {
@@ -67,6 +68,8 @@ func parseCustomServices() ([]CustomService, error) {
 		cs.CPU = getEnvOr(fmt.Sprintf("CS_%d_CPU", i), "0.5")
 		cs.TablePrefix = os.Getenv(fmt.Sprintf("CS_%d_TABLE_PREFIX", i))
 		cs.ExtraEnv = os.Getenv(fmt.Sprintf("CS_%d_ENV", i))
+		cs.HealthCheck = os.Getenv(fmt.Sprintf("CS_%d_HEALTHCHECK", i))
+		cs.EnvPassthrough = os.Getenv(fmt.Sprintf("CS_%d_ENV_PASSTHROUGH", i))
 
 		// Optional build context path override. Rejects absolute paths and
 		// path traversal so a misconfigured env can't escape the project root.

--- a/internal/config/types_ops_plugins.go
+++ b/internal/config/types_ops_plugins.go
@@ -144,6 +144,16 @@ type CustomService struct {
 	TablePrefix string // CS_N_TABLE_PREFIX
 	ExtraEnv    string // CS_N_ENV (raw key=val pairs, comma-separated)
 	BuildPath   string // CS_N_PATH: overrides default ./services/{name} build context
+
+	// HealthCheck is CS_N_HEALTHCHECK: a path (e.g. "/auth/health"), a full
+	// "CMD ..." / "CMD-SHELL ..." override, or "disabled"/"none"/"false" to
+	// omit the healthcheck entirely. Empty keeps the default GET /health.
+	HealthCheck string
+
+	// EnvPassthrough is CS_N_ENV_PASSTHROUGH: a comma-separated allowlist of
+	// project .env var names to forward into this container in addition to
+	// the fixed core set from coreEnvVars. CS_N_ENV still wins on conflict.
+	EnvPassthrough string
 }
 
 // FrontendApp represents a frontend application (FRONTEND_APP_1..FRONTEND_APP_20).


### PR DESCRIPTION
## What / why

Found while shipping `web#212` (auth_server as CS_8, P6 AUTH-SERVER-DEPLOY-CONFIG unit): auth_server serves `/auth/health`, but the generated healthcheck always probed `GET /health` and ignored a declared `CS_N_HEALTHCHECK` env var, so any custom service with a non-default health path reports unhealthy forever regardless of actual state. Separately, custom services receive only a fixed generic env set + `CS_N_ENV` (never the rest of the project's `.env`), which was undocumented and surprising when discovered against `coreEnvVars`.

This PR (FIX-CLI-4):
1. Implements `CS_N_HEALTHCHECK` in `buildHealthcheck` (`internal/compose/custom_services.go`): a path (e.g. `/auth/health`) overrides the probed path; a full `CMD`/`CMD-SHELL ...` command is passed through verbatim; `disabled`/`none`/`false` omits the healthcheck. Default (unset) keeps the prior hardcoded `GET /health` behavior byte-for-byte.
2. Keeps the fixed-env design (option a from the ticket — explicit, auditable per-service surface area) and documents it, adding `CS_N_ENV_PASSTHROUGH` as an explicit comma-separated allowlist to forward named project `.env` vars into a service. `CS_N_ENV` still wins on a name conflict.
3. Fixes `.github/wiki/Config-Custom-Services.md`, which incorrectly claimed all non-conflicting project `.env` vars were already forwarded into every custom service — that was never true; replaced with the actual fixed-set + passthrough-allowlist behavior. Adds both new vars to `.github/wiki/Config-Env-Vars.md`.

No behavior change for any project that doesn't set `CS_N_HEALTHCHECK` or `CS_N_ENV_PASSTHROUGH`.

## Acceptance evidence

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test ./internal/compose/... ./internal/config/...` — 394 passed.
- `go test ./...` (full suite, under local heavy-lock) — all packages `ok`.
- Table-driven tests over the real generator: `TestBuildHealthcheck` (default/custom-path/bare-path/CMD-override/disabled×3 cases), `TestBuildCustomService_HealthcheckDisabled`, `TestBuildCustomService_HealthcheckCustomPath` (the exact auth_server /auth/health scenario).
- `CS_N_ENV_PASSTHROUGH` covered by `TestCoreEnvVars_EnvPassthrough_{Forwarded,MultipleNames,AbsentSkipped,ExtraEnvWins,Absent}`.

## Scope note

Per the P6 crunch-agent brief, this PR stays inside `internal/compose/custom_services.go` + its tests, `internal/config/custom_services.go` + `types_ops_plugins.go`, and the two wiki pages. It does not merge — cli PR merges are owned by session nself-33.