### PR TITLE
docs: link the self-hosting boundary page and fix source-available links

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Categories include AI and intelligence, real-time communication, media processin
 - `compliance` — GDPR, CCPA, HIPAA, SOC 2, PCI-DSS coverage
 - `auth` — WebAuthn/passkeys, TOTP 2FA, magic links, device-code flow
 
-Pro plugins are source-available. License validated server-side via `ping.nself.org`. Revoked keys render plugins inert on next build.
+Pro plugins are [source-available](https://nself.org/legal/bundle-license). License validated server-side via `ping.nself.org`. Revoked keys render plugins inert on next build.
 
 ---
 
@@ -470,6 +470,9 @@ nself health check
 
 Security hardening runs automatically on every deploy. No license required.
 
+See [Self-hosting: what is and is not included](https://nself.org/docs/self-hosting/boundary) for
+what nSelf provides vs. what you own as the operator (backups, monitoring, on-call, capacity).
+
 ---
 
 ## Requirements
@@ -514,7 +517,7 @@ Tests live in `internal/` alongside the packages they test. Coverage target: 70%
 
 MIT, free for personal and commercial use. See [LICENSE](LICENSE).
 
-The 127 pro plugins are source-available under a separate commercial license. Compiled binaries are distributed through `ping.nself.org` after license validation.
+Pro plugins (count generated from the plugins-pro registry, not hand-typed here) are [source-available](https://nself.org/legal/bundle-license) under the nSelf Bundle License. Compiled binaries are distributed through `ping.nself.org` after license validation.
 
 ---
 


### PR DESCRIPTION
## Summary

Part of P6-E12-W4-S4-T1 and T3.

- Links `nself.org/docs/self-hosting/boundary` (new page, nself-org/web#226) from the Production
  Deployment section — what nSelf provides vs. what the operator owns.
- Links the two "source-available" plugin mentions to the new Bundle License page
  (nself-org/web#226 / nself-org/plugins-pro#130), and removes the hand-typed, already-inconsistent
  plugin counts ("109" here vs "59"/"46" elsewhere) in favor of "count generated from the registry,
  not hand-typed here."

## Related finding (not fixed here)

`cli/internal/license/keys.go:26-38` hardcodes display names "ɳSelf Pro", "ɳSelf Enterprise", "ɳSelf
Business+", and "nTV" (should be "ɳTV" per the branding convention) for license key prefixes, and
three tiers (Owner/Enterprise/Business+) that are not part of the documented four-tier offering canon
(CLI free / Bundles / ɳSelf+ / ɳCloud). This is a code change outside a docs ticket's scope — flagging
for a follow-up decision.

## Test plan
- [x] Diff is two doc-only edits to README.md
- [ ] CI green