### PR TITLE
db migrate: baseline / --detect / lint for populated-DB adoption

### DIFF
--- a/cmd/commands/db_commands_ext.go
+++ b/cmd/commands/db_commands_ext.go
@@ -172,6 +172,9 @@ func init() {
 	// --migration-dir flag on migrate status (G-008): repos with non-standard
 	// layouts (e.g. ntask postgres/migrations) otherwise report "No migrations found"
 	dbMigrateStatusCmd.Flags().String("migration-dir", "", "Report status for migrations in this directory instead of the auto-detected one")
+	// --detect flag on migrate status (cli#386): classify each pending
+	// migration against the live schema instead of only checking the ledger.
+	dbMigrateStatusCmd.Flags().Bool("detect", false, "Classify pending migrations against the live schema (BASELINE/APPLY/CONFLICT)")
 	// --env/--server: remote targeting (gap #9) — default local, opt-in remote.
 	addDBRemoteFlags(dbMigrateUpCmd)
 	addDBRemoteFlags(dbMigrateStatusCmd)

--- a/cmd/commands/db_migrate.go
+++ b/cmd/commands/db_migrate.go
@@ -101,12 +101,17 @@ func runDBMigrateStatus(cmd *cobra.Command, _ []string) error {
 	if f := cmd.Flags().Lookup("migration-dir"); f != nil {
 		migrationDir = f.Value.String()
 	}
+	detect, _ := cmd.Flags().GetBool("detect")
 
-	// Forward --migration-dir to the remote CLI: the pre-flight version-drift
-	// check (#162) guarantees the remote binary understands the flag.
+	// Forward --migration-dir/--detect to the remote CLI: the pre-flight
+	// version-drift check (#162) guarantees the remote binary understands
+	// the flags.
 	remoteArgs := []string{"db", "migrate", "status"}
 	if migrationDir != "" {
 		remoteArgs = append(remoteArgs, "--migration-dir", migrationDir)
+	}
+	if detect {
+		remoteArgs = append(remoteArgs, "--detect")
 	}
 	if handled, err := dispatchRemoteIfNeeded(cmd, remoteArgs...); handled {
 		return err
@@ -116,6 +121,14 @@ func runDBMigrateStatus(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+
+	// --detect classifies each pending migration against the live schema
+	// (BASELINE/APPLY/CONFLICT) instead of only checking the ledger — see
+	// db_migrate_detect.go. It never writes anything.
+	if detect {
+		return runDBMigrateStatusDetect(cmd, cfg, migrationDir)
+	}
+
 	statuses, err := database.MigrateStatus(cmd.Context(), cfg, migrationDir)
 	if err != nil {
 		return fmt.Errorf("migrate status: %w", err)

--- a/cmd/commands/db_migrate_baseline.go
+++ b/cmd/commands/db_migrate_baseline.go
@@ -1,0 +1,160 @@
+package commands
+
+// Purpose: `nself db migrate baseline <name...>` — record one or more
+// on-disk migrations as applied WITHOUT executing their SQL. This is the
+// verb cli#386 was missing: a populated database (built by dump/console/hand
+// SQL) has no way to adopt the CLI's migration ledger except by hand-editing
+// schema_versions, which the nSelf-First doctrine forbids.
+// Inputs: cobra command/args (migration names) plus --yes/--dry-run/
+// --migration-dir flags.
+// Outputs: printed plan + (unless --dry-run) ledger rows written via
+// database.BaselineMigration; a non-nil error on any failure or refusal.
+// Constraints: baseline is destructive-adjacent — it makes the CLI believe
+// SQL ran that never ran. It must never run as a side effect of any other
+// command, must always print exactly what it will record, and must refuse
+// without --yes or an interactive "yes" (see baselineConfirmed).
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/database"
+
+	"github.com/spf13/cobra"
+)
+
+var dbMigrateBaselineCmd = &cobra.Command{
+	Use:   "baseline <name> [name...]",
+	Short: "Record migration(s) as applied WITHOUT running their SQL",
+	Long: `Record one or more migrations in the schema_versions / nself_ops.migrations
+ledger as already applied, without executing the migration's SQL.
+
+Use this only when the migration's objects already exist in the database by
+some other means (a pg_dump restore, console-created tables, hand-written
+SQL) — the opposite case is 'nself db migrate apply', which runs the SQL.
+
+Run 'nself db migrate status --detect' first to see which pending migrations
+are safe BASELINE candidates (every object they create already exists).
+
+Always prints exactly what would be recorded. Requires --yes (or an
+interactive "yes" confirmation) to actually write; --dry-run never writes
+anything, with or without --yes.`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runDBMigrateBaseline,
+}
+
+func init() {
+	dbMigrateBaselineCmd.Flags().Bool("yes", false, "Skip interactive confirmation (required for non-interactive/CI use)")
+	dbMigrateBaselineCmd.Flags().Bool("dry-run", false, "Print what would be recorded without writing anything")
+	dbMigrateBaselineCmd.Flags().String("migration-dir", "", "Resolve migration names against this directory instead of the auto-detected one")
+	dbMigrateCmd.AddCommand(dbMigrateBaselineCmd)
+}
+
+func runDBMigrateBaseline(cmd *cobra.Command, args []string) error {
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	yesFlag, _ := cmd.Flags().GetBool("yes")
+	migrationDir, _ := cmd.Flags().GetString("migration-dir")
+
+	cfg, err := loadProjectConfig()
+	if err != nil {
+		return err
+	}
+
+	plans, err := database.PlanBaseline(cmd.Context(), cfg, migrationDir, args)
+	if err != nil {
+		return fmt.Errorf("plan baseline: %w", err)
+	}
+
+	pending := pendingBaselineCount(plans)
+	if pending == 0 {
+		fmt.Println("Nothing to baseline: all requested migrations are already recorded as applied.")
+		return nil
+	}
+
+	if !dryRun {
+		prompt := fmt.Sprintf(
+			"WARNING: this records %d migration(s) as applied WITHOUT running their SQL. Type \"yes\" to confirm: ",
+			pending)
+		confirmed, err := baselineConfirmed(yesFlag, os.Stdin, os.Stderr, prompt)
+		if err != nil {
+			return fmt.Errorf("reading confirmation: %w", err)
+		}
+		if !confirmed {
+			fmt.Fprintln(os.Stderr, "aborted")
+			return fmt.Errorf("baseline aborted: confirmation required (pass --yes for non-interactive use)")
+		}
+	}
+
+	applied, err := runBaselinePlans(cmd.OutOrStdout(), cmd.Context(), cfg, plans, dryRun, database.BaselineMigration)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		fmt.Println("Dry run: nothing was recorded.")
+		return nil
+	}
+	fmt.Printf("Baselined %d migration(s).\n", applied)
+	return nil
+}
+
+// pendingBaselineCount returns how many plans are not already applied.
+func pendingBaselineCount(plans []database.BaselinePlan) int {
+	n := 0
+	for _, p := range plans {
+		if !p.AlreadyApplied {
+			n++
+		}
+	}
+	return n
+}
+
+// baselineConfirmed implements the same destructive-adjacent confirmation
+// gate as runDBReset: --yes skips the prompt for CI/automation, otherwise the
+// operator must type exactly "yes". Pure I/O over injected reader/writer so
+// it is unit-testable without a terminal.
+func baselineConfirmed(yesFlag bool, in io.Reader, out io.Writer, prompt string) (bool, error) {
+	if yesFlag {
+		return true, nil
+	}
+	_, _ = fmt.Fprint(out, prompt)
+	scanner := bufio.NewScanner(in)
+	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(scanner.Text()) == "yes", nil
+}
+
+// baselineWriter matches database.BaselineMigration's signature so tests can
+// inject a fake and assert exactly which files were (or were not) written.
+type baselineWriter func(ctx context.Context, cfg *config.Config, filePath string) error
+
+// runBaselinePlans prints every plan's "would record" line, then — unless
+// dryRun — calls writer for each plan not already applied. dryRun guarantees
+// no write: the call to writer sits inside the `if !dryRun` branch and is
+// never reached otherwise, so a dry run is structurally incapable of
+// recording anything, not just conventionally.
+func runBaselinePlans(out io.Writer, ctx context.Context, cfg *config.Config, plans []database.BaselinePlan, dryRun bool, writer baselineWriter) (applied int, err error) {
+	for _, p := range plans {
+		if p.AlreadyApplied {
+			_, _ = fmt.Fprintf(out, "already applied: %s (skipped)\n", p.Name)
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "would record: %s (id=%s, checksum=%s)\n", p.Name, p.MigrationID, p.Checksum)
+		if dryRun {
+			continue
+		}
+		if werr := writer(ctx, cfg, p.FilePath); werr != nil {
+			return applied, fmt.Errorf("baseline %s: %w", p.Name, werr)
+		}
+		applied++
+		_, _ = fmt.Fprintf(out, "baselined: %s\n", p.Name)
+	}
+	return applied, nil
+}

--- a/cmd/commands/db_migrate_baseline_test.go
+++ b/cmd/commands/db_migrate_baseline_test.go
@@ -1,0 +1,129 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/database"
+)
+
+var errBaselineWriteFailed = errors.New("write failed")
+
+func TestBaselineConfirmed_YesFlagSkipsPrompt(t *testing.T) {
+	out := &bytes.Buffer{}
+	confirmed, err := baselineConfirmed(true, strings.NewReader(""), out, "prompt: ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !confirmed {
+		t.Fatal("expected confirmed=true when --yes is set")
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no prompt printed when --yes is set, got %q", out.String())
+	}
+}
+
+func TestBaselineConfirmed_InteractiveYes(t *testing.T) {
+	out := &bytes.Buffer{}
+	confirmed, err := baselineConfirmed(false, strings.NewReader("yes\n"), out, "prompt: ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !confirmed {
+		t.Fatal(`expected confirmed=true for typed "yes"`)
+	}
+	if !strings.Contains(out.String(), "prompt: ") {
+		t.Error("expected the prompt to be printed")
+	}
+}
+
+func TestBaselineConfirmed_InteractiveRefusal(t *testing.T) {
+	out := &bytes.Buffer{}
+	for _, input := range []string{"no\n", "\n", "Y\n", "sure\n"} {
+		confirmed, err := baselineConfirmed(false, strings.NewReader(input), out, "prompt: ")
+		if err != nil {
+			t.Fatalf("unexpected error for input %q: %v", input, err)
+		}
+		if confirmed {
+			t.Errorf("input %q must not confirm (only exact \"yes\" may)", input)
+		}
+	}
+}
+
+func TestRunBaselinePlans_DryRunWritesNothing(t *testing.T) {
+	calls := 0
+	fakeWriter := func(_ context.Context, _ *config.Config, _ string) error {
+		calls++
+		return nil
+	}
+	plans := []database.BaselinePlan{
+		{Name: "20260101_a.sql", MigrationID: "20260101_a", Checksum: "abc", FilePath: "/x/20260101_a.sql"},
+		{Name: "20260102_b.sql", MigrationID: "20260102_b", Checksum: "def", FilePath: "/x/20260102_b.sql"},
+	}
+	out := &bytes.Buffer{}
+	applied, err := runBaselinePlans(out, context.Background(), nil, plans, true, fakeWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("dry-run must never call the writer, got %d calls", calls)
+	}
+	if applied != 0 {
+		t.Fatalf("dry-run applied count = %d, want 0", applied)
+	}
+	if !strings.Contains(out.String(), "would record: 20260101_a.sql") {
+		t.Error("expected the plan to be printed even in dry-run")
+	}
+}
+
+func TestRunBaselinePlans_ConfirmedRunWritesOnlyPending(t *testing.T) {
+	var calledWith []string
+	fakeWriter := func(_ context.Context, _ *config.Config, filePath string) error {
+		calledWith = append(calledWith, filePath)
+		return nil
+	}
+	plans := []database.BaselinePlan{
+		{Name: "20260101_a.sql", AlreadyApplied: true, FilePath: "/x/20260101_a.sql"},
+		{Name: "20260102_b.sql", MigrationID: "20260102_b", Checksum: "def", FilePath: "/x/20260102_b.sql"},
+	}
+	out := &bytes.Buffer{}
+	applied, err := runBaselinePlans(out, context.Background(), nil, plans, false, fakeWriter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("applied = %d, want 1 (only the non-applied plan)", applied)
+	}
+	if len(calledWith) != 1 || calledWith[0] != "/x/20260102_b.sql" {
+		t.Fatalf("writer called with %v, want exactly the pending file", calledWith)
+	}
+	if !strings.Contains(out.String(), "already applied: 20260101_a.sql (skipped)") {
+		t.Error("expected the already-applied plan to be reported as skipped")
+	}
+}
+
+func TestRunBaselinePlans_WriterErrorPropagates(t *testing.T) {
+	fakeWriter := func(_ context.Context, _ *config.Config, _ string) error {
+		return errBaselineWriteFailed
+	}
+	plans := []database.BaselinePlan{{Name: "x.sql", FilePath: "/x/x.sql"}}
+	_, err := runBaselinePlans(&bytes.Buffer{}, context.Background(), nil, plans, false, fakeWriter)
+	if err == nil {
+		t.Fatal("expected the writer's error to propagate")
+	}
+}
+
+func TestPendingBaselineCount(t *testing.T) {
+	plans := []database.BaselinePlan{
+		{AlreadyApplied: true},
+		{AlreadyApplied: false},
+		{AlreadyApplied: false},
+	}
+	if n := pendingBaselineCount(plans); n != 2 {
+		t.Fatalf("pendingBaselineCount = %d, want 2", n)
+	}
+}

--- a/cmd/commands/db_migrate_detect.go
+++ b/cmd/commands/db_migrate_detect.go
@@ -1,0 +1,79 @@
+package commands
+
+// Purpose: `nself db migrate status --detect` — classify each pending
+// migration against the live schema (BASELINE/APPLY/CONFLICT) instead of
+// only reporting the ledger. See internal/database/migrate_detect*.go for the
+// classification logic. This file only prints, and for BASELINE-classified
+// migrations prints the exact `db migrate baseline` invocation that would
+// record them — baseline is never run automatically as a side effect.
+// Inputs: the loaded *config.Config and the resolved migrations directory.
+// Outputs: printed table + suggestions; a non-nil error only on a detection
+// failure (e.g. cannot reach the database).
+// Constraints: CONFLICT migrations are always listed separately and are
+// never included in the suggested baseline command.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nself-org/cli/internal/config"
+	"github.com/nself-org/cli/internal/database"
+	"github.com/nself-org/cli/internal/ui"
+
+	"github.com/spf13/cobra"
+)
+
+func runDBMigrateStatusDetect(cmd *cobra.Command, cfg *config.Config, migrationDir string) error {
+	results, err := database.DetectMigrations(cmd.Context(), cfg, migrationDir)
+	if err != nil {
+		return fmt.Errorf("detect migrations: %w", err)
+	}
+	if len(results) == 0 {
+		fmt.Println("No pending migrations to classify.")
+		return nil
+	}
+
+	tbl := ui.NewTable("MIGRATION", "CLASS", "PRESENT", "MISSING", "LINT")
+	var baselineCandidates, conflicts []string
+	for _, r := range results {
+		lint := "-"
+		if r.Lint != nil {
+			lint = fmt.Sprintf("FAIL (%d)", r.Lint.Count)
+		}
+		tbl.AddRow(r.Name, string(r.Class), objectCountLabel(r.Present), objectCountLabel(r.Missing), lint)
+		switch r.Class {
+		case database.DetectBaseline:
+			baselineCandidates = append(baselineCandidates, r.Name)
+		case database.DetectConflict:
+			conflicts = append(conflicts, r.Name)
+		}
+	}
+	tbl.Render()
+
+	if len(conflicts) > 0 {
+		fmt.Println()
+		ui.Warn(fmt.Sprintf(
+			"%d migration(s) are CONFLICT: some of their objects exist, some don't. "+
+				"Not auto-resolved — review each manually.", len(conflicts)))
+		for _, name := range conflicts {
+			fmt.Printf("  - %s\n", name)
+		}
+	}
+
+	if len(baselineCandidates) > 0 {
+		fmt.Println()
+		ui.Info("Every object these migrations create already exists. Review, then run:")
+		fmt.Printf("  nself db migrate baseline %s --yes\n", strings.Join(baselineCandidates, " "))
+	}
+
+	return nil
+}
+
+// objectCountLabel renders an object list as a compact count for the table,
+// or "-" when there are none.
+func objectCountLabel(objs []database.ObjectRef) string {
+	if len(objs) == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d", len(objs))
+}

--- a/cmd/commands/db_migrate_lint.go
+++ b/cmd/commands/db_migrate_lint.go
@@ -1,0 +1,78 @@
+package commands
+
+// Purpose: `nself db migrate lint [file...]` — statically refuse migrations
+// that mix many bare CREATE TABLE statements with no IF NOT EXISTS guard in
+// one file (the tasks_schema-style mistake behind cli#386: fine against an
+// empty database, a hard failure against one where some tables already
+// exist). See internal/database/migrate_lint.go for the check itself.
+// Inputs: cobra command/args — explicit file paths, or none to lint the
+// auto-detected (or --migration-dir) migrations directory.
+// Outputs: printed per-file OK/FAIL lines; a non-nil error (refusal) if any
+// file trips the lint.
+// Constraints: read-only — never touches a live database or writes anything.
+
+import (
+	"fmt"
+
+	"github.com/nself-org/cli/internal/database"
+
+	"github.com/spf13/cobra"
+)
+
+var dbMigrateLintCmd = &cobra.Command{
+	Use:   "lint [file...]",
+	Short: "Refuse migrations with many unguarded CREATE TABLE statements",
+	Long: `Statically scans migration SQL for a single file issuing many bare
+CREATE TABLE statements with no IF NOT EXISTS guard anywhere in the file.
+
+Such a file applies fine against an empty database but fails hard (and can
+leave a mixed apply/fail state) against a database where some of the tables
+already exist — the exact shape that blocked staging alignment in cli#386.
+
+With no arguments, lints every migration in the auto-detected (or
+--migration-dir) migrations directory. Pass one or more file paths to lint
+specific files instead.
+
+Exits non-zero (refuses) if any file trips the lint.`,
+	RunE: runDBMigrateLint,
+}
+
+func init() {
+	dbMigrateLintCmd.Flags().String("migration-dir", "", "Lint migrations in this directory instead of the auto-detected one")
+	dbMigrateCmd.AddCommand(dbMigrateLintCmd)
+}
+
+func runDBMigrateLint(cmd *cobra.Command, args []string) error {
+	files := args
+	if len(files) == 0 {
+		cfg, err := loadProjectConfig()
+		if err != nil {
+			return err
+		}
+		migrationDir, _ := cmd.Flags().GetString("migration-dir")
+		files, err = database.ListMigrationFiles(cfg, migrationDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	failed := 0
+	for _, f := range files {
+		finding, err := database.LintMigrationFile(f)
+		if err != nil {
+			return err
+		}
+		if finding == nil {
+			fmt.Printf("OK    %s\n", f)
+			continue
+		}
+		failed++
+		fmt.Printf("FAIL  %s: %s\n", f, finding.Message)
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("db migrate lint: refused %d migration file(s) — see messages above", failed)
+	}
+	fmt.Println("All migrations passed lint.")
+	return nil
+}

--- a/cmd/commands/db_migrate_lint_test.go
+++ b/cmd/commands/db_migrate_lint_test.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRunDBMigrateLint_RefusesUnguardedBulk(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "tasks_schema.sql")
+	sql := "CREATE TABLE a (id int);\nCREATE TABLE b (id int);\nCREATE TABLE c (id int);\n"
+	if err := os.WriteFile(path, []byte(sql), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	if err := runDBMigrateLint(cmd, []string{path}); err == nil {
+		t.Fatal("expected lint to refuse (return an error) for the bulk-unguarded fixture")
+	}
+}
+
+func TestRunDBMigrateLint_PassesGuarded(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "guarded.sql")
+	if err := os.WriteFile(path, []byte("CREATE TABLE IF NOT EXISTS a (id int);\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	if err := runDBMigrateLint(cmd, []string{path}); err != nil {
+		t.Fatalf("expected lint to pass, got error: %v", err)
+	}
+}

--- a/internal/database/migrate_baseline.go
+++ b/internal/database/migrate_baseline.go
@@ -1,0 +1,164 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// Purpose: the "adopt an already-populated database into the migration
+// ledger" verb (cli#386) — planning what a baseline would record, and the
+// actual ledger write that never executes the migration's own SQL.
+// Inputs: a *config.Config, a migrations directory (or "" to auto-detect),
+// and the migration name(s)/file path requested.
+// Outputs: BaselinePlan (planning) or a ledger write's error (execution).
+// Constraints: BaselineMigration never runs migration SQL — only the two
+// ledger INSERTs migrationRecordSQL already builds for the real apply path.
+// Planning must not write anything, including creating schema_versions, so a
+// missing ledger table is treated as "nothing applied yet", not an error.
+
+// BaselinePlan describes what baselining one migration would record.
+type BaselinePlan struct {
+	Name           string // ledger key (migrationKey)
+	MigrationID    string // nself_ops.migrations id (extractMigrationID)
+	Checksum       string // SHA-256 hex of the on-disk file
+	FilePath       string
+	AlreadyApplied bool
+}
+
+// resolveBaselineFiles is pure: matches each requested name to its on-disk
+// migration file. Errors on the first name with no match — baseline must
+// never record a ledger row for a migration that isn't a real file, since
+// recovering from that would need direct SQL, which the nSelf-First doctrine
+// forbids.
+func resolveBaselineFiles(files []string, names []string) ([]string, error) {
+	byKey := make(map[string]string, len(files))
+	for _, f := range files {
+		byKey[migrationKey(f)] = f
+	}
+	resolved := make([]string, 0, len(names))
+	for _, n := range names {
+		f, ok := byKey[n]
+		if !ok {
+			return nil, fmt.Errorf("migration %q not found on disk", n)
+		}
+		resolved = append(resolved, f)
+	}
+	return resolved, nil
+}
+
+// buildBaselinePlans is pure aside from reading the already-resolved files:
+// no database access, so --dry-run's plan and the real path's plan can never
+// disagree about what would be recorded.
+func buildBaselinePlans(resolved []string, applied map[string]time.Time) ([]BaselinePlan, error) {
+	plans := make([]BaselinePlan, 0, len(resolved))
+	for _, f := range resolved {
+		name := migrationKey(f)
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return nil, fmt.Errorf("read migration %s: %w", name, err)
+		}
+		checksum, err := checksumBytes(data)
+		if err != nil {
+			return nil, fmt.Errorf("checksum migration %s: %w", name, err)
+		}
+		_, isApplied := applied[name]
+		plans = append(plans, BaselinePlan{
+			Name:           name,
+			MigrationID:    extractMigrationID(f),
+			Checksum:       checksum,
+			FilePath:       f,
+			AlreadyApplied: isApplied,
+		})
+	}
+	return plans, nil
+}
+
+// PlanBaseline resolves each requested migration name against dir (or the
+// auto-detected migrations directory) and computes what baselining it would
+// record, without writing anything. If the schema_versions ledger does not
+// exist yet, every migration is reported as not-yet-applied rather than
+// erroring — this keeps --dry-run usable before any migration has ever run.
+func PlanBaseline(ctx context.Context, cfg *config.Config, dir string, names []string) ([]BaselinePlan, error) {
+	if dir == "" {
+		dir = migrationsDir(cfg, "")
+	}
+	files, err := scanMigrations(dir)
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := resolveBaselineFiles(files, names)
+	if err != nil {
+		return nil, err
+	}
+
+	applied, err := appliedMigrations(ctx, cfg)
+	if err != nil {
+		applied = map[string]time.Time{}
+	}
+	return buildBaselinePlans(resolved, applied)
+}
+
+// baselineTxSQL builds the ledger-only transaction BaselineMigration sends.
+// Factored out so a test can assert it contains only the two ledger INSERTs
+// and never the migration file's own SQL — that is what "record without
+// executing" means concretely, and it is structurally guaranteed here: the
+// migration's SQL body is never even a parameter to this function.
+func baselineTxSQL(migrationID, name, checksum string) string {
+	legacyRecord, opsRecord := migrationRecordSQL(migrationID, name, checksum)
+	return "BEGIN;\n" + legacyRecord + "\n" + opsRecord + "\nCOMMIT;\n"
+}
+
+// BaselineMigration records a single on-disk migration as applied WITHOUT
+// executing its SQL: it creates schema_versions/nself_ops.migrations if
+// absent, then writes the same two ledger INSERTs 'db migrate up' writes
+// after successfully running a migration — skipping straight to the record
+// step. Errors if the migration is already recorded (callers filter those
+// out via BaselinePlan.AlreadyApplied first; this is a defensive re-check).
+func BaselineMigration(ctx context.Context, cfg *config.Config, filePath string) error {
+	if err := ensureSchemaVersions(ctx, cfg); err != nil {
+		return fmt.Errorf("ensure schema_versions: %w", err)
+	}
+	if err := ensureMigrationsTable(ctx, cfg); err != nil {
+		return fmt.Errorf("ensure migrations table: %w", err)
+	}
+
+	name := migrationKey(filePath)
+	if err := validateMigrationName(name); err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("read migration %s: %w", name, err)
+	}
+	checksum, err := checksumBytes(data)
+	if err != nil {
+		return fmt.Errorf("checksum migration %s: %w", name, err)
+	}
+	if !sha256HexRegex.MatchString(checksum) {
+		return fmt.Errorf("unexpected checksum format for %s", name)
+	}
+
+	applied, err := appliedMigrations(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("check applied migrations: %w", err)
+	}
+	if _, ok := applied[name]; ok {
+		return fmt.Errorf("migration %s is already recorded as applied", name)
+	}
+
+	migrationID := extractMigrationID(filePath)
+	if err := validateMigrationName(migrationID); err != nil {
+		return fmt.Errorf("migration id from %s: %w", name, err)
+	}
+
+	txSQL := baselineTxSQL(migrationID, name, checksum)
+	if err := pipeSQLToContainer(ctx, cfg, txSQL); err != nil {
+		return fmt.Errorf("baseline %s: %w", name, err)
+	}
+	return nil
+}

--- a/internal/database/migrate_baseline_test.go
+++ b/internal/database/migrate_baseline_test.go
@@ -1,0 +1,84 @@
+package database
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveBaselineFiles(t *testing.T) {
+	files := []string{
+		filepath.Join("migrations", "20260101_a.sql"),
+		filepath.Join("migrations", "20260102_b.sql"),
+	}
+
+	resolved, err := resolveBaselineFiles(files, []string{"20260102_b.sql"})
+	if err != nil {
+		t.Fatalf("resolveBaselineFiles: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0] != files[1] {
+		t.Fatalf("resolved = %v, want [%s]", resolved, files[1])
+	}
+}
+
+func TestResolveBaselineFiles_UnmatchedNameErrors(t *testing.T) {
+	files := []string{filepath.Join("migrations", "20260101_a.sql")}
+	if _, err := resolveBaselineFiles(files, []string{"does_not_exist.sql"}); err == nil {
+		t.Fatal("expected an error for an unmatched migration name")
+	}
+}
+
+func TestBuildBaselinePlans(t *testing.T) {
+	tmp := t.TempDir()
+	withCwd(t, tmp)
+	writeFile(t, tmp, "migrations/20260101_a.sql", "CREATE TABLE a (id int);\n")
+	writeFile(t, tmp, "migrations/20260102_b.sql", "CREATE TABLE b (id int);\n")
+
+	files := []string{
+		filepath.Join(tmp, "migrations", "20260101_a.sql"),
+		filepath.Join(tmp, "migrations", "20260102_b.sql"),
+	}
+
+	applied := map[string]time.Time{"20260101_a.sql": time.Now()}
+	plans, err := buildBaselinePlans(files, applied)
+	if err != nil {
+		t.Fatalf("buildBaselinePlans: %v", err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("len(plans) = %d, want 2", len(plans))
+	}
+	if !plans[0].AlreadyApplied {
+		t.Error("plans[0] (20260101_a.sql) should be AlreadyApplied")
+	}
+	if plans[1].AlreadyApplied {
+		t.Error("plans[1] (20260102_b.sql) should NOT be AlreadyApplied")
+	}
+	if plans[1].Checksum == "" {
+		t.Error("expected a non-empty checksum")
+	}
+	if plans[1].MigrationID != "20260102_b" {
+		t.Errorf("MigrationID = %q, want 20260102_b", plans[1].MigrationID)
+	}
+}
+
+// TestBaselineTxSQL_NeverExecutesMigrationBody pins down what "record without
+// executing" means concretely: the transaction BaselineMigration sends
+// contains only the two ledger INSERTs and can never contain the migration
+// file's own DDL, because that DDL is never passed to baselineTxSQL at all.
+func TestBaselineTxSQL_NeverExecutesMigrationBody(t *testing.T) {
+	txSQL := baselineTxSQL("20260102_b", "20260102_b.sql", "deadbeef")
+
+	if !strings.Contains(txSQL, "INSERT INTO np_common.schema_versions") {
+		t.Error("expected the legacy ledger INSERT")
+	}
+	if !strings.Contains(txSQL, "INSERT INTO nself_ops.migrations") {
+		t.Error("expected the ops ledger INSERT")
+	}
+	if strings.Contains(strings.ToUpper(txSQL), "CREATE TABLE") {
+		t.Error("a baseline transaction must never contain migration DDL")
+	}
+	if !strings.HasPrefix(txSQL, "BEGIN;\n") || !strings.HasSuffix(txSQL, "COMMIT;\n") {
+		t.Errorf("expected a single wrapping transaction, got %q", txSQL)
+	}
+}

--- a/internal/database/migrate_detect.go
+++ b/internal/database/migrate_detect.go
@@ -1,0 +1,108 @@
+package database
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Purpose: parse migration SQL for the schema objects it creates, and
+// classify a migration against a live-catalog presence map. Pure text/data
+// functions only — see migrate_detect_query.go for the live pg_catalog query
+// that supplies the presence map DetectMigrations uses.
+// Inputs: raw SQL text (extraction) or an ObjectRef list + presence map
+// (classification).
+// Outputs: []ObjectRef, or (DetectClass, present, missing).
+// Constraints: extraction is best-effort regex, not a SQL parser — it is
+// intentionally conservative (may under-detect quoted/computed identifiers)
+// but must never fabricate an object that isn't in the text. Classification
+// is honest by construction: BASELINE requires every object present, APPLY
+// requires none present; anything else is CONFLICT, never silently resolved.
+
+// ObjectKind identifies the kind of schema object a CREATE statement makes.
+type ObjectKind string
+
+const (
+	ObjectTable      ObjectKind = "table"
+	ObjectIndex      ObjectKind = "index"
+	ObjectType       ObjectKind = "type"
+	ObjectView       ObjectKind = "view"
+	ObjectMatView    ObjectKind = "materialized view"
+	ObjectSequence   ObjectKind = "sequence"
+	ObjectSchemaKind ObjectKind = "schema"
+)
+
+// ObjectRef is one schema object a migration file creates.
+type ObjectRef struct {
+	Kind ObjectKind
+	Name string // as written in the SQL; may be schema-qualified
+}
+
+// Key returns the unique map key used to dedupe/look up presence for o.
+func (o ObjectRef) Key() string {
+	return string(o.Kind) + ":" + strings.ToLower(o.Name)
+}
+
+var (
+	createTableRe   = regexp.MustCompile(`(?i)\bCREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)`)
+	createIndexRe   = regexp.MustCompile(`(?i)\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w]*)`)
+	createTypeRe    = regexp.MustCompile(`(?i)\bCREATE\s+TYPE\s+([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)`)
+	createMatViewRe = regexp.MustCompile(`(?i)\bCREATE\s+MATERIALIZED\s+VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)`)
+	createViewRe    = regexp.MustCompile(`(?i)\bCREATE\s+(?:OR\s+REPLACE\s+)?VIEW\s+([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)`)
+	createSeqRe     = regexp.MustCompile(`(?i)\bCREATE\s+SEQUENCE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)`)
+	createSchemaRe  = regexp.MustCompile(`(?i)\bCREATE\s+SCHEMA\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w]*)`)
+)
+
+// ExtractCreatedObjects returns every schema object sqlContent creates.
+func ExtractCreatedObjects(sqlContent string) []ObjectRef {
+	var out []ObjectRef
+	collect := func(kind ObjectKind, re *regexp.Regexp) {
+		for _, m := range re.FindAllStringSubmatch(sqlContent, -1) {
+			out = append(out, ObjectRef{Kind: kind, Name: m[1]})
+		}
+	}
+	collect(ObjectTable, createTableRe)
+	collect(ObjectIndex, createIndexRe)
+	collect(ObjectType, createTypeRe)
+	collect(ObjectMatView, createMatViewRe)
+	collect(ObjectView, createViewRe)
+	collect(ObjectSequence, createSeqRe)
+	collect(ObjectSchemaKind, createSchemaRe)
+	return out
+}
+
+// DetectClass is the honest three-way (plus unknown) classification of a
+// pending migration against the live schema.
+type DetectClass string
+
+const (
+	DetectApply    DetectClass = "APPLY"
+	DetectBaseline DetectClass = "BASELINE"
+	DetectConflict DetectClass = "CONFLICT"
+	DetectUnknown  DetectClass = "UNKNOWN"
+)
+
+// ClassifyByPresence classifies a migration by how many of the objects it
+// creates already exist (existing, keyed by ObjectRef.Key()). BASELINE is
+// only reachable when every object is present and APPLY only when none
+// are — any partial match is CONFLICT, which callers must never
+// auto-resolve. UNKNOWN means extraction found no objects to check (e.g. a
+// data-only migration) — callers should fall back to ledger-only status.
+func ClassifyByPresence(objects []ObjectRef, existing map[string]bool) (class DetectClass, present, missing []ObjectRef) {
+	if len(objects) == 0 {
+		return DetectUnknown, nil, nil
+	}
+	for _, o := range objects {
+		if existing[o.Key()] {
+			present = append(present, o)
+		} else {
+			missing = append(missing, o)
+		}
+	}
+	if len(missing) == 0 {
+		return DetectBaseline, present, missing
+	}
+	if len(present) == 0 {
+		return DetectApply, present, missing
+	}
+	return DetectConflict, present, missing
+}

--- a/internal/database/migrate_detect_query.go
+++ b/internal/database/migrate_detect_query.go
@@ -1,0 +1,155 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// Purpose: the live-catalog half of --detect — querying pg_catalog /
+// information_schema for whether each object a pending migration creates
+// already exists, and assembling the per-migration DetectResult the `db
+// migrate status --detect` command prints.
+// Inputs: a *config.Config and a migrations directory (or "" to auto-detect).
+// Outputs: []DetectResult, one per pending (not-yet-in-ledger) migration.
+// Constraints: read-only. Never writes to the ledger or the schema; acting on
+// a BASELINE-classified result is always a separate, explicit command
+// (nself db migrate baseline), never an automatic side effect of detection.
+
+// DetectResult is one pending migration's classification against the live
+// schema, plus its bulk-unguarded-CREATE-TABLE lint finding (nil if clean).
+type DetectResult struct {
+	Name    string
+	Class   DetectClass
+	Present []ObjectRef
+	Missing []ObjectRef
+	Lint    *LintFinding
+}
+
+// existsExprFor returns the SQL boolean expression that tests whether o
+// already exists in the live catalog.
+func existsExprFor(o ObjectRef) string {
+	switch o.Kind {
+	case ObjectSchemaKind:
+		return fmt.Sprintf("EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = %s)", sqlLiteral(o.Name))
+	case ObjectType:
+		return fmt.Sprintf("to_regtype(%s) IS NOT NULL", sqlLiteral(o.Name))
+	default:
+		// Tables, views, materialized views, sequences, and indexes are all
+		// relations — to_regclass resolves any of them via search_path.
+		return fmt.Sprintf("to_regclass(%s) IS NOT NULL", sqlLiteral(o.Name))
+	}
+}
+
+// sqlLiteral quotes s as a SQL string literal, doubling embedded quotes.
+func sqlLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// queryExistingObjects checks every distinct object in objects against the
+// live catalog in a single round trip. Returns a map keyed by ObjectRef.Key().
+func queryExistingObjects(ctx context.Context, cfg *config.Config, objects []ObjectRef) (map[string]bool, error) {
+	result := make(map[string]bool, len(objects))
+	if len(objects) == 0 {
+		return result, nil
+	}
+
+	seen := make(map[string]bool, len(objects))
+	var selects []string
+	for _, o := range objects {
+		key := o.Key()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		selects = append(selects, fmt.Sprintf("SELECT %s || '|' || (%s)::text", sqlLiteral(key), existsExprFor(o)))
+	}
+
+	db := cfg.Postgres.DB
+	if db == "" {
+		db = "nself"
+	}
+	out, err := querySQL(ctx, cfg, db, strings.Join(selects, "\nUNION ALL\n"))
+	if err != nil {
+		return nil, fmt.Errorf("query existing objects: %w", err)
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		result[parts[0]] = parts[1] == "t" || parts[1] == "true"
+	}
+	return result, nil
+}
+
+// DetectMigrations classifies every pending (not-yet-in-ledger) migration in
+// dir (or the auto-detected directory when dir is "") against the live
+// schema.
+func DetectMigrations(ctx context.Context, cfg *config.Config, dir string) ([]DetectResult, error) {
+	if dir == "" {
+		dir = migrationsDir(cfg, "")
+	}
+	files, err := scanMigrations(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	applied, err := appliedMigrations(ctx, cfg)
+	if err != nil {
+		// Ledger table likely doesn't exist yet — detection is read-only, so
+		// treat this as "nothing applied" rather than creating it.
+		applied = map[string]time.Time{}
+	}
+
+	type candidate struct {
+		name    string
+		objects []ObjectRef
+		content string
+	}
+	var pending []candidate
+	var allObjects []ObjectRef
+	for _, f := range files {
+		name := migrationKey(f)
+		if _, ok := applied[name]; ok {
+			continue
+		}
+		data, readErr := os.ReadFile(f)
+		if readErr != nil {
+			return nil, fmt.Errorf("read migration %s: %w", name, readErr)
+		}
+		content := string(data)
+		objs := ExtractCreatedObjects(content)
+		pending = append(pending, candidate{name: name, objects: objs, content: content})
+		allObjects = append(allObjects, objs...)
+	}
+
+	existing, err := queryExistingObjects(ctx, cfg, allObjects)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]DetectResult, 0, len(pending))
+	for _, c := range pending {
+		class, present, missing := ClassifyByPresence(c.objects, existing)
+		results = append(results, DetectResult{
+			Name:    c.name,
+			Class:   class,
+			Present: present,
+			Missing: missing,
+			Lint:    LintUnguardedBulkCreateTables(c.content),
+		})
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].Name < results[j].Name })
+	return results, nil
+}

--- a/internal/database/migrate_detect_test.go
+++ b/internal/database/migrate_detect_test.go
@@ -1,0 +1,118 @@
+package database
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractCreatedObjects(t *testing.T) {
+	sql := `
+CREATE SCHEMA IF NOT EXISTS app;
+CREATE TABLE app.tasks (id uuid PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS app.projects (id uuid PRIMARY KEY);
+CREATE INDEX idx_tasks_project ON app.tasks (project_id);
+CREATE TYPE app.task_status AS ENUM ('open', 'done');
+CREATE MATERIALIZED VIEW app.task_counts AS SELECT 1;
+CREATE VIEW app.active_tasks AS SELECT 1;
+CREATE SEQUENCE app.task_seq;
+`
+	objs := ExtractCreatedObjects(sql)
+
+	want := map[ObjectKind]int{
+		ObjectTable:      2,
+		ObjectIndex:      1,
+		ObjectType:       1,
+		ObjectMatView:    1,
+		ObjectView:       1,
+		ObjectSequence:   1,
+		ObjectSchemaKind: 1,
+	}
+	got := map[ObjectKind]int{}
+	for _, o := range objs {
+		got[o.Kind]++
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("object kind counts = %+v, want %+v", got, want)
+	}
+}
+
+func TestExtractCreatedObjects_NoFalsePositiveOnMaterializedView(t *testing.T) {
+	objs := ExtractCreatedObjects("CREATE MATERIALIZED VIEW app.counts AS SELECT 1;")
+	views, matViews := 0, 0
+	for _, o := range objs {
+		switch o.Kind {
+		case ObjectView:
+			views++
+		case ObjectMatView:
+			matViews++
+		}
+	}
+	if matViews != 1 || views != 0 {
+		t.Fatalf("matViews=%d views=%d, want matViews=1 views=0 (no double count)", matViews, views)
+	}
+}
+
+func TestClassifyByPresence(t *testing.T) {
+	tbl := ObjectRef{Kind: ObjectTable, Name: "app.tasks"}
+	idx := ObjectRef{Kind: ObjectIndex, Name: "idx_tasks"}
+
+	tests := []struct {
+		name     string
+		objects  []ObjectRef
+		existing map[string]bool
+		want     DetectClass
+	}{
+		{"no objects is unknown", nil, map[string]bool{}, DetectUnknown},
+		{"none present is apply", []ObjectRef{tbl, idx}, map[string]bool{}, DetectApply},
+		{"all present is baseline", []ObjectRef{tbl, idx}, map[string]bool{tbl.Key(): true, idx.Key(): true}, DetectBaseline},
+		{"partial is conflict", []ObjectRef{tbl, idx}, map[string]bool{tbl.Key(): true}, DetectConflict},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, present, missing := ClassifyByPresence(tt.objects, tt.existing)
+			if class != tt.want {
+				t.Fatalf("class = %s, want %s", class, tt.want)
+			}
+			if len(present)+len(missing) != len(tt.objects) {
+				t.Fatalf("present(%d)+missing(%d) != objects(%d)", len(present), len(missing), len(tt.objects))
+			}
+		})
+	}
+}
+
+func TestClassifyByPresence_NeverAutoResolvesConflict(t *testing.T) {
+	objects := []ObjectRef{
+		{Kind: ObjectTable, Name: "a"},
+		{Kind: ObjectTable, Name: "b"},
+	}
+	existing := map[string]bool{objects[0].Key(): true} // only "a" exists
+	class, present, missing := ClassifyByPresence(objects, existing)
+	if class != DetectConflict {
+		t.Fatalf("class = %s, want CONFLICT", class)
+	}
+	if len(present) != 1 || len(missing) != 1 {
+		t.Fatalf("present=%d missing=%d, want 1 and 1", len(present), len(missing))
+	}
+}
+
+func TestExistsExprFor(t *testing.T) {
+	cases := []struct {
+		o    ObjectRef
+		want string
+	}{
+		{ObjectRef{Kind: ObjectSchemaKind, Name: "app"}, "EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'app')"},
+		{ObjectRef{Kind: ObjectType, Name: "app.status"}, "to_regtype('app.status') IS NOT NULL"},
+		{ObjectRef{Kind: ObjectTable, Name: "app.tasks"}, "to_regclass('app.tasks') IS NOT NULL"},
+	}
+	for _, c := range cases {
+		if got := existsExprFor(c.o); got != c.want {
+			t.Errorf("existsExprFor(%+v) = %q, want %q", c.o, got, c.want)
+		}
+	}
+}
+
+func TestSQLLiteral_EscapesQuotes(t *testing.T) {
+	if got, want := sqlLiteral("o'brien"), "'o''brien'"; got != want {
+		t.Errorf("sqlLiteral = %q, want %q", got, want)
+	}
+}

--- a/internal/database/migrate_lint.go
+++ b/internal/database/migrate_lint.go
@@ -1,0 +1,97 @@
+package database
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/nself-org/cli/internal/config"
+)
+
+// Purpose: detect the tasks_schema-style authoring mistake — a single
+// migration file issuing many bare CREATE TABLE statements with no
+// IF NOT EXISTS guard anywhere in the file. cli#386 traced staging's
+// migration backlog to exactly this shape: fine against an empty database,
+// but a hard failure (and a possible mixed apply/fail state) against one
+// where some of the tables already exist.
+// Inputs: raw migration SQL text, or a file/directory path.
+// Outputs: nil when clean; a LintFinding describing the violation otherwise.
+// Constraints: static, text-only — never touches a live database, so the
+// same check runs inside `db migrate lint` and inside --detect.
+
+// bulkUnguardedCreateTableThreshold is "many": one or two ungated CREATE
+// TABLE statements in an otherwise-guarded file is a plausible oversight;
+// three or more in a single file is the bulk-dump pattern this lint exists
+// to catch and refuse.
+const bulkUnguardedCreateTableThreshold = 3
+
+// createTableAnyRe matches every CREATE TABLE occurrence, guarded or not.
+// Go's RE2 regexp engine has no negative lookahead, so "not followed by IF
+// NOT EXISTS" is checked separately (see countUnguardedCreateTables) against
+// the text immediately after each match instead of being expressed in one
+// pattern.
+var createTableAnyRe = regexp.MustCompile(`(?i)\bCREATE\s+TABLE\s+`)
+
+// ifNotExistsAtStartRe matches "IF NOT EXISTS" anchored at the start of the
+// string it's tested against — used to check the text right after a
+// CREATE TABLE match.
+var ifNotExistsAtStartRe = regexp.MustCompile(`(?i)^IF\s+NOT\s+EXISTS\b`)
+
+// countUnguardedCreateTables returns how many CREATE TABLE statements in
+// sqlContent are NOT immediately followed by IF NOT EXISTS.
+func countUnguardedCreateTables(sqlContent string) int {
+	count := 0
+	for _, loc := range createTableAnyRe.FindAllStringIndex(sqlContent, -1) {
+		if !ifNotExistsAtStartRe.MatchString(sqlContent[loc[1]:]) {
+			count++
+		}
+	}
+	return count
+}
+
+// LintFinding describes one migration-file lint violation.
+type LintFinding struct {
+	Rule    string
+	Message string
+	Count   int
+}
+
+// LintUnguardedBulkCreateTables returns nil when sqlContent has fewer than
+// bulkUnguardedCreateTableThreshold unguarded CREATE TABLE statements.
+// Callers (the `db migrate lint` command, --detect) treat a non-nil finding
+// as a refusal, never a warning to silently route around.
+func LintUnguardedBulkCreateTables(sqlContent string) *LintFinding {
+	count := countUnguardedCreateTables(sqlContent)
+	if count < bulkUnguardedCreateTableThreshold {
+		return nil
+	}
+	return &LintFinding{
+		Rule: "bulk-unguarded-create-table",
+		Message: fmt.Sprintf(
+			"%d CREATE TABLE statement(s) without IF NOT EXISTS in one migration — "+
+				"fails hard on a database where any of them already exists. "+
+				"Add IF NOT EXISTS to each, or split into per-object migrations.",
+			count),
+		Count: count,
+	}
+}
+
+// LintMigrationFile reads a single migration file and lints it.
+func LintMigrationFile(path string) (*LintFinding, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return LintUnguardedBulkCreateTables(string(data)), nil
+}
+
+// ListMigrationFiles returns the sorted on-disk migration files for dir (or
+// the auto-detected directory when dir is ""). Exported so commands that
+// need the raw file list (lint) don't have to reach into the DB-backed
+// status/apply paths.
+func ListMigrationFiles(cfg *config.Config, dir string) ([]string, error) {
+	if dir == "" {
+		dir = migrationsDir(cfg, "")
+	}
+	return scanMigrations(dir)
+}

--- a/internal/database/migrate_lint_test.go
+++ b/internal/database/migrate_lint_test.go
@@ -1,0 +1,90 @@
+package database
+
+import "testing"
+
+func TestLintUnguardedBulkCreateTables_FiresOnBulkUnguarded(t *testing.T) {
+	sql := `
+CREATE TABLE tasks (id uuid PRIMARY KEY);
+CREATE TABLE projects (id uuid PRIMARY KEY);
+CREATE TABLE labels (id uuid PRIMARY KEY);
+`
+	finding := LintUnguardedBulkCreateTables(sql)
+	if finding == nil {
+		t.Fatal("expected a finding for 3 unguarded CREATE TABLE statements")
+	}
+	if finding.Count != 3 {
+		t.Errorf("Count = %d, want 3", finding.Count)
+	}
+	if finding.Rule != "bulk-unguarded-create-table" {
+		t.Errorf("Rule = %q", finding.Rule)
+	}
+}
+
+func TestLintUnguardedBulkCreateTables_OKWhenGuarded(t *testing.T) {
+	sql := `
+CREATE TABLE IF NOT EXISTS tasks (id uuid PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS projects (id uuid PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS labels (id uuid PRIMARY KEY);
+`
+	if finding := LintUnguardedBulkCreateTables(sql); finding != nil {
+		t.Fatalf("expected no finding for guarded statements, got %+v", finding)
+	}
+}
+
+func TestLintUnguardedBulkCreateTables_BelowThreshold(t *testing.T) {
+	sql := `
+CREATE TABLE tasks (id uuid PRIMARY KEY);
+CREATE TABLE projects (id uuid PRIMARY KEY);
+`
+	if finding := LintUnguardedBulkCreateTables(sql); finding != nil {
+		t.Fatalf("expected no finding below threshold, got %+v", finding)
+	}
+}
+
+func TestLintUnguardedBulkCreateTables_MixedGuardedStillCounted(t *testing.T) {
+	sql := `
+CREATE TABLE IF NOT EXISTS tasks (id uuid PRIMARY KEY);
+CREATE TABLE projects (id uuid PRIMARY KEY);
+CREATE TABLE labels (id uuid PRIMARY KEY);
+CREATE TABLE comments (id uuid PRIMARY KEY);
+`
+	finding := LintUnguardedBulkCreateTables(sql)
+	if finding == nil {
+		t.Fatal("expected a finding: 3 unguarded creates even with one guarded present")
+	}
+	if finding.Count != 3 {
+		t.Errorf("Count = %d, want 3 (the guarded statement must not be counted)", finding.Count)
+	}
+}
+
+func TestLintMigrationFile(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, tmp, "tasks_schema.sql", `
+CREATE TABLE tasks (id uuid PRIMARY KEY);
+CREATE TABLE projects (id uuid PRIMARY KEY);
+CREATE TABLE labels (id uuid PRIMARY KEY);
+`)
+
+	finding, err := LintMigrationFile(tmp + "/tasks_schema.sql")
+	if err != nil {
+		t.Fatalf("LintMigrationFile: %v", err)
+	}
+	if finding == nil {
+		t.Fatal("expected a finding for the tasks_schema-style fixture")
+	}
+}
+
+func TestListMigrationFiles(t *testing.T) {
+	tmp := t.TempDir()
+	withCwd(t, tmp)
+	writeFile(t, tmp, "migrations/20260101_a.sql", "CREATE TABLE a (id int);\n")
+	writeFile(t, tmp, "migrations/20260102_b.sql", "CREATE TABLE b (id int);\n")
+
+	files, err := ListMigrationFiles(nil, "migrations")
+	if err != nil {
+		t.Fatalf("ListMigrationFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("len(files) = %d, want 2", len(files))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #386.

On staging, `db migrate status` reported 21 migrations pending and 0 applied against a database that was fully populated by dumps/console/hand SQL. There was no way to adopt the CLI's migration ledger: `apply --file` runs the migration's SQL (which fails on objects that already exist), and hand-editing `schema_versions` is forbidden by the nSelf-First doctrine.

This adds the missing verbs:

- **`nself db migrate baseline <name> [name...]`** — records one or more migrations as applied in `schema_versions` / `nself_ops.migrations` **without running their SQL**. Destructive-adjacent by design: always prints exactly what would be recorded, refuses without `--yes` (or an interactive `"yes"`), and `--dry-run` never writes anything (structurally — the write call is never reached in that branch, not just skipped by convention). Baseline never runs as a side effect of any other command.
- **`nself db migrate status --detect`** — classifies each pending migration against the live schema (via `pg_catalog`/`information_schema`: `to_regclass`, `to_regtype`, `pg_namespace`) as `BASELINE` (every object it creates already exists), `APPLY` (none exist), or `CONFLICT` (some exist, some don't). A `CONFLICT` is always printed and never auto-resolved. For `BASELINE` candidates it prints the exact `db migrate baseline ... --yes` command to run — it never runs it.
- **`nself db migrate lint [file...]`** — refuses (non-zero exit) a migration file with 3+ bare `CREATE TABLE` statements and no `IF NOT EXISTS` guard anywhere in the file — the `tasks_schema`-style bulk-dump pattern from the issue, which applies fine against an empty database but fails hard against one where some tables already exist.

## Design notes

- `schema_versions` is created if absent; the unrelated app-level `schema_migrations` table is never touched.
- Object extraction from migration SQL is a best-effort regex scan (tables, indexes, types, views, materialized views, sequences, schemas) — conservative by design, documented as such.
- Go's `regexp` (RE2) has no lookahead, so the lint counts unguarded `CREATE TABLE` by matching every occurrence and checking the text immediately after each match for `IF NOT EXISTS`, rather than a single lookahead pattern.
- No SSH/remote DB access added; `--detect`/`baseline`/`lint` all operate on the local project's database only (or files directly, for `lint`).

## Test plan

- [x] `go build -mod=vendor ./...`
- [x] `go vet -mod=vendor ./...`
- [x] `gofmt -l` clean on all new/changed files
- [x] `golangci-lint run` clean on `cmd/commands/...` and `internal/database/...`
- [x] `go test -mod=vendor -timeout 10m ./...` — full suite green, including `internal/repoqa` (command inventory / file-size ratchets unaffected)
- [x] New unit tests: baseline records without executing (`TestBaselineTxSQL_NeverExecutesMigrationBody`), baseline refuses without confirmation (`TestBaselineConfirmed_*`), `--dry-run` writes nothing (`TestRunBaselinePlans_DryRunWritesNothing`), `--detect` classifies BASELINE/APPLY/CONFLICT (`TestClassifyByPresence*`), the no-`IF NOT EXISTS` lint fires (`TestLintUnguardedBulkCreateTables_*`)
- [ ] Manual verification against a real populated database (owner-gated — no staging/production access in this change)