### PR TITLE
fix(doctor): audit the served nginx dir for SEC-HARDENING-06 on fronted stacks

### DIFF
--- a/internal/doctor/hardening_check_nginx_fronted_dir.go
+++ b/internal/doctor/hardening_check_nginx_fronted_dir.go
@@ -1,0 +1,106 @@
+package doctor
+
+// hardening_check_nginx_fronted_dir.go — resolves which on-disk directory a
+// fronted project's nginx checks should audit.
+//
+// Purpose: split out of hardening_check_nginx_zones.go so "which directory
+// do we audit" (a filesystem/topology question) stays separate from "does
+// that directory's config carry the right rate limits" (a content-scanning
+// question). Also gives a future ResolveServedNginxDir generalization (any
+// check that needs the served nginx dir, not just SEC-HARDENING-06) a home.
+// Inputs: projectDir (the nSelf working directory) and the configured
+// NGINX_FRONTED_BY stack name.
+// Outputs: the resolved directory and whether resolution succeeded.
+// Constraints: never guesses — returns ok=false rather than a wrong path.
+// SPORT: cli/internal/doctor — SEC-HARDENING-06 fronted-topology fix.
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// resolveNginxFrontedDir resolves the on-disk nginx directory for a project
+// fronted by another stack (NGINX_FRONTED_BY — see config.NginxConfig.FrontedBy).
+//
+// FrontedBy carries only a stack NAME (e.g. "nself-web"), never a path, and
+// none of the codebase's other three consumers of it
+// (internal/build/detection.go, internal/build/manifest_resolve.go,
+// internal/compose/generator.go) resolve that name to a filesystem
+// location — all three only test it for emptiness, to decide whether to
+// generate this project's own nginx service. There is no config-driven
+// convention anywhere in this CLI for turning a stack name into a directory
+// in the general case, so this function does not attempt one.
+//
+// The one topology it trusts is the one that caused the regression this
+// check exists to catch (cli#380/cli#371 on staging): this project living
+// as a subdirectory (conventionally "backend") directly under the fronting
+// stack's own directory, whose basename equals FrontedBy — e.g. projectDir
+// ".../nself-web/backend" with FrontedBy "nself-web" resolves to
+// ".../nself-web/nginx". That is a structural inference from the directory
+// layout the operator already chose, not a second FrontedBy-to-path
+// convention grafted onto config. When the parent directory's name does
+// not match, this function returns ok=false — the caller must not guess
+// further and silently audit the wrong directory.
+func resolveNginxFrontedDir(projectDir, frontedBy string) (dir string, ok bool) {
+	parent := filepath.Dir(projectDir)
+	if parent == projectDir || filepath.Base(parent) != frontedBy {
+		return "", false
+	}
+	return parent, true
+}
+
+// nginxAuditPlan is the outcome of deciding which directory
+// checkHardeningNginxRateZones should scan for SEC-HARDENING-06. skip is
+// non-nil when the plan could not be resolved for a fronted project — the
+// caller must return it as-is rather than falling through to a scan.
+type nginxAuditPlan struct {
+	auditDir           string
+	skipDockerFallback bool
+	skip               *CheckResult
+}
+
+// planNginxAudit decides which directory's nginx/** SEC-HARDENING-06 should
+// read for projectDir.
+//
+// Fronted deployments (cli#380/cli#371 staging regression): when
+// NGINX_FRONTED_BY names another stack as this project's ingress, this
+// project's own <projectDir>/nginx/** is not what the running nginx reads
+// — the fronting stack's nginx directory is, and this project generates no
+// nginx container of its own to fall back to (internal/build/detection.go).
+// Auditing <projectDir>/nginx/** unconditionally let SEC-HARDENING-06 pass
+// or fail off a directory nginx never serves from.
+//
+// When unfronted (the default), the plan is unchanged from before this
+// fix: auditDir is projectDir itself and the docker-exec fallback applies.
+// When fronted and resolveNginxFrontedDir cannot confirm the real
+// directory, skip carries a "skip" CheckResult stating why, so the caller
+// never silently scans (and passes or fails on) the wrong directory.
+func planNginxAudit(projectDir string) nginxAuditPlan {
+	plan := nginxAuditPlan{auditDir: projectDir}
+
+	cfg, err := config.Load(projectDir)
+	if err != nil || cfg.Nginx.FrontedBy == "" {
+		return plan
+	}
+
+	// Fronted: this project has no nginx container of its own to exec
+	// into (internal/build/detection.go), regardless of whether the real
+	// directory below resolves.
+	plan.skipDockerFallback = true
+
+	resolved, ok := resolveNginxFrontedDir(projectDir, cfg.Nginx.FrontedBy)
+	if !ok {
+		plan.skip = &CheckResult{
+			Section: hardeningSection,
+			Name:    "SEC-HARDENING-06",
+			Status:  "skip",
+			Message: fmt.Sprintf("SEC-HARDENING-06: skipped — audited nothing. Project is fronted by nginx stack %q (NGINX_FRONTED_BY) but its nginx directory could not be resolved from %q; %s's own nginx config was not scanned here and must be audited directly for rate-limit zones", cfg.Nginx.FrontedBy, projectDir, cfg.Nginx.FrontedBy),
+		}
+		return plan
+	}
+
+	plan.auditDir = resolved
+	return plan
+}

--- a/internal/doctor/hardening_check_nginx_fronted_test.go
+++ b/internal/doctor/hardening_check_nginx_fronted_test.go
@@ -21,6 +21,7 @@ package doctor
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,22 @@ location /auth/login { limit_req zone=auth_login; }
 limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
 location /api/ { limit_req zone=api; }
 `
+
+// messageNamesPath reports whether msg names path as evidence, tolerating
+// both a literal embed (fmt %s, used by the pass/fail/warn messages) and a
+// Go-quoted embed (fmt %q, used by the skip message). %q escapes backslash
+// as a literal two-character sequence, so on Windows — where path itself
+// contains single backslashes — a raw strings.Contains(msg, path) can never
+// match a %q-embedded copy of the same path; only its escaped form appears
+// in msg. This does not depend on which verb the source code happens to
+// use today, so it stays correct if that changes.
+func messageNamesPath(msg, path string) bool {
+	if strings.Contains(msg, path) {
+		return true
+	}
+	quoted := strings.Trim(fmt.Sprintf("%q", path), `"`)
+	return strings.Contains(msg, quoted)
+}
 
 // writeNginxConf writes a single conf.d file containing content under
 // <dir>/nginx/conf.d/ratelimit.conf, creating directories as needed.
@@ -193,7 +210,7 @@ func TestCheckHardeningNginxRateZones_FrontedTopology(t *testing.T) {
 			// check that can't produce this evidence is how the wrong-
 			// directory bug stayed hidden through cli#380 and cli#371.
 			for _, substr := range tt.wantMsgSubstrs(projectDir) {
-				if !strings.Contains(res.Message, substr) {
+				if !messageNamesPath(res.Message, substr) {
 					t.Errorf("message does not name expected evidence %q: %s", substr, res.Message)
 				}
 			}

--- a/internal/doctor/hardening_check_nginx_fronted_test.go
+++ b/internal/doctor/hardening_check_nginx_fronted_test.go
@@ -1,0 +1,202 @@
+package doctor
+
+// hardening_check_nginx_fronted_test.go — table-driven coverage for the
+// NGINX_FRONTED_BY handling in checkHardeningNginxRateZones.
+//
+// Purpose: prove SEC-HARDENING-06 audits the directory nginx actually
+// serves on a fronted deployment (staging: nginx mounts the parent
+// directory of the project dir, which is "backend"), instead of the
+// project's own <projectDir>/nginx/** — a directory the running nginx
+// never reads there. Before this fix the check silently scanned the wrong
+// directory, so it could pass while the live config had no rate limiting
+// (or fail while it did) without ever saying so.
+// Inputs: synthetic project trees under t.TempDir(), each with a .env
+// declaring NGINX_FRONTED_BY where the case is fronted.
+// Outputs: pass/fail/warn/skip assertions plus a check that every result's
+// Message names the directory that was actually audited (falsifiability).
+// Constraints: no real machine paths — fixtures are built fresh per test.
+// SPORT: cli/internal/doctor — closes the fronted-topology gap in
+// SEC-HARDENING-06 (cli#380/cli#371 did not actually close this on
+// staging).
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// nginxRateLimitFixture is a minimal conf.d file that satisfies both the
+// auth and API rate-limit signals via the literal-path fallback signal
+// (see scanNginxContentForRateZones).
+const nginxRateLimitFixture = `
+limit_req_zone $binary_remote_addr zone=auth_login:10m rate=5r/m;
+location /auth/login { limit_req zone=auth_login; }
+limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
+location /api/ { limit_req zone=api; }
+`
+
+// writeNginxConf writes a single conf.d file containing content under
+// <dir>/nginx/conf.d/ratelimit.conf, creating directories as needed.
+func writeNginxConf(t *testing.T, dir, content string) {
+	t.Helper()
+	confDir := filepath.Join(dir, "nginx", "conf.d")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", confDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "ratelimit.conf"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write ratelimit.conf: %v", err)
+	}
+}
+
+func TestCheckHardeningNginxRateZones_FrontedTopology(t *testing.T) {
+	tests := []struct {
+		name string
+		// setup builds the fixture tree and returns the projectDir to pass
+		// to checkHardeningNginxRateZones, plus the directory-path
+		// substring the result's Message must contain — the falsifiability
+		// proof that the result names what it actually looked at.
+		setup          func(t *testing.T) string
+		wantStatus     string
+		wantMsgSubstrs func(projectDir string) []string
+	}{
+		{
+			// (a) non-fronted, rate limits present at <projectDir>/nginx -> pass.
+			name: "non-fronted present passes",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeNginxConf(t, dir, nginxRateLimitFixture)
+				return dir
+			},
+			wantStatus: "pass",
+			wantMsgSubstrs: func(projectDir string) []string {
+				return []string{filepath.Join(projectDir, "nginx")}
+			},
+		},
+		{
+			// (b) non-fronted, rate limits absent -> fail (no Docker fallback
+			// available in this test environment).
+			name: "non-fronted absent fails",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeNginxConf(t, dir, "# empty\n")
+				return dir
+			},
+			wantStatus: "fail",
+			wantMsgSubstrs: func(projectDir string) []string {
+				return []string{filepath.Join(projectDir, "nginx")}
+			},
+		},
+		{
+			// (c) THE REGRESSION THIS FIXES: fronted, parent dir (named
+			// after the fronting stack) has the rate limits, backend/nginx
+			// (the project dir) does not. This is the staging shape —
+			// projectDir=".../nself-web/backend", nginx served from
+			// ".../nself-web/nginx". Must PASS: the check must read the
+			// parent, not the project's own (unserved) nginx dir.
+			name: "fronted parent has limits backend does not passes",
+			setup: func(t *testing.T) string {
+				base := t.TempDir()
+				parent := filepath.Join(base, "nself-web")
+				projectDir := filepath.Join(parent, "backend")
+				if err := os.MkdirAll(projectDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				// t.Setenv (not a .env file): config.Load's godotenv.Overload
+				// mutates process-wide env for keys present in a file, and
+				// that mutation outlives the subtest (Go tests in one
+				// package share a process) — it leaked NGINX_FRONTED_BY
+				// into every later test in this file the first time this
+				// used writeEnvFile. t.Setenv restores it automatically.
+				t.Setenv("NGINX_FRONTED_BY", "nself-web")
+				writeNginxConf(t, parent, nginxRateLimitFixture)     // served dir: has limits
+				writeNginxConf(t, projectDir, "# empty, unserved\n") // backend/nginx: none
+				return projectDir
+			},
+			wantStatus: "pass",
+			wantMsgSubstrs: func(projectDir string) []string {
+				// Must name the PARENT's nginx dir, not backend's.
+				return []string{filepath.Join(filepath.Dir(projectDir), "nginx")}
+			},
+		},
+		{
+			// (d) PROVES IT STOPPED READING THE WRONG DIR: fronted, parent
+			// lacks the limits, backend/nginx (unserved) has them. Must
+			// FAIL — if the check were still reading backend/nginx this
+			// would incorrectly pass.
+			name: "fronted parent lacks limits backend has them fails",
+			setup: func(t *testing.T) string {
+				base := t.TempDir()
+				parent := filepath.Join(base, "nself-web")
+				projectDir := filepath.Join(parent, "backend")
+				if err := os.MkdirAll(projectDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				// t.Setenv (not a .env file): config.Load's godotenv.Overload
+				// mutates process-wide env for keys present in a file, and
+				// that mutation outlives the subtest (Go tests in one
+				// package share a process) — it leaked NGINX_FRONTED_BY
+				// into every later test in this file the first time this
+				// used writeEnvFile. t.Setenv restores it automatically.
+				t.Setenv("NGINX_FRONTED_BY", "nself-web")
+				writeNginxConf(t, parent, "# empty, served dir has nothing\n")
+				writeNginxConf(t, projectDir, nginxRateLimitFixture) // backend/nginx: has limits, but unserved
+				return projectDir
+			},
+			wantStatus: "fail",
+			wantMsgSubstrs: func(projectDir string) []string {
+				return []string{filepath.Join(filepath.Dir(projectDir), "nginx")}
+			},
+		},
+		{
+			// (e) fronted but the directory cannot be resolved (parent dir
+			// name does not match FrontedBy) -> skip/unknown, never a
+			// silent pass on the wrong directory.
+			name: "fronted unresolvable directory skips",
+			setup: func(t *testing.T) string {
+				base := t.TempDir()
+				parent := filepath.Join(base, "some-other-name")
+				projectDir := filepath.Join(parent, "backend")
+				if err := os.MkdirAll(projectDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				// t.Setenv (not a .env file): config.Load's godotenv.Overload
+				// mutates process-wide env for keys present in a file, and
+				// that mutation outlives the subtest (Go tests in one
+				// package share a process) — it leaked NGINX_FRONTED_BY
+				// into every later test in this file the first time this
+				// used writeEnvFile. t.Setenv restores it automatically.
+				t.Setenv("NGINX_FRONTED_BY", "nself-web")
+				// Even if limits exist somewhere, they must not be trusted
+				// since the directory cannot be confirmed.
+				writeNginxConf(t, parent, nginxRateLimitFixture)
+				return projectDir
+			},
+			wantStatus: "skip",
+			wantMsgSubstrs: func(projectDir string) []string {
+				return []string{"nself-web", projectDir}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectDir := tt.setup(t)
+			ctx := context.Background()
+			res := checkHardeningNginxRateZones(ctx, projectDir)
+			if res.Status != tt.wantStatus {
+				t.Errorf("status = %q, want %q; msg=%s", res.Status, tt.wantStatus, res.Message)
+			}
+			// Falsifiability: every result must name the directory it
+			// actually audited (or, for skip, why it audited none) — a
+			// check that can't produce this evidence is how the wrong-
+			// directory bug stayed hidden through cli#380 and cli#371.
+			for _, substr := range tt.wantMsgSubstrs(projectDir) {
+				if !strings.Contains(res.Message, substr) {
+					t.Errorf("message does not name expected evidence %q: %s", substr, res.Message)
+				}
+			}
+		})
+	}
+}

--- a/internal/doctor/hardening_check_nginx_zones.go
+++ b/internal/doctor/hardening_check_nginx_zones.go
@@ -44,6 +44,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nself-org/cli/internal/config"
 	"github.com/nself-org/cli/internal/health"
 )
 
@@ -178,19 +179,84 @@ func scanNginxContentForRateZones(content string) (authZone, apiZone bool) {
 	return authZone, apiZone
 }
 
+// resolveNginxFrontedDir resolves the on-disk nginx directory for a project
+// fronted by another stack (NGINX_FRONTED_BY — see config.NginxConfig.FrontedBy).
+//
+// FrontedBy carries only a stack NAME (e.g. "nself-web"), never a path, and
+// none of the codebase's other three consumers of it
+// (internal/build/detection.go, internal/build/manifest_resolve.go,
+// internal/compose/generator.go) resolve that name to a filesystem
+// location — all three only test it for emptiness, to decide whether to
+// generate this project's own nginx service. There is no config-driven
+// convention anywhere in this CLI for turning a stack name into a directory
+// in the general case, so this function does not attempt one.
+//
+// The one topology it trusts is the one that caused the regression this
+// check exists to catch (cli#380/cli#371 on staging): this project living
+// as a subdirectory (conventionally "backend") directly under the fronting
+// stack's own directory, whose basename equals FrontedBy — e.g. projectDir
+// ".../nself-web/backend" with FrontedBy "nself-web" resolves to
+// ".../nself-web/nginx". That is a structural inference from the directory
+// layout the operator already chose, not a second FrontedBy-to-path
+// convention grafted onto config. When the parent directory's name does
+// not match, this function returns ok=false — the caller must not guess
+// further and silently audit the wrong directory.
+func resolveNginxFrontedDir(projectDir, frontedBy string) (dir string, ok bool) {
+	parent := filepath.Dir(projectDir)
+	if parent == projectDir || filepath.Base(parent) != frontedBy {
+		return "", false
+	}
+	return parent, true
+}
+
 // checkHardeningNginxRateZones verifies nginx has limit_req_zone + limit_req
 // directives covering the auth and API surfaces, first by scanning local
 // config files, then by grepping inside the running nginx container as a
 // fallback. See the file-level doc comment for the two detection signals.
+//
+// Fronted deployments (cli#380/cli#371 staging regression): when
+// NGINX_FRONTED_BY names another stack as this project's ingress, this
+// project's own <projectDir>/nginx/** is not what the running nginx reads
+// — the fronting stack's nginx directory is, and this project generates no
+// nginx container of its own to fall back to (internal/build/detection.go).
+// Auditing <projectDir>/nginx/** unconditionally let SEC-HARDENING-06 pass
+// or fail off a directory nginx never serves from. See
+// resolveNginxFrontedDir for how (and how far) this resolves the real
+// directory; when it cannot, this check reports "skip" with a reason
+// instead of silently auditing (and passing) the wrong path.
 func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckResult {
 	const checkID = "SEC-HARDENING-06"
 
-	// Search nginx/conf.d/ and nginx/sites/ for limit_req_zone + limit_req directives
-	// covering the auth and API surfaces.
+	// auditDir is the directory whose nginx/** this check actually reads.
+	// Defaults to projectDir (today's unfronted behavior); resolved to the
+	// fronting stack's directory below when NGINX_FRONTED_BY is set and
+	// resolvable. skipDockerFallback disables the this-project container
+	// exec fallback for fronted projects, which never have an nginx
+	// container of their own to exec into (internal/build/detection.go).
+	auditDir := projectDir
+	skipDockerFallback := false
+
+	if cfg, err := config.Load(projectDir); err == nil && cfg.Nginx.FrontedBy != "" {
+		skipDockerFallback = true
+		resolved, ok := resolveNginxFrontedDir(projectDir, cfg.Nginx.FrontedBy)
+		if !ok {
+			return CheckResult{
+				Section: hardeningSection,
+				Name:    checkID,
+				Status:  "skip",
+				Message: fmt.Sprintf("SEC-HARDENING-06: skipped — audited nothing. Project is fronted by nginx stack %q (NGINX_FRONTED_BY) but its nginx directory could not be resolved from %q; %s's own nginx config was not scanned here and must be audited directly for rate-limit zones", cfg.Nginx.FrontedBy, projectDir, cfg.Nginx.FrontedBy),
+			}
+		}
+		auditDir = resolved
+	}
+
+	// Search <auditDir>/nginx/conf.d/, /sites/ and /nginx.conf for
+	// limit_req_zone + limit_req directives covering the auth and API
+	// surfaces.
 	nginxDirs := []string{
-		filepath.Join(projectDir, "nginx", "conf.d"),
-		filepath.Join(projectDir, "nginx", "sites"),
-		filepath.Join(projectDir, "nginx", "nginx.conf"),
+		filepath.Join(auditDir, "nginx", "conf.d"),
+		filepath.Join(auditDir, "nginx", "sites"),
+		filepath.Join(auditDir, "nginx", "nginx.conf"),
 	}
 
 	hasAuthZone := false
@@ -233,7 +299,10 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 	}
 
 	// Fallback: inspect nginx container config if local files not found.
-	if !hasAuthZone || !hasAPIZone {
+	// Skipped for fronted projects — they generate no nginx container of
+	// their own to exec into (internal/build/detection.go), so this would
+	// only ever exec into a nonexistent or unrelated container.
+	if !skipDockerFallback && (!hasAuthZone || !hasAPIZone) {
 		nginxContainer := health.ContainerName(resolveProjectName(projectDir), "nginx")
 		cmd := exec.CommandContext(ctx, "docker", "exec", nginxContainer,
 			"sh", "-c", "cat /etc/nginx/nginx.conf /etc/nginx/conf.d/* /etc/nginx/sites/* 2>/dev/null")
@@ -249,20 +318,25 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 		}
 	}
 
+	// auditedNginxDir names the directory this run actually read, so the
+	// result is falsifiable — a pass/fail/warn that cannot say what it
+	// looked at is how this check stayed hollow on a fronted deployment.
+	auditedNginxDir := filepath.Join(auditDir, "nginx")
+
 	switch {
 	case hasAuthZone && hasAPIZone:
 		return CheckResult{
 			Section: hardeningSection,
 			Name:    checkID,
 			Status:  "pass",
-			Message: "SEC-HARDENING-06: nginx rate-limit zones set for the auth and API services",
+			Message: fmt.Sprintf("SEC-HARDENING-06: nginx rate-limit zones set for the auth and API services (audited %s)", auditedNginxDir),
 		}
 	case !hasAuthZone && !hasAPIZone:
 		return CheckResult{
 			Section: hardeningSection,
 			Name:    checkID,
 			Status:  "fail",
-			Message: "SEC-HARDENING-06: nginx missing rate-limit zones for the auth and API services — add limit_req_zone directives",
+			Message: fmt.Sprintf("SEC-HARDENING-06: nginx missing rate-limit zones for the auth and API services (audited %s) — add limit_req_zone directives", auditedNginxDir),
 			FixCmd:  "See nself.org/docs/security/nginx-rate-limiting",
 		}
 	default:
@@ -274,7 +348,7 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 			Section: hardeningSection,
 			Name:    checkID,
 			Status:  "warn",
-			Message: fmt.Sprintf("SEC-HARDENING-06: nginx rate-limit zone missing for %s — add a limit_req directive", missing),
+			Message: fmt.Sprintf("SEC-HARDENING-06: nginx rate-limit zone missing for %s (audited %s) — add a limit_req directive", missing, auditedNginxDir),
 			FixCmd:  "See nself.org/docs/security/nginx-rate-limiting",
 		}
 	}

--- a/internal/doctor/hardening_check_nginx_zones.go
+++ b/internal/doctor/hardening_check_nginx_zones.go
@@ -44,7 +44,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/nself-org/cli/internal/config"
 	"github.com/nself-org/cli/internal/health"
 )
 
@@ -179,76 +178,21 @@ func scanNginxContentForRateZones(content string) (authZone, apiZone bool) {
 	return authZone, apiZone
 }
 
-// resolveNginxFrontedDir resolves the on-disk nginx directory for a project
-// fronted by another stack (NGINX_FRONTED_BY — see config.NginxConfig.FrontedBy).
-//
-// FrontedBy carries only a stack NAME (e.g. "nself-web"), never a path, and
-// none of the codebase's other three consumers of it
-// (internal/build/detection.go, internal/build/manifest_resolve.go,
-// internal/compose/generator.go) resolve that name to a filesystem
-// location — all three only test it for emptiness, to decide whether to
-// generate this project's own nginx service. There is no config-driven
-// convention anywhere in this CLI for turning a stack name into a directory
-// in the general case, so this function does not attempt one.
-//
-// The one topology it trusts is the one that caused the regression this
-// check exists to catch (cli#380/cli#371 on staging): this project living
-// as a subdirectory (conventionally "backend") directly under the fronting
-// stack's own directory, whose basename equals FrontedBy — e.g. projectDir
-// ".../nself-web/backend" with FrontedBy "nself-web" resolves to
-// ".../nself-web/nginx". That is a structural inference from the directory
-// layout the operator already chose, not a second FrontedBy-to-path
-// convention grafted onto config. When the parent directory's name does
-// not match, this function returns ok=false — the caller must not guess
-// further and silently audit the wrong directory.
-func resolveNginxFrontedDir(projectDir, frontedBy string) (dir string, ok bool) {
-	parent := filepath.Dir(projectDir)
-	if parent == projectDir || filepath.Base(parent) != frontedBy {
-		return "", false
-	}
-	return parent, true
-}
-
 // checkHardeningNginxRateZones verifies nginx has limit_req_zone + limit_req
 // directives covering the auth and API surfaces, first by scanning local
 // config files, then by grepping inside the running nginx container as a
 // fallback. See the file-level doc comment for the two detection signals.
 //
-// Fronted deployments (cli#380/cli#371 staging regression): when
-// NGINX_FRONTED_BY names another stack as this project's ingress, this
-// project's own <projectDir>/nginx/** is not what the running nginx reads
-// — the fronting stack's nginx directory is, and this project generates no
-// nginx container of its own to fall back to (internal/build/detection.go).
-// Auditing <projectDir>/nginx/** unconditionally let SEC-HARDENING-06 pass
-// or fail off a directory nginx never serves from. See
-// resolveNginxFrontedDir for how (and how far) this resolves the real
-// directory; when it cannot, this check reports "skip" with a reason
-// instead of silently auditing (and passing) the wrong path.
+// Fronted deployments (cli#380/cli#371) need a different directory than
+// <projectDir>/nginx/** — see planNginxAudit (hardening_check_nginx_fronted_dir.go).
 func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckResult {
 	const checkID = "SEC-HARDENING-06"
 
-	// auditDir is the directory whose nginx/** this check actually reads.
-	// Defaults to projectDir (today's unfronted behavior); resolved to the
-	// fronting stack's directory below when NGINX_FRONTED_BY is set and
-	// resolvable. skipDockerFallback disables the this-project container
-	// exec fallback for fronted projects, which never have an nginx
-	// container of their own to exec into (internal/build/detection.go).
-	auditDir := projectDir
-	skipDockerFallback := false
-
-	if cfg, err := config.Load(projectDir); err == nil && cfg.Nginx.FrontedBy != "" {
-		skipDockerFallback = true
-		resolved, ok := resolveNginxFrontedDir(projectDir, cfg.Nginx.FrontedBy)
-		if !ok {
-			return CheckResult{
-				Section: hardeningSection,
-				Name:    checkID,
-				Status:  "skip",
-				Message: fmt.Sprintf("SEC-HARDENING-06: skipped — audited nothing. Project is fronted by nginx stack %q (NGINX_FRONTED_BY) but its nginx directory could not be resolved from %q; %s's own nginx config was not scanned here and must be audited directly for rate-limit zones", cfg.Nginx.FrontedBy, projectDir, cfg.Nginx.FrontedBy),
-			}
-		}
-		auditDir = resolved
+	plan := planNginxAudit(projectDir)
+	if plan.skip != nil {
+		return *plan.skip
 	}
+	auditDir := plan.auditDir
 
 	// Search <auditDir>/nginx/conf.d/, /sites/ and /nginx.conf for
 	// limit_req_zone + limit_req directives covering the auth and API
@@ -302,7 +246,7 @@ func checkHardeningNginxRateZones(ctx context.Context, projectDir string) CheckR
 	// Skipped for fronted projects — they generate no nginx container of
 	// their own to exec into (internal/build/detection.go), so this would
 	// only ever exec into a nonexistent or unrelated container.
-	if !skipDockerFallback && (!hasAuthZone || !hasAPIZone) {
+	if !plan.skipDockerFallback && (!hasAuthZone || !hasAPIZone) {
 		nginxContainer := health.ContainerName(resolveProjectName(projectDir), "nginx")
 		cmd := exec.CommandContext(ctx, "docker", "exec", nginxContainer,
 			"sh", "-c", "cat /etc/nginx/nginx.conf /etc/nginx/conf.d/* /etc/nginx/sites/* 2>/dev/null")


### PR DESCRIPTION
## Defect

`checkHardeningNginxRateZones` (`internal/doctor/hardening_check_nginx_zones.go`) always scanned `<projectDir>/nginx/{conf.d,sites,nginx.conf}`, regardless of `NGINX_FRONTED_BY`. On a **fronted** deployment (this project has no ingress nginx of its own — another stack's nginx serves its domains, see `config.NginxConfig.FrontedBy`), that directory is never read by the running nginx.

Staging is the live example: nginx mounts `/opt/nself-web/nginx` (the parent directory) while the doctor-invoked project directory is `/opt/nself-web/backend`. The check audited `backend/nginx/**` — a directory nginx never serves from — so SEC-HARDENING-06 could pass while the live config had no rate limiting, or fail while it did, independent of reality. This is why cli#380 and cli#371 did not actually close SEC-HARDENING-06 on staging. It's also the second occurrence of the same parent-vs-backend confusion: `nself ssl add` writes to `backend/` while nginx mounts the parent (recorded 2026-08-17).

## Fix

`NGINX_FRONTED_BY` carries only a stack **name** (e.g. `nself-web`), never a path. Its other three consumers (`internal/build/detection.go`, `internal/build/manifest_resolve.go`, `internal/compose/generator.go`) only test it for emptiness — none resolve the name to a filesystem location — so there is no existing path-resolution convention to reuse.

Given that, the fix takes the conservative branch (task step 5 in the brief): resolve a path only when it can be confirmed, otherwise report "skip" rather than guess.

- `resolveNginxFrontedDir(projectDir, frontedBy)` trusts exactly one topology: the project directory living directly under the fronting stack's own directory, whose basename equals `FrontedBy` — i.e. `.../nself-web/backend` fronted by `nself-web` resolves to `.../nself-web/nginx`. This is the shape behind the staging regression.
- When the parent directory's name doesn't match `FrontedBy`, the check returns `"skip"` with a message naming the stack and the reason, instead of auditing (and silently passing/failing on) the wrong directory.
- The container-exec fallback is skipped entirely for fronted projects — they generate no nginx container of their own (`internal/build/detection.go`), so it would only ever exec into a nonexistent or unrelated container.
- **Falsifiability**: every result (pass/fail/warn/skip) now names the directory it actually audited in its `Message`, so a hollow pass can't hide silently again.

Files: `internal/doctor/hardening_check_nginx_zones.go`, new tests in `internal/doctor/hardening_check_nginx_fronted_test.go`.

## Proof

Table-driven tests, `t.TempDir()` fixtures only (no real machine paths):

| Case | Setup | Expect |
|---|---|---|
| (a) | non-fronted, limits present | pass |
| (b) | non-fronted, limits absent | fail |
| (c) | fronted, **parent** has limits, `backend/nginx` does not (staging shape) | **pass** — the regression this fixes |
| (d) | fronted, parent lacks limits, `backend/nginx` has them | **fail** — proves it stopped reading the wrong dir |
| (e) | fronted, directory unresolvable | skip, with reason |

With the fix (all gates from repo root):
```
make fmt-check   → exit 0 ("gofmt check passed")
make vet         → exit 0
heavy-lock make build                      → exit 0
heavy-lock go test ./internal/doctor/...   → exit 0, ok
```

Negative proof — source reverted, tests kept (`git stash` on `hardening_check_nginx_zones.go` only):
```
go test ./internal/doctor/... -run TestCheckHardeningNginxRateZones_FrontedTopology -v
```
→ FAIL, all 5 subtests fail. Notably:
- (c) `status = "fail", want "pass"` — old code scans `backend/nginx` (empty) instead of the parent
- (d) `status = "pass", want "fail"` — old code scans `backend/nginx` (has limits) instead of the parent (which lacks them)

Restoring the fix (`git stash pop`) → all 5 subtests pass again, full suite green.

## Residue (not fixed here — other `<projectDir>/nginx` assumptions found via `git grep -n '"nginx"' -- internal/ cmd/`)

Not fronted-aware, same class of bug, out of scope for this PR:
- `cmd/commands/ssl_add.go` (writes `<workdir>/nginx/conf.d/custom-*.conf`, execs `docker compose exec nginx`) — the exact case recorded 2026-08-17
- `cmd/commands/ssl_install.go`, `ssl_renew.go`, `ssl_setup.go` — same nginx-conf-dir / exec-into-nginx assumptions
- `internal/build/orchestrator_build_finish.go`, `orchestrator_build_ssl.go`, `plugin_nginx.go` — build-time writes to `<workdir>/nginx/{sites,conf.d}`
- `internal/deploy/bluegreen/bluegreen_traffic.go` — writes `<ProjectRoot>/nginx/conf.d/bluegreen-upstream.conf`, execs `docker compose exec nginx`
- `internal/security/waf.go` — execs `docker compose exec nginx`
- `internal/doctor/deep_nginx.go`, `nself_audit_scan.go` — other doctor checks reading/exec'ing this project's own nginx
- `internal/migration/detector.go`, `migrator_backup.go` — migration assumes `<projectDir>/nginx`