### PR TITLE
fix(doctor): SEC-HARDENING-06 detects rate limiting by service identity (#379)

### DIFF
--- a/.github/wiki/Nginx-Generation.md
+++ b/.github/wiki/Nginx-Generation.md
@@ -139,8 +139,26 @@ Source: `internal/nginx/generator.go`'s `defaultSecurityPathZones()`
 by `internal/nginx/templates/service.conf.tmpl`; custom-domain equivalent
 in `cmd/commands/ssl_install.go`'s `writeCustomDomainConf()`. Verified by
 `nself doctor --deep`'s `SEC-HARDENING-06` check
-(`internal/doctor/hardening_check_nginx_zones.go`), which scans generated
-confs for both paths each co-occurring with `limit_req`.
+(`internal/doctor/hardening_check_nginx_zones.go`), which accepts either of
+two signals per generated conf file — it does not require both:
+
+1. **Service identity** (cli#379): the file is split into its `server {}`
+   blocks, and a block whose `server_name` first label is a known
+   auth/API hostname (`auth` for the auth service; `api`, `hasura`,
+   `graphql`, `ping`, or `ping-api` for the API/Hasura/ping-api surface —
+   see `nginx.Route` defaults in `internal/nginx/routes_core.go` and the
+   shipped `CS_1_ROUTE=ping` example in
+   `internal/setup/setup_env_files.go`) contains a `limit_req` directive
+   anywhere in its body, including the server-wide `location /` zone from
+   the table above — not only the path-scoped blocks.
+2. **Literal path fallback** (original behavior): the file contains
+   `limit_req` co-occurring with the literal string `/auth/login` or
+   `/api/`, for hand-written gateway configs that route by path instead
+   of by `server_name`.
+
+A conf with no `limit_req` anywhere fails both signals, and a `limit_req`
+confined to an unrelated service's block (e.g. only a frontend app's
+`location /`) satisfies neither.
 
 ---
 

--- a/internal/doctor/hardening_check_nginx_zones.go
+++ b/internal/doctor/hardening_check_nginx_zones.go
@@ -1,13 +1,39 @@
 package doctor
 
 // hardening_check_nginx_zones.go — SEC-HARDENING-06: nginx rate-limit zones
-// for /auth/login and /api/. Split out of hardening_check_auth_net.go
+// for the auth and API surfaces. Split out of hardening_check_auth_net.go
 // (CLI-R12) as a pure move.
 //
 // Inputs: a context (for the docker-exec fallback) and the project directory.
 // Outputs: a single CheckResult — pass/warn/fail with remediation hint.
 // Constraints: depends on hardeningSection, defined elsewhere in this package.
 // SPORT: cli/internal/doctor — decomposed from hardening_check.go (T-E2-06).
+//
+// Detection strategy (cli#379): the default `nself build` nginx layout is
+// one `server {}` block per service, named by `server_name
+// <route>.<domain>` (internal/nginx/templates/service.conf.tmpl) — auth's
+// route defaults to "auth" (routes_core.go), Hasura/GraphQL's to "api", and
+// the shipped ping-api example custom service to "ping"
+// (internal/setup/setup_env_files.go: CS_1_ROUTE=ping). A hand-rolled or
+// pre-P6-E2-W2-S3-T20 config may instead rate-limit the whole server block
+// (`limit_req` inside `location /`) without ever mentioning the literal
+// paths /auth/login or /api/ anywhere in the file — the original
+// literal-path substring scan can never pass that shape even though the
+// service genuinely is rate-limited. So this check now looks for EITHER
+// signal, per file:
+//  1. Service identity: split the file into server{} blocks, read each
+//     block's server_name, and if a block whose first hostname label
+//     matches a known auth/API route name also contains a `limit_req`
+//     directive anywhere inside it (location / or a path-scoped location),
+//     that half is satisfied.
+//  2. Literal path fallback (original behavior, kept unweakened): the file
+//     contains both "limit_req" and the literal "/auth/login" or "/api/"
+//     path string, for hand-written gateway configs that route by path
+//     rather than by server_name.
+// A config with no limit_req anywhere still fails both signals. A
+// limit_req confined to an unrelated server block (e.g. only the "static"
+// frontend route) satisfies neither signal, since that block's server_name
+// matches no known auth/API identity and the file lacks the literal paths.
 
 import (
 	"context"
@@ -15,19 +41,152 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/nself-org/cli/internal/health"
 )
 
+// nginxAuthRouteNames are the first-label server_name hostnames that
+// identify a server block as fronting the auth service. "auth" is the
+// generator's default (routes_core.go authRoute) and survives app-prefixed
+// routes too (appPrefixedRoute produces "auth.<appname>", whose first label
+// is still "auth").
+var nginxAuthRouteNames = map[string]bool{
+	"auth": true,
+}
+
+// nginxAPIRouteNames are the first-label server_name hostnames that
+// identify a server block as fronting the API/GraphQL surface. "api" is
+// Hasura's default route (routes_core.go hasuraRoute), "hasura" and
+// "graphql" cover an explicitly-renamed Hasura route, and "ping"/"ping-api"
+// cover the shipped ping-api custom-service example
+// (CS_1_NAME=ping-api, CS_1_ROUTE=ping in setup_env_files.go) — the same
+// service cli#379 named as already being rate-limited on staging.
+var nginxAPIRouteNames = map[string]bool{
+	"api":      true,
+	"hasura":   true,
+	"graphql":  true,
+	"ping":     true,
+	"ping-api": true,
+}
+
+// nginxServerBlockRe finds the start of each top-level `server { ... }`
+// block so its contents can be brace-matched out of the surrounding file.
+var nginxServerBlockRe = regexp.MustCompile(`(?m)^\s*server\s*\{`)
+
+// nginxServerNameRe extracts the hostname(s) from a `server_name ...;`
+// directive inside a server block.
+var nginxServerNameRe = regexp.MustCompile(`server_name\s+([^;]+);`)
+
+// nginxServerBlock is one parsed `server {}` block: its declared
+// server_name hostnames and whether it contains a limit_req directive
+// anywhere in its body (location / or a path-scoped location).
+type nginxServerBlock struct {
+	serverNames []string
+	hasLimitReq bool
+}
+
+// extractNginxServerBlocks splits nginx config content into its top-level
+// server{} blocks via brace counting, so a limit_req found in one service's
+// block is never misattributed to another. Nested blocks (location {})
+// share the same brace depth as their parent, so counting to zero finds
+// the correct outer closing brace regardless of nesting.
+func extractNginxServerBlocks(content string) []nginxServerBlock {
+	var blocks []nginxServerBlock
+	pos := 0
+	for {
+		loc := nginxServerBlockRe.FindStringIndex(content[pos:])
+		if loc == nil {
+			break
+		}
+		start := pos + loc[0]
+		braceIdx := pos + loc[1] - 1 // index of the opening '{'
+		depth := 1
+		i := braceIdx + 1
+		for i < len(content) && depth > 0 {
+			switch content[i] {
+			case '{':
+				depth++
+			case '}':
+				depth--
+			}
+			i++
+		}
+		body := content[start:i]
+		pos = i
+
+		var names []string
+		for _, m := range nginxServerNameRe.FindAllStringSubmatch(body, -1) {
+			for _, h := range strings.Fields(m[1]) {
+				names = append(names, strings.ToLower(h))
+			}
+		}
+		blocks = append(blocks, nginxServerBlock{
+			serverNames: names,
+			hasLimitReq: strings.Contains(body, "limit_req"),
+		})
+		if pos >= len(content) {
+			break
+		}
+	}
+	return blocks
+}
+
+// nginxHostnameFirstLabel returns the lowercased first dot-separated label
+// of a server_name hostname, e.g. "auth.myapp.staging.nself.org" -> "auth".
+func nginxHostnameFirstLabel(hostname string) string {
+	if i := strings.IndexByte(hostname, '.'); i >= 0 {
+		return hostname[:i]
+	}
+	return hostname
+}
+
+// scanNginxContentForRateZones applies both detection signals (service
+// identity by server_name, and the literal-path fallback) to one file's
+// raw nginx config text, returning which of the auth/API halves it
+// satisfies.
+func scanNginxContentForRateZones(content string) (authZone, apiZone bool) {
+	// Signal 1: service identity — a server{} block whose server_name
+	// identifies it as auth or API AND that contains a limit_req anywhere
+	// in its body (server-wide `location /` zone or a path-scoped one).
+	for _, block := range extractNginxServerBlocks(content) {
+		if !block.hasLimitReq {
+			continue
+		}
+		for _, name := range block.serverNames {
+			label := nginxHostnameFirstLabel(name)
+			if nginxAuthRouteNames[label] {
+				authZone = true
+			}
+			if nginxAPIRouteNames[label] {
+				apiZone = true
+			}
+		}
+	}
+
+	// Signal 2: literal path fallback (original behavior, unweakened) —
+	// hand-written gateway configs that route by literal path instead of
+	// by server_name.
+	if strings.Contains(content, "/auth/login") && strings.Contains(content, "limit_req") {
+		authZone = true
+	}
+	if strings.Contains(content, "/api/") && strings.Contains(content, "limit_req") {
+		apiZone = true
+	}
+
+	return authZone, apiZone
+}
+
 // checkHardeningNginxRateZones verifies nginx has limit_req_zone + limit_req
-// directives covering /auth/login and /api/, first by scanning local config
-// files, then by grepping inside the running nginx container as a fallback.
+// directives covering the auth and API surfaces, first by scanning local
+// config files, then by grepping inside the running nginx container as a
+// fallback. See the file-level doc comment for the two detection signals.
 func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckResult {
 	const checkID = "SEC-HARDENING-06"
 
 	// Search nginx/conf.d/ and nginx/sites/ for limit_req_zone + limit_req directives
-	// covering the two required paths.
+	// covering the auth and API surfaces.
 	nginxDirs := []string{
 		filepath.Join(projectDir, "nginx", "conf.d"),
 		filepath.Join(projectDir, "nginx", "sites"),
@@ -63,11 +222,11 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 			if err != nil {
 				continue
 			}
-			content := string(data)
-			if strings.Contains(content, "/auth/login") && strings.Contains(content, "limit_req") {
+			authZone, apiZone := scanNginxContentForRateZones(string(data))
+			if authZone {
 				hasAuthZone = true
 			}
-			if strings.Contains(content, "/api/") && strings.Contains(content, "limit_req") {
+			if apiZone {
 				hasAPIZone = true
 			}
 		}
@@ -77,14 +236,14 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 	if !hasAuthZone || !hasAPIZone {
 		nginxContainer := health.ContainerName(resolveProjectName(projectDir), "nginx")
 		cmd := exec.CommandContext(ctx, "docker", "exec", nginxContainer,
-			"grep", "-r", "limit_req", "/etc/nginx/")
+			"sh", "-c", "cat /etc/nginx/nginx.conf /etc/nginx/conf.d/* /etc/nginx/sites/* 2>/dev/null")
 		out, err := cmd.Output()
 		if err == nil {
-			content := string(out)
-			if strings.Contains(content, "auth/login") {
+			authZone, apiZone := scanNginxContentForRateZones(string(out))
+			if authZone {
 				hasAuthZone = true
 			}
-			if strings.Contains(content, "/api/") {
+			if apiZone {
 				hasAPIZone = true
 			}
 		}
@@ -96,26 +255,26 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 			Section: hardeningSection,
 			Name:    checkID,
 			Status:  "pass",
-			Message: "SEC-HARDENING-06: nginx rate-limit zones set for /auth/login and /api/",
+			Message: "SEC-HARDENING-06: nginx rate-limit zones set for the auth and API services",
 		}
 	case !hasAuthZone && !hasAPIZone:
 		return CheckResult{
 			Section: hardeningSection,
 			Name:    checkID,
 			Status:  "fail",
-			Message: "SEC-HARDENING-06: nginx missing rate-limit zones for /auth/login and /api/ — add limit_req_zone directives",
+			Message: "SEC-HARDENING-06: nginx missing rate-limit zones for the auth and API services — add limit_req_zone directives",
 			FixCmd:  "See nself.org/docs/security/nginx-rate-limiting",
 		}
 	default:
-		missing := "/api/"
+		missing := "the API service (e.g. hasura/api.<domain>)"
 		if !hasAuthZone {
-			missing = "/auth/login"
+			missing = "the auth service (auth.<domain>)"
 		}
 		return CheckResult{
 			Section: hardeningSection,
 			Name:    checkID,
 			Status:  "warn",
-			Message: fmt.Sprintf("SEC-HARDENING-06: nginx rate-limit zone missing for %s — add limit_req_zone directive", missing),
+			Message: fmt.Sprintf("SEC-HARDENING-06: nginx rate-limit zone missing for %s — add a limit_req directive", missing),
 			FixCmd:  "See nself.org/docs/security/nginx-rate-limiting",
 		}
 	}

--- a/internal/doctor/hardening_check_test.go
+++ b/internal/doctor/hardening_check_test.go
@@ -290,6 +290,142 @@ func TestCheckHardeningNginxRateZones_RealGeneratorOutputPasses(t *testing.T) {
 	}
 }
 
+// TestCheckHardeningNginxRateZones_ServiceIdentity is the cli#379
+// regression: detect rate limiting by server_name/service identity, not
+// just the literal /auth/login and /api/ path substrings, while keeping
+// the literal-path match as a fallback and never weakening the check
+// (no limit_req anywhere must still fail; a limit_req in an unrelated
+// server block must still fail).
+func TestCheckHardeningNginxRateZones_ServiceIdentity(t *testing.T) {
+	tests := []struct {
+		name       string
+		files      map[string]string
+		wantStatus string
+	}{
+		{
+			// The exact shape cli#379 reported: one server{} block per
+			// service, named by server_name, with limit_req only inside
+			// the server-wide `location /` — no literal /auth/login or
+			// /api/ path anywhere. Pre-fix this always failed.
+			name: "generated-shape config: server_name-per-service, limit_req in location /",
+			files: map[string]string{
+				"auth.conf": `
+server {
+    listen 443 ssl;
+    server_name auth.staging.nself.org;
+    location / {
+        limit_req zone=auth burst=5 nodelay;
+        set $up_auth auth:4000;
+        proxy_pass $up_auth;
+    }
+}
+`,
+				"hasura.conf": `
+server {
+    listen 443 ssl;
+    server_name api.staging.nself.org;
+    location / {
+        limit_req zone=graphql_api burst=20 nodelay;
+        set $up_hasura hasura:8080;
+        proxy_pass $up_hasura;
+    }
+}
+`,
+			},
+			wantStatus: "pass",
+		},
+		{
+			// Hand-written gateway that routes by literal path instead of
+			// by server_name — the original detection signal, kept as a
+			// fallback and must keep passing.
+			name: "literal-path legacy gateway config",
+			files: map[string]string{
+				"gateway.conf": `
+limit_req_zone $binary_remote_addr zone=auth_login:10m rate=5r/m;
+location /auth/login { limit_req zone=auth_login; }
+limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
+location /api/ { limit_req zone=api; }
+`,
+			},
+			wantStatus: "pass",
+		},
+		{
+			name: "no limit_req anywhere",
+			files: map[string]string{
+				"default.conf": "server {\n    listen 80;\n    server_name example.com;\n    location / { proxy_pass http://app:3000; }\n}\n",
+			},
+			wantStatus: "fail",
+		},
+		{
+			// limit_req exists, but only inside a server block whose
+			// server_name identifies neither the auth nor the API
+			// service, and no literal path fallback applies. Must not be
+			// misread as satisfying either half.
+			name: "limit_req only in an unrelated server block",
+			files: map[string]string{
+				"static.conf": `
+server {
+    listen 443 ssl;
+    server_name static.staging.nself.org;
+    location / {
+        limit_req zone=static burst=10 nodelay;
+        set $up_static frontend:3000;
+        proxy_pass $up_static;
+    }
+}
+`,
+			},
+			wantStatus: "fail",
+		},
+		{
+			// Auth half satisfied by identity, API half present but not
+			// actually rate-limited — must land on warn, not pass.
+			name: "auth satisfied by identity, api block present but unlimited",
+			files: map[string]string{
+				"auth.conf": `
+server {
+    server_name auth.staging.nself.org;
+    location / {
+        limit_req zone=auth burst=5 nodelay;
+        proxy_pass http://auth:4000;
+    }
+}
+`,
+				"hasura.conf": `
+server {
+    server_name api.staging.nself.org;
+    location / {
+        proxy_pass http://hasura:8080;
+    }
+}
+`,
+			},
+			wantStatus: "warn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			confDir := filepath.Join(dir, "nginx", "sites")
+			if err := os.MkdirAll(confDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			for fname, content := range tt.files {
+				if err := os.WriteFile(filepath.Join(confDir, fname), []byte(content), 0o644); err != nil {
+					t.Fatalf("write %s: %v", fname, err)
+				}
+			}
+
+			ctx := context.Background()
+			res := checkHardeningNginxRateZones(ctx, dir)
+			if res.Status != tt.wantStatus {
+				t.Errorf("status=%q, want %q; msg=%s", res.Status, tt.wantStatus, res.Message)
+			}
+		})
+	}
+}
+
 // ─── SEC-HARDENING-08: Encryption at rest ───────────────────────────────────
 
 func TestCheckHardeningEncryptionAtRest_EnvSet(t *testing.T) {


### PR DESCRIPTION
## What / why

`nself doctor --deep`'s SEC-HARDENING-06 check grepped generated nginx config for the literal strings `/auth/login` and `/api/` co-occurring with `limit_req`. nSelf's default `nself build` layout is one `server {}` block per service, named by `server_name <route>.<domain>` (e.g. `auth.<domain>`, `api.<domain>` for Hasura), with `limit_req` inside the server-wide `location /` block — no literal path strings anywhere. The check always failed against this default layout; found on staging (167.235.233.65) closing P6-E8-W1-S1-T2.

Fixes #379.

## Fix

`checkHardeningNginxRateZones` (`internal/doctor/hardening_check_nginx_zones.go`) now accepts either of two signals per config file:

1. **Service identity**: split the file into its `server {}` blocks (brace-matched, so nested `location {}` blocks don't break parsing), read each block's `server_name`, and if a block whose first hostname label is a known auth/API route name (`auth` — auth service default; `api`, `hasura`, `graphql` — Hasura/GraphQL defaults/aliases; `ping`, `ping-api` — the shipped `CS_1_ROUTE=ping` example, the same service cli#379 named as already rate-limited on staging) contains `limit_req` anywhere in its body, that half is satisfied.
2. **Literal path fallback** (original behavior, unweakened): the file contains `limit_req` co-occurring with the literal `/auth/login` or `/api/` string, for hand-written gateway configs that route by path.

Neither signal weakens the check: no `limit_req` anywhere still fails both, and a `limit_req` confined to an unrelated server block (e.g. only a frontend app) still satisfies neither.

Also updated `.github/wiki/Nginx-Generation.md`'s SEC-HARDENING-06 section to document both detection signals.

## Test table (`TestCheckHardeningNginxRateZones_ServiceIdentity`, table-driven)

| Case | Shape | Want |
|---|---|---|
| generated-shape config | server_name-per-service (`auth.<domain>`, `api.<domain>`), `limit_req` only in `location /`, no literal paths | **pass** |
| literal-path legacy gateway | single file, literal `/auth/login` + `/api/` locations | **pass** |
| no limit_req anywhere | plain server block, no rate limiting | **fail** |
| limit_req only in unrelated block | `static.<domain>` block rate-limited, auth/api absent | **fail** |
| auth identified, api block present but unlimited | mixed | **warn** |

Plus the pre-existing `TestCheckHardeningNginxRateZones_BothPresent`, `_NonePresent`, and `_RealGeneratorOutputPasses` (closed-loop regression against real `nginx.Generate()` output) all still pass.

## Verification

- `go build ./...` — pass
- `go vet ./...` — clean
- `go test ./internal/doctor/...` — 190 passed
- `go test ./internal/nginx/...` — 57 passed
- `go test ./...` (under `~/bin/heavy-lock`) — all packages `ok`

## Scope

Local gate only — GitHub Actions billing is ignored per standing rule; this repo is public and GitHub-hosted so `gh pr checks` is safe to read once, but per crunch brief §8 I am not watching/polling CI here.