### PR TITLE
fix(compose): stop nself build from swapping a running pgvector image

### DIFF
--- a/.github/wiki/Config-Env-Vars.md
+++ b/.github/wiki/Config-Env-Vars.md
@@ -77,13 +77,14 @@ These vars control the top-level identity and behavior of a project.
 | Variable | Type | Default | Required | Description |
 |---|---|---|---|---|
 | `POSTGRES_VERSION` | string | `16-alpine` | No | Docker image tag for the Postgres container. |
+| `POSTGRES_IMAGE` | string | *(unset)* | No | Explicit image override for the Postgres container (e.g. `pgvector/pgvector:pg16`). Wins over every other resolution, including the `POSTGRES_EXTENSIONS` pgvector inference below. Set this to pin a running image across `nself build` regens. |
 | `BACKUP_CRITICAL_TABLES` | string | `np_users,np_licenses,np_audit_log,np_plugins,np_billing` | No | Comma-separated tables `nself backup drill` looks for after restoring into its scratch database. The check is presence-only and advisory: an empty table counts as present, and missing tables are reported without failing the drill. Set this when your schema does not use the `np_` prefix, or the defaults will all read as missing. See [[cmd-backup]]. |
 | `POSTGRES_HOST` | string | `postgres` | No | Internal container hostname. Change only if running Postgres externally. |
 | `POSTGRES_PORT` | int | `5432` | No | Port exposed to the host machine. |
 | `POSTGRES_DB` | string | derived from the project name | No | Database created on first start. `nself init` writes a name derived from the project directory, lowercased with hyphens, dots and spaces folded to underscores, since a database name must be a valid SQL identifier and a directory name often is not. `my-app` becomes `my_app`. Only if nothing sets it at all does it fall back to `nself`. Set it explicitly to control the name. |
 | `POSTGRES_USER` | string | `postgres` | No | Superuser account name. |
 | `POSTGRES_PASSWORD` | string | *(none)* | **Yes** | Superuser password. Minimum 16 characters. |
-| `POSTGRES_EXTENSIONS` | string | `uuid-ossp` | No | Comma-separated list of extensions to install automatically. |
+| `POSTGRES_EXTENSIONS` | string | `uuid-ossp` | No | Comma-separated list of extensions to install automatically. When this list contains `pgvector` and `POSTGRES_IMAGE` is unset, `nself build` selects the `pgvector/pgvector:pg<major>` image instead of plain `postgres:<POSTGRES_VERSION>`. |
 | `POSTGRES_EXPOSE_PORT` | enum | `auto` | No | Controls host-port binding. `auto` exposes in dev and hides in prod. Accepted values: `auto`, `true`, `false`. |
 | `POSTGRES_MEM_LIMIT` | string | `2g` | No | Docker memory limit for the Postgres container. |
 | `POSTGRES_CPU_LIMIT` | string | `2.0` | No | Docker CPU core limit for the Postgres container. |

--- a/.github/wiki/Config-Postgres.md
+++ b/.github/wiki/Config-Postgres.md
@@ -11,13 +11,14 @@ All Postgres variables are optional except `POSTGRES_PASSWORD`, which must be se
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
 | `POSTGRES_VERSION` | `16-alpine` | No | Docker image tag for the Postgres container. Change this to pin a specific version, e.g. `15-alpine` or `16.2-alpine`. |
+| `POSTGRES_IMAGE` | *(unset)* | No | Explicit image override for the Postgres container (e.g. `pgvector/pgvector:pg16`). When set, wins over both `POSTGRES_VERSION` and the `POSTGRES_EXTENSIONS` pgvector inference below — use it to pin a running image across `nself build` regens. |
 | `POSTGRES_HOST` | `postgres` | No | Internal hostname used by other containers (Hasura, Auth, Functions) to reach Postgres. This is a Docker network name and should almost never be changed. |
 | `POSTGRES_INTERNAL_PORT` | `5432` | No | Port Postgres listens on inside the container. Always `5432`. Do not change this , it is the standard Postgres port expected by all dependent services. |
 | `POSTGRES_PORT` | `5432` | No | Port exposed to the host machine. Change this if you have a port conflict with another local Postgres instance (e.g., set to `5433`). |
 | `POSTGRES_DB` | `nself` | No | Name of the default database created on first start. |
 | `POSTGRES_USER` | `postgres` | No | Superuser account name for the database. |
 | `POSTGRES_PASSWORD` | *(none)* | **Yes** | Superuser password. Must be at least 16 characters. ɳSelf enforces a minimum length and rejects common insecure patterns (e.g., `postgres`, `password`, `changeme`). |
-| `POSTGRES_EXTENSIONS` | `uuid-ossp` | No | Comma-separated list of extensions to install automatically at startup. The extensions `uuid-ossp`, `pgcrypto`, and `pg_trgm` are always installed regardless of this value. Add additional extensions here as needed. |
+| `POSTGRES_EXTENSIONS` | `uuid-ossp` | No | Comma-separated list of extensions to install automatically at startup. The extensions `uuid-ossp`, `pgcrypto`, and `pg_trgm` are always installed regardless of this value. Add additional extensions here as needed. When this list contains `pgvector` and `POSTGRES_IMAGE` is unset, `nself build` selects the `pgvector/pgvector:pg<major>` image instead of plain `postgres:<POSTGRES_VERSION>`. |
 | `POSTGRES_EXPOSE_PORT` | `auto` | No | Controls whether `POSTGRES_PORT` is bound on the host. `auto` exposes the port in dev and hides it in prod. Set to `true` to always expose, or `false` to always hide. |
 | `POSTGRES_MEM_LIMIT` | `2g` | No | Docker memory limit for the Postgres container. Uses Docker format: `512m`, `1g`, `4g`, etc. |
 | `POSTGRES_CPU_LIMIT` | `2.0` | No | CPU core limit for the Postgres container. A value of `2.0` means the container can use up to two full cores. |

--- a/internal/build/orchestrator_build_compose.go
+++ b/internal/build/orchestrator_build_compose.go
@@ -39,6 +39,15 @@ func (st *buildState) generateCompose() error {
 		return fmt.Errorf("generating docker-compose.yml: %w", err)
 	}
 
+	// ── Step 8.1: Warn if this regen would swap a running postgres image ──
+	// (cli#384 — advisory only, never blocks the build; see
+	// PostgresImageChangeWarning for the data-loss scenario this guards.)
+	postgresContainer := fmt.Sprintf("%s_postgres", st.cfg.ProjectName)
+	generatedPostgresImage := compose.ResolveImage("postgres", compose.ResolvePostgresImage(st.cfg.Postgres))
+	if warning := PostgresImageChangeWarning(postgresContainer, generatedPostgresImage); warning != "" {
+		slog.Warn(warning)
+	}
+
 	// ── Step 8.5: Merge Ollama sidecar when AI_OLLAMA_ENABLED=true ──
 	ollamaEnv := collectOllamaEnv()
 	mergedYAML, ollamaInjected, err := MergeOllamaSidecar(composeYAML, ollamaEnv)

--- a/internal/build/postgres_image_warning.go
+++ b/internal/build/postgres_image_warning.go
@@ -1,0 +1,70 @@
+package build
+
+// postgres_image_warning.go — warns when a build-time postgres image would
+// change what a currently running postgres container is using.
+//
+// Purpose: cli#384 — `nself build` must never silently regenerate a compose
+// file that swaps a populated, running postgres/pgvector container for a
+// different image. Restarting postgres under a swapped image is a data-loss
+// event (P1 EOP staging incident 2026-06-10). This surfaces the mismatch as a
+// build-time WARNING so the operator can pin POSTGRES_IMAGE before applying
+// the regenerated compose file with `nself start`.
+// Inputs: containerName — the postgres container name (<project>_postgres);
+//         generatedImage — the image `nself build` is about to write.
+// Outputs: a non-empty warning string when the running and generated images
+//          differ; "" when they match, the container isn't running, or
+//          Docker isn't reachable.
+// Constraints: best-effort and advisory only — never returns an error, never
+//              blocks or modifies the build, never shells out for more than
+//              a few seconds.
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// runningContainerImageTimeout bounds the `docker inspect` call so a hung or
+// unreachable Docker daemon cannot stall `nself build`.
+const runningContainerImageTimeout = 3 * time.Second
+
+// runningContainerImage returns the image:tag reference (Config.Image, not
+// the sha256 image ID) that containerName was created from. Returns "" when
+// Docker isn't reachable or the container doesn't exist — callers must treat
+// that as "nothing to compare", never as an error.
+func runningContainerImage(containerName string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), runningContainerImageTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "docker", "inspect", "--format", "{{.Config.Image}}", containerName).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// PostgresImageChangeWarning returns a WARNING message when the postgres
+// image `nself build` is about to generate differs from the image the
+// currently running postgres container was started from. Returns "" when
+// there is nothing to warn about (no running container, or the images match).
+func PostgresImageChangeWarning(containerName, generatedImage string) string {
+	return postgresImageChangeWarning(containerName, generatedImage, runningContainerImage)
+}
+
+// postgresImageChangeWarning is the testable core of
+// PostgresImageChangeWarning, parameterized by an image-lookup function so
+// tests can inject a fake baseline without a reachable Docker daemon.
+func postgresImageChangeWarning(containerName, generatedImage string, lookup func(string) string) string {
+	running := lookup(containerName)
+	if running == "" || running == generatedImage {
+		return ""
+	}
+	return fmt.Sprintf(
+		"postgres image change detected for %q: running container uses %q, "+
+			"this build generated %q — applying it will recreate postgres under "+
+			"a different image. If %q is pgvector-based and this is unintended, "+
+			"set POSTGRES_IMAGE=%s to keep it before running `nself start`",
+		containerName, running, generatedImage, running, running,
+	)
+}

--- a/internal/build/postgres_image_warning_test.go
+++ b/internal/build/postgres_image_warning_test.go
@@ -1,0 +1,59 @@
+package build
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPostgresImageChangeWarning_NoRunningContainer verifies the advisory
+// check never errors or fabricates a warning when the container doesn't
+// exist (e.g. Docker isn't running, or this is a first-ever build) — a
+// missing baseline must never block `nself build`.
+func TestPostgresImageChangeWarning_NoRunningContainer(t *testing.T) {
+	got := PostgresImageChangeWarning("nonexistent_project_postgres_container_xyz", "pgvector/pgvector:pg16")
+	if got != "" {
+		t.Errorf("PostgresImageChangeWarning(no container) = %q, want empty", got)
+	}
+}
+
+// TestPostgresImageChangeWarning_Mismatch verifies cli#384's core case: a
+// running pgvector container against a regen that would produce a plain
+// alpine image must produce a WARNING naming both images and the fix.
+func TestPostgresImageChangeWarning_Mismatch(t *testing.T) {
+	lookup := func(name string) string {
+		if name == "myproj_postgres" {
+			return "pgvector/pgvector:pg16"
+		}
+		return ""
+	}
+	got := postgresImageChangeWarning("myproj_postgres", "postgres:16-alpine", lookup)
+	if got == "" {
+		t.Fatal("expected a warning, got empty string")
+	}
+	for _, want := range []string{"myproj_postgres", "pgvector/pgvector:pg16", "postgres:16-alpine", "POSTGRES_IMAGE"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning %q missing expected substring %q", got, want)
+		}
+	}
+}
+
+// TestPostgresImageChangeWarning_Match verifies no warning is raised when the
+// running container's image already matches what this build generated.
+func TestPostgresImageChangeWarning_Match(t *testing.T) {
+	lookup := func(string) string { return "pgvector/pgvector:pg16" }
+	got := postgresImageChangeWarning("myproj_postgres", "pgvector/pgvector:pg16", lookup)
+	if got != "" {
+		t.Errorf("postgresImageChangeWarning(match) = %q, want empty", got)
+	}
+}
+
+// TestPostgresImageChangeWarning_EmptyBaselineIsSilent verifies an empty
+// lookup result (no running container, or Docker unreachable) is treated as
+// "nothing to compare", not as a mismatch.
+func TestPostgresImageChangeWarning_EmptyBaselineIsSilent(t *testing.T) {
+	lookup := func(string) string { return "" }
+	got := postgresImageChangeWarning("myproj_postgres", "postgres:16-alpine", lookup)
+	if got != "" {
+		t.Errorf("postgresImageChangeWarning(empty baseline) = %q, want empty", got)
+	}
+}

--- a/internal/compose/core_services.go
+++ b/internal/compose/core_services.go
@@ -26,7 +26,7 @@ func remoteSchemaEnvVars(schemas []config.RemoteSchema) map[string]string {
 // buildPostgresService returns the PostgreSQL service configuration.
 func (g *Generator) buildPostgresService() ServiceConfig {
 	cfg := g.cfg
-	image := ResolveImage("postgres", fmt.Sprintf("postgres:%s", cfg.Postgres.Version))
+	image := ResolveImage("postgres", ResolvePostgresImage(cfg.Postgres))
 	// Image-aware runtime identity: alpine postgres images run as uid 70 and
 	// existing alpine volumes are initialized directly at /var/lib/postgresql/data.
 	// Debian-family images (incl. pgvector/pgvector) run as uid 999 with a pgdata

--- a/internal/compose/images.go
+++ b/internal/compose/images.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/nself-org/cli/internal/config"
 )
 
 // AdminImagePath is the Docker Hub image name for the nSelf Admin GUI service.
@@ -29,6 +33,64 @@ var DefaultImageVersions = map[string]string{
 	"mlflow":      "ghcr.io/mlflow/mlflow:v2.10.0",
 }
 
+// pgvectorMajorVersionRE extracts the leading numeric major version from a
+// POSTGRES_VERSION string such as "16-alpine" or "16.4" so the pgvector image
+// tag tracks the configured Postgres major version rather than being
+// hardcoded to whatever DefaultImageVersions currently pins.
+var pgvectorMajorVersionRE = regexp.MustCompile(`^(\d+)`)
+
+// ResolvePostgresImage decides which Postgres image `nself build` emits.
+//
+// Purpose: fix cli#384 — nself build previously ignored the pgvector pin
+// entirely and always emitted postgres:<POSTGRES_VERSION>, silently swapping
+// a running pgvector/pgvector container (uid 999, PGDATA subdir) for a plain
+// alpine postgres image (uid 70, no PGDATA) on every regen. Restarting
+// postgres under the swapped image on a populated database is a data-loss
+// event (P1 EOP staging incident 2026-06-10).
+// Inputs: pg — the resolved PostgresConfig (Image, Version, Extensions).
+// Outputs: the image reference the postgres service should run.
+// Constraints: precedence is fixed and MUST NOT be reordered:
+//  1. pg.Image (POSTGRES_IMAGE), when set, always wins — an explicit
+//     operator pin overrides every inference below it.
+//  2. pg.Extensions containing "pgvector" (POSTGRES_EXTENSIONS) selects the
+//     pgvector image matching the configured Postgres major version.
+//  3. Otherwise, postgres:<POSTGRES_VERSION> (unchanged default behavior).
+//
+// buildPostgresService derives PGDATA and the container uid from the
+// resulting image name (alpine vs. debian-family), so getting this
+// precedence right also fixes PGDATA/uid preservation: a pgvector or other
+// debian-family image always resolves to uid 999 + PGDATA, matching what the
+// upstream image actually requires.
+func ResolvePostgresImage(pg config.PostgresConfig) string {
+	if img := strings.TrimSpace(pg.Image); img != "" {
+		return img
+	}
+	if hasExtension(pg.Extensions, "pgvector") {
+		return pgvectorImageForVersion(pg.Version)
+	}
+	return fmt.Sprintf("postgres:%s", pg.Version)
+}
+
+// hasExtension reports whether extensions contains name, case-insensitively.
+func hasExtension(extensions []string, name string) bool {
+	for _, e := range extensions {
+		if strings.EqualFold(strings.TrimSpace(e), name) {
+			return true
+		}
+	}
+	return false
+}
+
+// pgvectorImageForVersion maps a POSTGRES_VERSION like "16-alpine" or "16.4"
+// to the matching pgvector/pgvector image tag. Falls back to the
+// DefaultImageVersions pin when no leading major-version digit is found.
+func pgvectorImageForVersion(version string) string {
+	if major := pgvectorMajorVersionRE.FindString(version); major != "" {
+		return fmt.Sprintf("pgvector/pgvector:pg%s", major)
+	}
+	return DefaultImageVersions["postgres"]
+}
+
 // ImageDigests maps service name to sha256 digest for image pinning.
 // When a digest is available, ResolveImage appends @sha256:... to the tag.
 // Populated by LoadImageDigests from the project config directory.
@@ -41,10 +103,12 @@ const DigestConfigFile = ".nself-image-digests.json"
 // digest suffix when available.
 //
 // Precedence: a non-empty caller-supplied image (built from env/config such as
-// POSTGRES_VERSION / HASURA_VERSION) ALWAYS wins. The DefaultImageVersions pin
-// applies only when the caller supplies no image. Pins overriding configured
-// versions force-migrated existing deployments on upgrade (P1 EOP staging
-// incident 2026-06-10: postgres:16-alpine volume recreated as pgvector pg16).
+// POSTGRES_VERSION / HASURA_VERSION, or ResolvePostgresImage for postgres)
+// ALWAYS wins. The DefaultImageVersions pin applies only when the caller
+// supplies no image — for postgres specifically that image is always
+// resolved via ResolvePostgresImage before reaching here, so this pin is a
+// fallback for other services (or an unparseable POSTGRES_VERSION), not the
+// live postgres selection path.
 func ResolveImage(service, image string) string {
 	resolved := image
 	if resolved == "" {

--- a/internal/compose/images_test.go
+++ b/internal/compose/images_test.go
@@ -3,6 +3,8 @@ package compose
 import (
 	"strings"
 	"testing"
+
+	"github.com/nself-org/cli/internal/config"
 )
 
 func TestResolveImage_KnownService(t *testing.T) {
@@ -56,6 +58,75 @@ func TestAdminImagePath_DockerHubNotGHCR(t *testing.T) {
 	}
 	if !strings.HasPrefix(AdminImagePath, "nself/") {
 		t.Errorf("AdminImagePath must start with 'nself/' (Docker Hub namespace) — got %q", AdminImagePath)
+	}
+}
+
+// TestResolvePostgresImage_ExplicitImageWins verifies precedence branch 1:
+// POSTGRES_IMAGE always wins, even when POSTGRES_EXTENSIONS also lists
+// pgvector or POSTGRES_VERSION is set (cli#384).
+func TestResolvePostgresImage_ExplicitImageWins(t *testing.T) {
+	pg := config.PostgresConfig{
+		Image:      "pgvector/pgvector:pg16",
+		Version:    "16-alpine",
+		Extensions: []string{"pgvector"},
+	}
+	got := ResolvePostgresImage(pg)
+	want := "pgvector/pgvector:pg16"
+	if got != want {
+		t.Errorf("ResolvePostgresImage(explicit image) = %q, want %q", got, want)
+	}
+}
+
+// TestResolvePostgresImage_PgvectorExtensionImpliesImage verifies precedence
+// branch 2: POSTGRES_EXTENSIONS containing pgvector selects the pgvector
+// image matching the configured major version when POSTGRES_IMAGE is unset.
+// This is the defect at the heart of cli#384 — this pin was previously dead
+// code under buildPostgresService's old precedence.
+func TestResolvePostgresImage_PgvectorExtensionImpliesImage(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"alpine suffix", "16-alpine", "pgvector/pgvector:pg16"},
+		{"dotted version", "15.4", "pgvector/pgvector:pg15"},
+		{"unparseable falls back to pin", "latest", DefaultImageVersions["postgres"]},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pg := config.PostgresConfig{Version: tt.version, Extensions: []string{"pgvector"}}
+			got := ResolvePostgresImage(pg)
+			if got != tt.want {
+				t.Errorf("ResolvePostgresImage(version=%q, pgvector) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolvePostgresImage_ExtensionMatchCaseInsensitiveAndTrimmed verifies
+// POSTGRES_EXTENSIONS entries are matched case-insensitively and tolerate
+// surrounding whitespace from a comma-separated env value.
+func TestResolvePostgresImage_ExtensionMatchCaseInsensitiveAndTrimmed(t *testing.T) {
+	pg := config.PostgresConfig{
+		Version:    "16-alpine",
+		Extensions: []string{"uuid-ossp", " PgVector ", "pgcrypto"},
+	}
+	got := ResolvePostgresImage(pg)
+	want := "pgvector/pgvector:pg16"
+	if got != want {
+		t.Errorf("ResolvePostgresImage(mixed-case extension) = %q, want %q", got, want)
+	}
+}
+
+// TestResolvePostgresImage_DefaultVersionOnly verifies precedence branch 3:
+// with no POSTGRES_IMAGE and no pgvector extension, the plain
+// postgres:<POSTGRES_VERSION> default is unchanged from before cli#384.
+func TestResolvePostgresImage_DefaultVersionOnly(t *testing.T) {
+	pg := config.PostgresConfig{Version: "16-alpine", Extensions: []string{"uuid-ossp", "pgcrypto"}}
+	got := ResolvePostgresImage(pg)
+	want := "postgres:16-alpine"
+	if got != want {
+		t.Errorf("ResolvePostgresImage(no image, no pgvector) = %q, want %q", got, want)
 	}
 }
 

--- a/internal/compose/postgres_service_test.go
+++ b/internal/compose/postgres_service_test.go
@@ -1,0 +1,94 @@
+package compose
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildPostgresService_PgvectorExtensionPreservesUidAndPGDATA verifies
+// cli#384 end-to-end: a build with POSTGRES_EXTENSIONS=pgvector (and no
+// explicit POSTGRES_IMAGE) must emit the pgvector image, uid 999:999, and a
+// PGDATA subdir — matching what the pgvector/pgvector image actually runs as,
+// so a regen against an already-running pgvector container does not crash
+// the container or lose the extension on restart.
+func TestBuildPostgresService_PgvectorExtensionPreservesUidAndPGDATA(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.Postgres.Version = "16-alpine"
+	cfg.Postgres.Extensions = []string{"pgvector"}
+	g := NewGenerator(cfg)
+
+	svc := g.buildPostgresService()
+
+	if svc.Image != "pgvector/pgvector:pg16" {
+		t.Errorf("Image = %q, want pgvector/pgvector:pg16", svc.Image)
+	}
+	if svc.User != "999:999" {
+		t.Errorf("User = %q, want 999:999 for a pgvector (debian-family) image", svc.User)
+	}
+	if got := svc.Environment["PGDATA"]; got != "/var/lib/postgresql/data/pgdata" {
+		t.Errorf("PGDATA = %q, want /var/lib/postgresql/data/pgdata", got)
+	}
+}
+
+// TestBuildPostgresService_ExplicitImageWinsOverExtensions verifies
+// POSTGRES_IMAGE overrides both the version default and the pgvector
+// inference from POSTGRES_EXTENSIONS.
+func TestBuildPostgresService_ExplicitImageWinsOverExtensions(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.Postgres.Version = "16-alpine"
+	cfg.Postgres.Extensions = []string{"pgvector"}
+	cfg.Postgres.Image = "postgres:16" // debian, not alpine, not pgvector
+	g := NewGenerator(cfg)
+
+	svc := g.buildPostgresService()
+
+	if svc.Image != "postgres:16" {
+		t.Errorf("Image = %q, want postgres:16 (explicit POSTGRES_IMAGE)", svc.Image)
+	}
+	if svc.User != "999:999" {
+		t.Errorf("User = %q, want 999:999 for a debian-family image", svc.User)
+	}
+	if _, ok := svc.Environment["PGDATA"]; !ok {
+		t.Error("PGDATA missing, want set for a debian-family image")
+	}
+}
+
+// TestBuildPostgresService_PlainAlpineDefault_NoExtensions verifies the
+// unchanged default: no POSTGRES_IMAGE, no pgvector extension, plain alpine
+// postgres image, uid 70:70, and no PGDATA (matches upstream alpine image
+// behavior — this is not the regression case).
+func TestBuildPostgresService_PlainAlpineDefault_NoExtensions(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.Postgres.Version = "16-alpine"
+	cfg.Postgres.Extensions = []string{"uuid-ossp", "pgcrypto"}
+	g := NewGenerator(cfg)
+
+	svc := g.buildPostgresService()
+
+	if svc.Image != "postgres:16-alpine" {
+		t.Errorf("Image = %q, want postgres:16-alpine", svc.Image)
+	}
+	if svc.User != "70:70" {
+		t.Errorf("User = %q, want 70:70 for a plain alpine image", svc.User)
+	}
+	if _, ok := svc.Environment["PGDATA"]; ok {
+		t.Error("PGDATA set, want absent for a plain alpine image")
+	}
+}
+
+// TestBuildPostgresService_ExtensionMatchIsCaseInsensitive guards the
+// POSTGRES_EXTENSIONS=pgvector matching used by buildPostgresService via
+// ResolvePostgresImage against case/whitespace variants a hand-edited .env
+// might contain.
+func TestBuildPostgresService_ExtensionMatchIsCaseInsensitive(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.Postgres.Version = "15-alpine"
+	cfg.Postgres.Extensions = []string{" PGVECTOR "}
+	g := NewGenerator(cfg)
+
+	svc := g.buildPostgresService()
+
+	if !strings.HasPrefix(svc.Image, "pgvector/pgvector:pg15") {
+		t.Errorf("Image = %q, want pgvector/pgvector:pg15", svc.Image)
+	}
+}

--- a/internal/config/loader_known_vars_core.go
+++ b/internal/config/loader_known_vars_core.go
@@ -27,6 +27,7 @@ var knownEnvVarsCore = []string{
 
 	// PostgreSQL
 	"POSTGRES_VERSION",
+	"POSTGRES_IMAGE",
 	"POSTGRES_HOST",
 	"POSTGRES_PORT",
 	"POSTGRES_DB",

--- a/internal/config/loader_parse_env_core.go
+++ b/internal/config/loader_parse_env_core.go
@@ -28,6 +28,7 @@ func parseEnvCore(cfg *Config) {
 	// ── PostgreSQL ───────────────────────────────────────────────────
 	cfg.Postgres = PostgresConfig{
 		Version:    os.Getenv("POSTGRES_VERSION"),
+		Image:      os.Getenv("POSTGRES_IMAGE"),
 		Host:       os.Getenv("POSTGRES_HOST"),
 		Port:       getEnvInt("POSTGRES_PORT", 0),
 		DB:         os.Getenv("POSTGRES_DB"),

--- a/internal/config/types_datastores.go
+++ b/internal/config/types_datastores.go
@@ -9,11 +9,16 @@ package config
 
 // PostgresConfig holds PostgreSQL database configuration.
 type PostgresConfig struct {
-	Version    string   `env:"POSTGRES_VERSION"` // 16-alpine
-	Host       string   `env:"POSTGRES_HOST"`    // postgres (container name)
-	Port       int      `env:"POSTGRES_PORT"`    // 5432
-	DB         string   `env:"POSTGRES_DB"`      // nself
-	User       string   `env:"POSTGRES_USER"`    // postgres
+	Version string `env:"POSTGRES_VERSION"` // 16-alpine
+	// Image, when set, is the exact postgres image nself build emits and wins
+	// over every other resolution (see compose.ResolvePostgresImage). Set this
+	// to pin a running image (e.g. pgvector/pgvector:pg16) across regens
+	// without relying on POSTGRES_EXTENSIONS inference (cli#384).
+	Image      string   `env:"POSTGRES_IMAGE"`
+	Host       string   `env:"POSTGRES_HOST"` // postgres (container name)
+	Port       int      `env:"POSTGRES_PORT"` // 5432
+	DB         string   `env:"POSTGRES_DB"`   // nself
+	User       string   `env:"POSTGRES_USER"` // postgres
 	Password   string   `env:"POSTGRES_PASSWORD"`
 	Extensions []string `env:"POSTGRES_EXTENSIONS"`  // comma-separated list
 	ExposePort string   `env:"POSTGRES_EXPOSE_PORT"` // auto, true, false


### PR DESCRIPTION
## Summary

- `buildPostgresService()` always emitted `postgres:<POSTGRES_VERSION>`, so the `pgvector/pgvector` pin in `DefaultImageVersions` was dead code and `POSTGRES_EXTENSIONS=pgvector` never changed the generated image. Regenerating against a populated pgvector database silently swapped the running container for plain alpine postgres (uid 70, no PGDATA) — a data-loss event on restart.
- Adds `compose.ResolvePostgresImage` with a fixed precedence:
  1. `POSTGRES_IMAGE` (new env knob) always wins.
  2. `POSTGRES_EXTENSIONS` containing `pgvector` selects `pgvector/pgvector:pg<major>` (major version parsed from `POSTGRES_VERSION`).
  3. Otherwise the existing `postgres:<POSTGRES_VERSION>` default (unchanged behavior).
- `buildPostgresService` derives PGDATA + the container uid from the resulting image name (alpine vs. debian-family), so fixing the precedence also fixes uid/PGDATA preservation — a pgvector or other debian-family image now correctly resolves to uid 999 + PGDATA.
- Adds `build.PostgresImageChangeWarning`: a build-time advisory that shells out to `docker inspect` for the running postgres container's actual image and logs a `slog.Warn` when it differs from what this build just generated. Best-effort only — never blocks the build, never errors when Docker/the container is unreachable.
- Registers `POSTGRES_IMAGE` in the config loader (`loader_parse_env_core.go`, `loader_known_vars_core.go`) and in the project's env-var reference doc.

Fixes #384

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./internal/compose/... ./internal/config/... ./internal/build/...` — clean
- [x] `go test ./...` — full suite passes (exit 0)
- [x] New unit tests cover all three precedence branches, case/whitespace-insensitive extension matching, PGDATA/uid preservation for pgvector/explicit-image/plain-alpine cases, and the image-change warning (mismatch/match/no-baseline/no-container)