### PR TITLE
docs(wiki): fill the 8 TODO(docs) command pages (P6-E9-W4-S3-T1)

### DIFF
--- a/.github/wiki/cmd-account.md
+++ b/.github/wiki/cmd-account.md
@@ -216,10 +216,21 @@ nself account licenses list
 ## Examples
 
 <!-- BEGIN PROSE:examples -->
-<!-- TODO(docs): needs human prose -->
-
 ```bash
+# With no subcommand, show current account status
 nself account
+
+# Same thing, explicit
+nself account status
+
+# List devices registered to this account
+nself account devices
+
+# List active licenses linked to this account
+nself account licenses
+
+# Move a license to another account
+nself account transfer
 ```
 <!-- END PROSE:examples -->
 

--- a/.github/wiki/cmd-backup.md
+++ b/.github/wiki/cmd-backup.md
@@ -313,10 +313,18 @@ Outputs the public key to add to `.env` as `BACKUP_AGE_RECIPIENTS`.
 ## Examples
 
 <!-- BEGIN PROSE:examples -->
-<!-- TODO(docs): needs human prose -->
-
 ```bash
-nself backup
+# Create a local backup
+nself backup create
+
+# List available backups
+nself backup list
+
+# Stream an encrypted backup straight to S3, no temp files
+nself backup stream --to s3:mybucket/backups --recipient age1abc123
+
+# Check backup subsystem status: last run, next scheduled, retention
+nself backup status
 ```
 <!-- END PROSE:examples -->
 

--- a/.github/wiki/cmd-bundle.md
+++ b/.github/wiki/cmd-bundle.md
@@ -223,10 +223,18 @@ Buy or manage subscriptions at: https://nself.org/pricing
 ## Examples
 
 <!-- BEGIN PROSE:examples -->
-<!-- TODO(docs): needs human prose -->
-
 ```bash
-nself bundle
+# List all available bundles with pricing and plugin counts
+nself bundle list
+
+# See what's in the ɳClaw bundle and your current license status
+nself bundle info nclaw
+
+# Install every plugin in a bundle in one transaction
+nself bundle install nclaw
+
+# Preview a bundle removal without changing anything
+nself bundle remove ntv --dry-run
 ```
 <!-- END PROSE:examples -->
 

--- a/.github/wiki/cmd-db.md
+++ b/.github/wiki/cmd-db.md
@@ -247,10 +247,19 @@ nself db hasura validate
 ## Examples
 
 <!-- BEGIN PROSE:examples -->
-<!-- TODO(docs): needs human prose -->
-
 ```bash
-nself db
+# Apply all pending migrations
+nself db migrate up
+
+# Open an interactive psql shell inside the Postgres container
+nself db shell
+
+# Audit RLS policies and schema for tenant-scoped tables
+nself db lint
+
+# Take a local backup, then check migration status
+nself db backup
+nself db migrate status
 ```
 <!-- END PROSE:examples -->
 

--- a/.github/wiki/cmd-functions.md
+++ b/.github/wiki/cmd-functions.md
@@ -105,10 +105,18 @@ Resource limits are controlled by `FUNCTIONS_MEMORY` (default `256M`) and `FUNCT
 ## Examples
 
 <!-- BEGIN PROSE:examples -->
-<!-- TODO(docs): needs human prose -->
-
 ```bash
-nself functions
+# Deploy a function from a single file
+nself functions deploy hello-world.ts
+
+# List deployed functions and their health status
+nself functions list
+
+# Invoke a function with a JSON payload
+nself functions invoke hello-world --payload '{"name":"Alice"}'
+
+# Follow logs for a running function
+nself functions logs hello-world --follow
 ```
 <!-- END PROSE:examples -->
 

--- a/.github/wiki/cmd-oauth.md
+++ b/.github/wiki/cmd-oauth.md
@@ -84,10 +84,15 @@ nself oauth refresh --all
 ## Examples
 
 <!-- BEGIN PROSE:examples -->
-<!-- TODO(docs): needs human prose -->
-
 ```bash
-nself oauth
+# Refresh Google OAuth tokens now, outside the cron schedule
+nself oauth refresh google
+
+# Refresh just one account
+nself oauth refresh google --account-id user@example.com
+
+# Refresh every configured provider in parallel
+nself oauth refresh --all
 ```
 <!-- END PROSE:examples -->
 

--- a/.github/wiki/cmd-security.md
+++ b/.github/wiki/cmd-security.md
@@ -87,10 +87,18 @@ Security: 5/6 checks passing | Last audit: 2 hours ago
 ## Examples
 
 <!-- BEGIN PROSE:examples -->
-<!-- TODO(docs): needs human prose -->
-
 ```bash
-nself security
+# Run a read-only security audit
+nself security audit
+
+# Preview hardening changes without applying them
+nself security setup
+
+# Apply hardening for real (requires root)
+sudo nself security setup --apply
+
+# One-line posture summary
+nself security status
 ```
 <!-- END PROSE:examples -->
 

--- a/.github/wiki/cmd-template.md
+++ b/.github/wiki/cmd-template.md
@@ -210,10 +210,18 @@ nself template update --force
 ## Examples
 
 <!-- BEGIN PROSE:examples -->
-<!-- TODO(docs): needs human prose -->
-
 ```bash
-nself template
+# Browse available templates
+nself template list
+
+# Filter to free templates, sorted by rating
+nself template list --free --sort rating
+
+# Inspect one template before installing
+nself template info saas-starter
+
+# Scaffold a new project from a marketplace template
+nself init --template saas-starter ./my-saas
 ```
 <!-- END PROSE:examples -->
 


### PR DESCRIPTION
## What
Fills the Examples section on the 8 cmd-*.md wiki pages that still carried a literal `<!-- TODO(docs) -->` placeholder: cmd-account, cmd-backup, cmd-bundle, cmd-db, cmd-functions, cmd-oauth, cmd-security, cmd-template.

## Why
P6-E9-T1 doc-sync gap measurement (`.claude/phases/current/p6/qa/e9-t1-doc-sync-gaps.md`) found 8 of the 50 top-level command wiki pages under `.github/wiki/cmd-*.md` still had unfinished Examples sections.

## How
Each page's Description section already had accurate, human-written prose describing subcommands and flags (sourced from `cmd/commands/*.go` on origin/main). The gap was only the bare, comment-free Examples block at the bottom. Replaced each with 3-4 real invocations built strictly from subcommand/flag names already verified elsewhere on the same page — no new flags invented. Verified `account status` (not `show`) is the correct default subcommand by reading `cmd/commands/account.go` directly.

## Evidence
- `grep -rn 'TODO(docs)' .github/wiki` → empty (repo-wide)
- `grep -L 'TODO\|placeholder' .github/wiki/cmd-*.md` → 109/110 pages clean; the one remaining hit (`cmd-ssl.md`) is legitimate prose about a "200 placeholder response," not a doc-gap marker, and was not touched
- No other content changed on any of the 8 pages (diff is Examples-block only)

Ticket: P6-E9-W4-S3-T1