### PR TITLE
fix(nginx): emit 443 blocks for certs already on disk, refuse mismatched output dir

### DIFF
--- a/internal/build/nginx_sites_dir.go
+++ b/internal/build/nginx_sites_dir.go
@@ -53,16 +53,23 @@ func resolveNginxSitesDir(workdir, frontedBy string) (string, error) {
 
 	frontingDir, ok := nginxtopo.ResolveFrontingDir(workdir, frontedBy)
 	if !ok {
+		// Paths are interpolated with %s, not %q: on Windows %q doubles
+		// each backslash in the path separator, which breaks any caller
+		// (including tests) that looks for the literal path inside this
+		// message via strings.Contains — the same class of bug documented
+		// in internal/doctor/hardening_check_nginx_fronted_test.go's
+		// messageNamesPath helper. Using %s here avoids needing that
+		// tolerance at all.
 		parent := filepath.Dir(workdir)
 		return "", fmt.Errorf(
 			"refusing to generate nginx site configs: NGINX_FRONTED_BY=%q names another "+
-				"stack's nginx as this project's ingress, so %q is never read by any running "+
-				"nginx (a fronted project generates no nginx container of its own) — and %q "+
-				"could not be confirmed as %q's own directory (its basename must equal "+
+				"stack's nginx as this project's ingress, so %s is never read by any running "+
+				"nginx (a fronted project generates no nginx container of its own) — and %s "+
+				"could not be confirmed as %[1]q's own directory (its basename must equal "+
 				"NGINX_FRONTED_BY); lay this project out as \"backend\" directly under "+
-				"%[4]s's own directory, or unset NGINX_FRONTED_BY if this project fronts "+
+				"%[1]s's own directory, or unset NGINX_FRONTED_BY if this project fronts "+
 				"itself",
-			frontedBy, ownDir, parent, frontedBy)
+			frontedBy, ownDir, parent)
 	}
 	return filepath.Join(frontingDir, "nginx", "sites"), nil
 }

--- a/internal/build/nginx_sites_dir.go
+++ b/internal/build/nginx_sites_dir.go
@@ -1,0 +1,68 @@
+package build
+
+// nginx_sites_dir.go — decides which on-disk directory `nself build` writes
+// generated per-service nginx site confs (nginx/sites/*.conf) into.
+//
+// Purpose: cli#385 — a project with NGINX_FRONTED_BY set generates no nginx
+// container of its own (see detection.go: DetectServices omits "nginx" and
+// compose.Generator skips the nginx service entirely when FrontedBy is
+// set), so <workdir>/nginx/sites/ is never mounted into any running nginx.
+// Before this fix, `nself build` still wrote there unconditionally — a
+// staging box was found with the generator's output at
+// "<checkout>/backend/nginx/sites" while the running nginx (belonging to
+// the fronting stack) served from "/opt/nself-web/nginx/sites", an entirely
+// different tree an operator's reconciliation step could copy stale/missing
+// confs from without any warning. This targets the confs at the directory
+// the fronting stack's own nginx actually reads from when that stack's
+// layout can be confirmed, and refuses the build otherwise rather than
+// silently writing a tree nginx never reads.
+// Inputs: workdir (this project's resolved nSelf root) and
+// cfg.Nginx.FrontedBy (NGINX_FRONTED_BY; empty for the default, unfronted
+// case).
+// Outputs: resolveNginxSitesDir returns the directory to write nginx/sites/
+// *.conf files into, or an error naming both the project's own (unused)
+// directory and the parent directory that was checked and did not resolve.
+// Constraints: reuses internal/nginxtopo.ResolveFrontingDir — the same
+// structural convention already established for the SEC-HARDENING-06
+// doctor check (internal/doctor) — rather than inventing a second
+// FrontedBy-to-path mechanism.
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/nself-org/cli/internal/nginxtopo"
+)
+
+// resolveNginxSitesDir returns the directory `nself build` should write
+// generated nginx/sites/*.conf route files into for workdir.
+//
+// When frontedBy is empty, behavior is unchanged: filepath.Join(workdir,
+// "nginx", "sites"). When frontedBy is set, this project's own nginx/sites/
+// is never read by any running nginx, so the fronting stack's own nginx
+// directory is targeted instead — resolved via the same "this project lives
+// directly under the fronting stack's directory, conventionally as
+// 'backend'" convention the SEC-HARDENING-06 doctor check trusts. When that
+// convention cannot be confirmed, this returns an error rather than
+// guessing: the caller must not write a tree nginx never reads.
+func resolveNginxSitesDir(workdir, frontedBy string) (string, error) {
+	ownDir := filepath.Join(workdir, "nginx", "sites")
+	if frontedBy == "" {
+		return ownDir, nil
+	}
+
+	frontingDir, ok := nginxtopo.ResolveFrontingDir(workdir, frontedBy)
+	if !ok {
+		parent := filepath.Dir(workdir)
+		return "", fmt.Errorf(
+			"refusing to generate nginx site configs: NGINX_FRONTED_BY=%q names another "+
+				"stack's nginx as this project's ingress, so %q is never read by any running "+
+				"nginx (a fronted project generates no nginx container of its own) — and %q "+
+				"could not be confirmed as %q's own directory (its basename must equal "+
+				"NGINX_FRONTED_BY); lay this project out as \"backend\" directly under "+
+				"%[4]s's own directory, or unset NGINX_FRONTED_BY if this project fronts "+
+				"itself",
+			frontedBy, ownDir, parent, frontedBy)
+	}
+	return filepath.Join(frontingDir, "nginx", "sites"), nil
+}

--- a/internal/build/nginx_sites_dir_test.go
+++ b/internal/build/nginx_sites_dir_test.go
@@ -1,0 +1,98 @@
+package build
+
+// nginx_sites_dir_test.go — cli#385: proves resolveNginxSitesDir targets
+// the fronting stack's own nginx/sites/ when NGINX_FRONTED_BY's structural
+// convention can be confirmed, leaves the unfronted default untouched, and
+// refuses (naming both directories) when the convention cannot be
+// confirmed rather than silently writing a tree nginx never reads.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveNginxSitesDir_Unfronted proves the default (FrontedBy unset)
+// case is unchanged: the project's own workdir/nginx/sites.
+func TestResolveNginxSitesDir_Unfronted(t *testing.T) {
+	workdir := t.TempDir()
+
+	got, err := resolveNginxSitesDir(workdir, "")
+	if err != nil {
+		t.Fatalf("resolveNginxSitesDir: %v", err)
+	}
+	want := filepath.Join(workdir, "nginx", "sites")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestResolveNginxSitesDir_FrontedResolved proves that when this project
+// lives as "backend" directly under the fronting stack's own directory
+// (basename == FrontedBy), route confs are targeted at the fronting
+// stack's own nginx/sites — the directory its nginx actually serves from —
+// not this project's own (unread) tree.
+func TestResolveNginxSitesDir_FrontedResolved(t *testing.T) {
+	base := t.TempDir()
+	frontingDir := filepath.Join(base, "nself-web")
+	workdir := filepath.Join(frontingDir, "backend")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	got, err := resolveNginxSitesDir(workdir, "nself-web")
+	if err != nil {
+		t.Fatalf("resolveNginxSitesDir: %v", err)
+	}
+	want := filepath.Join(frontingDir, "nginx", "sites")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	// Must NOT be this project's own (unserved) directory.
+	if got == filepath.Join(workdir, "nginx", "sites") {
+		t.Error("resolved to this project's own nginx/sites — that tree is never read by any running nginx when fronted")
+	}
+}
+
+// TestResolveNginxSitesDir_FrontedUnresolvedRefuses is the refusal path:
+// FrontedBy is set but the parent directory's basename does not match it,
+// so the fronting stack's directory cannot be confirmed. The build must
+// refuse, and the error must name BOTH this project's own directory and
+// the (mismatched) parent directory that was actually checked, so an
+// operator can act on the message without re-deriving the topology.
+func TestResolveNginxSitesDir_FrontedUnresolvedRefuses(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "some-other-name")
+	workdir := filepath.Join(parent, "backend")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	_, err := resolveNginxSitesDir(workdir, "nself-web")
+	if err == nil {
+		t.Fatal("expected an error when the fronting stack's directory cannot be confirmed, got nil")
+	}
+
+	ownDir := filepath.Join(workdir, "nginx", "sites")
+	msg := err.Error()
+	if !strings.Contains(msg, ownDir) {
+		t.Errorf("error must name this project's own directory %q, got: %s", ownDir, msg)
+	}
+	if !strings.Contains(msg, parent) {
+		t.Errorf("error must name the checked (mismatched) parent directory %q, got: %s", parent, msg)
+	}
+	if !strings.Contains(msg, "nself-web") {
+		t.Errorf("error must name the NGINX_FRONTED_BY stack, got: %s", msg)
+	}
+}
+
+// TestResolveNginxSitesDir_FrontedAtFilesystemRoot guards the edge case
+// where workdir has no parent (filepath.Dir returns itself) — must refuse,
+// never loop or panic.
+func TestResolveNginxSitesDir_FrontedAtFilesystemRoot(t *testing.T) {
+	root := string(filepath.Separator)
+	if _, err := resolveNginxSitesDir(root, "nself-web"); err == nil {
+		t.Error("expected an error resolving a fronting dir at filesystem root, got nil")
+	}
+}

--- a/internal/build/orchestrator_build_ssl.go
+++ b/internal/build/orchestrator_build_ssl.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/nself-org/cli/internal/nginx"
 	"github.com/nself-org/cli/internal/postgres"
@@ -48,25 +49,51 @@ func (st *buildState) generateSSLAndNginx() error {
 	st.filesGenerated += sslResult.Count * 2 // fullchain.pem + privkey.pem per cert set
 
 	// ── Step 7: Generate nginx configuration ────────────────────────
-	// Clear nginx/sites/ before regenerating so stale configs from a previous
-	// BASE_DOMAIN value don't persist. conf.d/ is hand-managed and is NOT cleared.
-	nginxSitesClearDir := filepath.Join(st.workdir, "nginx", "sites")
-	if entries, readErr := os.ReadDir(nginxSitesClearDir); readErr == nil {
-		for _, e := range entries {
-			if !e.IsDir() {
-				_ = os.Remove(filepath.Join(nginxSitesClearDir, e.Name()))
+	// sitesDir is normally <workdir>/nginx/sites. When NGINX_FRONTED_BY is
+	// set this project generates no nginx container of its own, so that
+	// directory is never read by any running nginx — resolveNginxSitesDir
+	// (cli#385) targets the fronting stack's own nginx/sites/ instead, or
+	// refuses the build when that stack's directory cannot be confirmed.
+	// See nginx_sites_dir.go.
+	sitesDir, err := resolveNginxSitesDir(st.workdir, st.cfg.Nginx.FrontedBy)
+	if err != nil {
+		return err
+	}
+
+	// Clear stale *.conf files from a previous BASE_DOMAIN before
+	// regenerating — but only in sitesDir's own (unfronted) case. When
+	// fronted, sitesDir belongs to another project's stack, which writes
+	// its own per-service confs into the same directory; blanket-clearing
+	// it would delete that stack's own routes. conf.d/ is hand-managed and
+	// is NOT cleared either way.
+	if sitesDir == filepath.Join(st.workdir, "nginx", "sites") {
+		if entries, readErr := os.ReadDir(sitesDir); readErr == nil {
+			for _, e := range entries {
+				if !e.IsDir() {
+					_ = os.Remove(filepath.Join(sitesDir, e.Name()))
+				}
 			}
 		}
 	}
+
 	nginxGen := nginx.NewGenerator(st.cfg, st.workdir)
 	nginxFiles, err := nginxGen.Generate()
 	if err != nil {
 		return fmt.Errorf("generating nginx config: %w", err)
 	}
 
-	// Write each nginx config file.
+	// Write each nginx config file. Per-service site route confs
+	// ("nginx/sites/...") are redirected to sitesDir; everything else
+	// (nginx.conf, conf.d/default.conf, includes/rate-limits.conf) stays
+	// under this project's own workdir/nginx regardless of FrontedBy.
+	const sitesPrefix = "nginx/sites/"
 	for relPath, content := range nginxFiles {
-		absPath := filepath.Join(st.workdir, relPath)
+		var absPath string
+		if strings.HasPrefix(relPath, sitesPrefix) {
+			absPath = filepath.Join(sitesDir, strings.TrimPrefix(relPath, sitesPrefix))
+		} else {
+			absPath = filepath.Join(st.workdir, relPath)
+		}
 		dir := filepath.Dir(absPath)
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("creating directory for %s: %w", relPath, err)

--- a/internal/doctor/hardening_check_nginx_fronted_dir.go
+++ b/internal/doctor/hardening_check_nginx_fronted_dir.go
@@ -16,39 +16,23 @@ package doctor
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/nginxtopo"
 )
 
 // resolveNginxFrontedDir resolves the on-disk nginx directory for a project
 // fronted by another stack (NGINX_FRONTED_BY — see config.NginxConfig.FrontedBy).
 //
-// FrontedBy carries only a stack NAME (e.g. "nself-web"), never a path, and
-// none of the codebase's other three consumers of it
-// (internal/build/detection.go, internal/build/manifest_resolve.go,
-// internal/compose/generator.go) resolve that name to a filesystem
-// location — all three only test it for emptiness, to decide whether to
-// generate this project's own nginx service. There is no config-driven
-// convention anywhere in this CLI for turning a stack name into a directory
-// in the general case, so this function does not attempt one.
-//
-// The one topology it trusts is the one that caused the regression this
-// check exists to catch (cli#380/cli#371 on staging): this project living
-// as a subdirectory (conventionally "backend") directly under the fronting
-// stack's own directory, whose basename equals FrontedBy — e.g. projectDir
-// ".../nself-web/backend" with FrontedBy "nself-web" resolves to
-// ".../nself-web/nginx". That is a structural inference from the directory
-// layout the operator already chose, not a second FrontedBy-to-path
-// convention grafted onto config. When the parent directory's name does
-// not match, this function returns ok=false — the caller must not guess
-// further and silently audit the wrong directory.
+// FrontedBy carries only a stack NAME (e.g. "nself-web"), never a path.
+// Turning it into a filesystem location is internal/nginxtopo.
+// ResolveFrontingDir's job — this wrapper exists only so this file's
+// existing callers (planNginxAudit) keep their local name. See that
+// package for the structural convention this delegates to (cli#380/cli#371
+// on staging; reused as-is by the nginx generator for cli#385 rather than
+// inventing a second convention).
 func resolveNginxFrontedDir(projectDir, frontedBy string) (dir string, ok bool) {
-	parent := filepath.Dir(projectDir)
-	if parent == projectDir || filepath.Base(parent) != frontedBy {
-		return "", false
-	}
-	return parent, true
+	return nginxtopo.ResolveFrontingDir(projectDir, frontedBy)
 }
 
 // nginxAuditPlan is the outcome of deciding which directory

--- a/internal/nginx/generator.go
+++ b/internal/nginx/generator.go
@@ -55,21 +55,22 @@ type Generator struct {
 	tmpl       *template.Template
 	seenRoutes map[string]bool // tracks server names seen in the current generation batch
 	workdir    string          // project root directory for conf.d/ conflict scanning
-	hasSSL     bool            // true when local SSL certs are expected on disk (SSL_MODE=local)
+	hasSSL     bool            // true when a cert pair for BaseDomain is expected/present on disk — see sslShouldEmit
 }
 
 // NewGenerator creates an nginx Generator from the given config.
 // When SSL_MODE is "local" (or empty, which defaults to "local" in dev),
 // nginx server blocks are generated with ssl_certificate directives pointing
-// to the locally generated cert files. For other modes (letsencrypt, custom,
-// none), the HTTPS server blocks are omitted so nginx can start without
-// requiring cert files that do not yet exist.
+// to the locally generated cert files. For "letsencrypt"/"custom" modes the
+// HTTPS server blocks are emitted only once a certificate pair already
+// exists on disk for the domain — see sslShouldEmit. "none" always omits
+// them, regardless of what cert files happen to be present.
 func NewGenerator(cfg *config.Config, workdir string) *Generator {
 	mode := cfg.SSLMode
 	if mode == "" {
 		mode = "local"
 	}
-	return &Generator{cfg: cfg, workdir: workdir, hasSSL: mode == "local"}
+	return &Generator{cfg: cfg, workdir: workdir, hasSSL: sslShouldEmit(cfg, workdir, mode)}
 }
 
 // Generate produces all nginx config files.

--- a/internal/nginx/ssl_detect.go
+++ b/internal/nginx/ssl_detect.go
@@ -1,0 +1,68 @@
+package nginx
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// ssl_detect.go — decides whether generated nginx site confs should
+// terminate TLS, split out of generator.go (CLI-R12 file-size discipline).
+//
+// Purpose: cli#385 — SSL_MODE only ever controls whether *this build*
+// GENERATES new local certificates (internal/ssl/generator.go skips local
+// generation entirely for "letsencrypt"/"custom"/"none", since certbot or
+// the operator supplies those certs out of band). Before this fix, the
+// nginx generator's hasSSL flag was hard-wired to `SSL_MODE == "local"`, so
+// a "letsencrypt"/"custom" project whose certs were already issued and
+// sitting on disk from an earlier `certbot`/`ssl add` run still generated
+// HTTP-only site confs with no `listen 443 ssl` block. Reconciling that
+// generated tree onto a serving nginx that already terminates TLS per
+// service would have dropped HTTPS stack-wide.
+// Inputs: cfg (BaseDomain, SSLMode) and workdir (project root — certs live
+// under workdir/ssl/certificates/<dir>/, see internal/ssl.DomainToDirName).
+// Outputs: sslShouldEmit reports whether nginx should emit the 443/
+// ssl_certificate block; sslCertsPresent reports raw cert-file presence.
+// Constraints: see sslShouldEmit's own doc comment for the per-mode rules.
+
+// sslShouldEmit decides whether generated nginx site confs should include a
+// `listen 443 ssl` server block with ssl_certificate directives.
+//
+// Inputs: cfg, workdir (see package doc above), and the resolved SSL_MODE
+// (never empty; NewGenerator defaults it to "local" before calling this).
+// Outputs: true when nginx should emit the 443/ssl_certificate block.
+// Constraints:
+//   - "none" is an explicit opt-out: always false, regardless of any stray
+//     cert files that might exist on disk.
+//   - "local" is always true: `nself build` regenerates/refreshes local
+//     certs on every run (internal/ssl/generator.go), so they are
+//     guaranteed present by the time this runs in the real Build() flow.
+//   - any other mode ("letsencrypt", "custom", ...) checks the filesystem:
+//     these modes never generate certs themselves, so presence on disk is
+//     the only trustworthy signal that nginx can safely reference them.
+func sslShouldEmit(cfg *config.Config, workdir, mode string) bool {
+	switch mode {
+	case "none":
+		return false
+	case "local":
+		return true
+	default:
+		return sslCertsPresent(cfg, workdir)
+	}
+}
+
+// sslCertsPresent reports whether a usable certificate pair (fullchain.pem +
+// privkey.pem) already exists on disk for cfg.BaseDomain, at the same path
+// internal/ssl.Generator writes to and RenderServiceRoute/hasTrustedChain
+// read from.
+func sslCertsPresent(cfg *config.Config, workdir string) bool {
+	certDir := filepath.Join(workdir, "ssl", "certificates", sslDirName(cfg.BaseDomain))
+	if _, err := os.Stat(filepath.Join(certDir, "fullchain.pem")); err != nil {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(certDir, "privkey.pem")); err != nil {
+		return false
+	}
+	return true
+}

--- a/internal/nginx/ssl_detect_test.go
+++ b/internal/nginx/ssl_detect_test.go
@@ -1,0 +1,153 @@
+package nginx
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// ssl_detect_test.go — cli#385: proves generated per-service site confs
+// emit a `listen 443 ssl` block whenever a certificate pair is actually on
+// disk, regardless of SSL_MODE, while preserving the pre-existing Bug #68
+// guarantees (nginx_test.go) that "local" is always true and "none" is
+// always false.
+
+// writeCertPair writes a minimal fullchain.pem + privkey.pem pair under
+// workdir/ssl/certificates/<sslDirName(domain)>/, matching the layout
+// internal/ssl.Generator writes to.
+func writeCertPair(t *testing.T, workdir, domain string) {
+	t.Helper()
+	certDir := filepath.Join(workdir, "ssl", "certificates", sslDirName(domain))
+	if err := os.MkdirAll(certDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", certDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(certDir, "fullchain.pem"), []byte("fake-fullchain"), 0o644); err != nil {
+		t.Fatalf("write fullchain.pem: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(certDir, "privkey.pem"), []byte("fake-privkey"), 0o600); err != nil {
+		t.Fatalf("write privkey.pem: %v", err)
+	}
+}
+
+func newCfgForSSLDetect(t *testing.T, mode string) *config.Config {
+	t.Helper()
+	cfg := &config.Config{BaseDomain: "example.com"}
+	cfg, err := config.ApplyDefaults(cfg)
+	if err != nil {
+		t.Fatalf("ApplyDefaults() error: %v", err)
+	}
+	cfg.SSLMode = mode
+	return cfg
+}
+
+// TestSSLShouldEmit_LetsEncryptWithCertsPresent is the core cli#385
+// regression: a "letsencrypt" project whose certs were already issued by an
+// earlier certbot/`ssl add` run must emit the 443 block, not silently drop
+// it the way SSL_MODE=="local"-only logic did.
+func TestSSLShouldEmit_LetsEncryptWithCertsPresent(t *testing.T) {
+	workdir := t.TempDir()
+	cfg := newCfgForSSLDetect(t, "letsencrypt")
+	writeCertPair(t, workdir, cfg.BaseDomain)
+
+	gen := NewGenerator(cfg, workdir)
+	if !gen.hasSSL {
+		t.Error("cli#385: letsencrypt mode with certs already on disk must set hasSSL=true")
+	}
+}
+
+// TestSSLShouldEmit_CustomWithCertsPresent mirrors the letsencrypt case for
+// operator-supplied ("custom") certs placed at the same conventional path.
+func TestSSLShouldEmit_CustomWithCertsPresent(t *testing.T) {
+	workdir := t.TempDir()
+	cfg := newCfgForSSLDetect(t, "custom")
+	writeCertPair(t, workdir, cfg.BaseDomain)
+
+	gen := NewGenerator(cfg, workdir)
+	if !gen.hasSSL {
+		t.Error("cli#385: custom mode with certs already on disk must set hasSSL=true")
+	}
+}
+
+// TestSSLShouldEmit_LetsEncryptWithoutCerts preserves the pre-existing Bug
+// #68 guarantee: before certbot has ever run, no cert files exist yet, and
+// nginx must still be able to start HTTP-only.
+func TestSSLShouldEmit_LetsEncryptWithoutCerts(t *testing.T) {
+	workdir := t.TempDir()
+	cfg := newCfgForSSLDetect(t, "letsencrypt")
+
+	gen := NewGenerator(cfg, workdir)
+	if gen.hasSSL {
+		t.Error("letsencrypt mode with no certs on disk must set hasSSL=false")
+	}
+}
+
+// TestSSLShouldEmit_CustomWithoutCerts is the "custom" analog of the above.
+func TestSSLShouldEmit_CustomWithoutCerts(t *testing.T) {
+	workdir := t.TempDir()
+	cfg := newCfgForSSLDetect(t, "custom")
+
+	gen := NewGenerator(cfg, workdir)
+	if gen.hasSSL {
+		t.Error("custom mode with no certs on disk must set hasSSL=false")
+	}
+}
+
+// TestSSLShouldEmit_NoneAlwaysFalseEvenWithCertsPresent proves "none" is a
+// hard opt-out: even if a cert pair happens to be sitting on disk (e.g. left
+// over from a prior SSL_MODE), nginx must never reference it.
+func TestSSLShouldEmit_NoneAlwaysFalseEvenWithCertsPresent(t *testing.T) {
+	workdir := t.TempDir()
+	cfg := newCfgForSSLDetect(t, "none")
+	writeCertPair(t, workdir, cfg.BaseDomain)
+
+	gen := NewGenerator(cfg, workdir)
+	if gen.hasSSL {
+		t.Error("SSL_MODE=none must set hasSSL=false even when cert files are present")
+	}
+}
+
+// TestSSLShouldEmit_LocalAlwaysTrueEvenWithoutCertsYet preserves Bug #68:
+// local mode is trusted unconditionally because `nself build` always
+// (re)generates local certs earlier in the same run.
+func TestSSLShouldEmit_LocalAlwaysTrueEvenWithoutCertsYet(t *testing.T) {
+	workdir := t.TempDir()
+	cfg := newCfgForSSLDetect(t, "local")
+
+	gen := NewGenerator(cfg, workdir)
+	if !gen.hasSSL {
+		t.Error("SSL_MODE=local must set hasSSL=true even before this run's certs are written")
+	}
+}
+
+// TestServiceConf_LetsEncryptWithCertsPresent_Emits443Block renders an
+// actual service.conf.tmpl through RenderServiceRoute and asserts the
+// output contains a real `listen 443 ssl` block with the matching
+// ssl_certificate paths — the end-to-end shape of the cli#385 fix, not just
+// the internal hasSSL flag.
+func TestServiceConf_LetsEncryptWithCertsPresent_Emits443Block(t *testing.T) {
+	workdir := t.TempDir()
+	cfg := newCfgForSSLDetect(t, "letsencrypt")
+	writeCertPair(t, workdir, cfg.BaseDomain)
+
+	gen := NewGenerator(cfg, workdir)
+	out, err := gen.RenderServiceRoute(ServiceRouteData{
+		Route:      "api",
+		BaseDomain: cfg.BaseDomain,
+		Upstream:   "api_upstream:8080",
+		SSLDir:     sslDirName(cfg.BaseDomain),
+	})
+	if err != nil {
+		t.Fatalf("RenderServiceRoute: %v", err)
+	}
+
+	if !strings.Contains(out, "listen 443 ssl;") {
+		t.Errorf("expected a listen 443 ssl block, got:\n%s", out)
+	}
+	wantCert := "ssl_certificate /etc/nginx/ssl/certificates/" + sslDirName(cfg.BaseDomain) + "/fullchain.pem;"
+	if !strings.Contains(out, wantCert) {
+		t.Errorf("expected ssl_certificate directive %q, got:\n%s", wantCert, out)
+	}
+}

--- a/internal/nginxtopo/resolve.go
+++ b/internal/nginxtopo/resolve.go
@@ -1,0 +1,36 @@
+// Package nginxtopo resolves on-disk nginx directory topology for projects
+// fronted by another stack's nginx (NGINX_FRONTED_BY / config.NginxConfig.
+// FrontedBy). It has no dependency on internal/config, internal/build, or
+// internal/doctor so any of them can import it without a cycle.
+package nginxtopo
+
+import "path/filepath"
+
+// Purpose: FrontedBy names only a stack (e.g. "nself-web"), never a path —
+// nothing in the CLI's config model turns a stack name into a filesystem
+// location. ResolveFrontingDir is the one topology the CLI trusts to bridge
+// that gap, first established for the SEC-HARDENING-06 doctor check
+// (internal/doctor, cli#380/cli#371 staging regression) and reused as-is by
+// the nginx site-conf generator (internal/build, cli#385) rather than
+// inventing a second convention.
+// Inputs: projectDir (a project's resolved nSelf root) and frontedBy
+// (config.NginxConfig.FrontedBy, expected non-empty by callers).
+// Outputs: the fronting stack's own project directory and ok=true when the
+// convention is confirmed; "", false otherwise.
+// Constraints: never guesses beyond the one confirmed convention — callers
+// must refuse rather than fall back to a wrong directory when ok is false.
+
+// ResolveFrontingDir resolves the directory of the stack named by frontedBy
+// when projectDir is laid out as a subdirectory (conventionally "backend")
+// directly under that stack's own directory.
+//
+// Example: projectDir ".../nself-web/backend" with frontedBy "nself-web"
+// resolves to ".../nself-web" — the fronting stack's own root. Callers
+// append their own "nginx/..." subpath (e.g. "nginx/sites") to that root.
+func ResolveFrontingDir(projectDir, frontedBy string) (dir string, ok bool) {
+	parent := filepath.Dir(projectDir)
+	if parent == projectDir || filepath.Base(parent) != frontedBy {
+		return "", false
+	}
+	return parent, true
+}

--- a/internal/nginxtopo/resolve_test.go
+++ b/internal/nginxtopo/resolve_test.go
@@ -1,0 +1,51 @@
+package nginxtopo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveFrontingDir_Confirmed proves the one structural convention this
+// package trusts: projectDir living directly under a directory whose
+// basename equals frontedBy resolves to that parent.
+func TestResolveFrontingDir_Confirmed(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "nself-web")
+	projectDir := filepath.Join(parent, "backend")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	dir, ok := ResolveFrontingDir(projectDir, "nself-web")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if dir != parent {
+		t.Errorf("got %q, want %q", dir, parent)
+	}
+}
+
+// TestResolveFrontingDir_MismatchedBasename proves resolution refuses
+// (ok=false) rather than guessing when the parent's basename doesn't match.
+func TestResolveFrontingDir_MismatchedBasename(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "some-other-name")
+	projectDir := filepath.Join(parent, "backend")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if _, ok := ResolveFrontingDir(projectDir, "nself-web"); ok {
+		t.Error("expected ok=false for a mismatched parent basename")
+	}
+}
+
+// TestResolveFrontingDir_FilesystemRoot guards against an infinite loop or
+// false positive when projectDir has no parent.
+func TestResolveFrontingDir_FilesystemRoot(t *testing.T) {
+	root := string(filepath.Separator)
+	if _, ok := ResolveFrontingDir(root, "nself-web"); ok {
+		t.Error("expected ok=false at filesystem root")
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/nginx.NewGenerator`'s `hasSSL` flag was hard-wired to `SSL_MODE == "local"`. A `letsencrypt`/`custom` project whose certs were already issued by an earlier certbot/`ssl add` run still generated HTTP-only per-service site confs with no `listen 443 ssl` block, even though certs existed on disk. Reconciling that generated tree onto a serving nginx that already terminates TLS per service would drop HTTPS stack-wide.
- `hasSSL` now checks for a cert pair on disk (`ssl/certificates/<dir>/{fullchain,privkey}.pem`) for any mode other than `local` (always true — `nself build` regenerates local certs every run) or `none` (always false, explicit opt-out). Preserves all pre-existing "Bug #68" regression tests.
- Separately: a project fronted by another stack's nginx (`NGINX_FRONTED_BY`) generates no nginx container of its own (`internal/build/detection.go`), so its own `nginx/sites/` is never mounted by any running nginx. `nself build` kept writing generated site confs there regardless — an orphaned tree, observed on staging as `backend/nginx/sites/*.conf` while the served tree was `/opt/nself-web/nginx/sites`.
- `resolveNginxSitesDir` (new, `internal/build/nginx_sites_dir.go`) now targets the fronting stack's own `nginx/sites/` when the directory layout can be confirmed, reusing the exact structural convention already established for the SEC-HARDENING-06 doctor check (`internal/doctor`) rather than inventing a second mechanism — that convention is now factored into a small shared leaf package, `internal/nginxtopo`, used by both. When the fronting stack's directory cannot be confirmed, the build refuses with an error naming both this project's own (unused) directory and the mismatched parent directory that was checked.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -mod=vendor ./...` — 5022 passed, 96 packages
- [x] New unit tests: SSL on vs off, certs present vs absent (`internal/nginx/ssl_detect_test.go`, including an end-to-end `RenderServiceRoute` assertion on the actual `listen 443 ssl;` + `ssl_certificate` output)
- [x] New unit tests: fronted-by set vs unset, and the refusal path asserting the error names both directories (`internal/build/nginx_sites_dir_test.go`, `internal/nginxtopo/resolve_test.go`)
- [x] Existing doctor fronted-topology tests (`internal/doctor/hardening_check_nginx_fronted_test.go`) still pass unchanged after refactor

Fixes #385