### PR TITLE
fix(license): grant grace period on bundle-entitled network errors

### DIFF
--- a/internal/license/checker.go
+++ b/internal/license/checker.go
@@ -32,12 +32,30 @@ type bundleValidateResponse struct {
 
 // BundleEntitled reports whether the operator's license key grants access to
 // the named bundle. It calls ping_api /license/validate?bundle=<bundleName>
-// with the key. Returns false on any error (network, auth, invalid key) so
-// the installer can surface a precise message rather than silently proceeding.
+// with the key.
+//
+// An AUTHORITATIVE server answer always wins: a 401/403 (key rejected) or a
+// 200 with valid:false (server says no) fails CLOSED, full stop — no grace
+// applies to those. Grace exists only for the case the server never answered
+// at all.
+//
+// On a NETWORK error (server unreachable), BundleEntitled no longer fails
+// closed outright. Per the two-panel licensing review (2026-09-06), punishing
+// a paying customer for our own outage is the wrong default, so it consults
+// the documented grace-period ladder (grace.go) against the local cache:
+//   - cache < GraceSoftThreshold (24h) old: proceed silently.
+//   - cache < GraceHardThreshold (7d) old: proceed, warn loudly.
+//   - cache >= GraceHardThreshold old, absent, key-mismatched, or the licence
+//     is on the revocation list: fail closed — a network outage buys at most
+//     7 days, never indefinite access, and revocation is never overridden by
+//     grace at any cache age.
 //
 // FAIL-OPEN exception: when NSELF_LICENSE_FAIL_OPEN=1 is set (CI / air-gap
-// environments) and the network is unreachable, falls back to the local cache
-// to check tier coverage. Production deployments MUST NOT set this var.
+// environments), the network-unreachable branch instead uses the unbounded
+// bundleEntitledFromCache path (tier/sentinel only, no time window) for
+// environments that are permanently offline by design. This is now one of
+// two grace paths, not the only one — production deployments that leave it
+// unset still get the bounded grace ladder above instead of a hard fail.
 func BundleEntitled(ctx context.Context, key, bundleName string) (bool, error) {
 	if key == "" {
 		return false, fmt.Errorf("no license key configured; run 'nself license set <key>' or visit nself.org/pricing")
@@ -56,11 +74,17 @@ func BundleEntitled(ctx context.Context, key, bundleName string) (bool, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		// Network unreachable — attempt FAIL-OPEN via cache if explicitly enabled.
+		// Network unreachable — this is NOT an authoritative rejection, so it
+		// gets a grace path rather than an immediate fail-closed.
+		//
+		// NSELF_LICENSE_FAIL_OPEN=1 keeps its pre-existing unbounded behaviour
+		// for deliberately offline CI/air-gap builds. Everyone else falls
+		// through to the bounded, revocation-aware grace ladder, which is the
+		// default grace path now (see BundleEntitled doc comment).
 		if os.Getenv("NSELF_LICENSE_FAIL_OPEN") == "1" {
 			return bundleEntitledFromCache(key, bundleName)
 		}
-		return false, fmt.Errorf("license validation network error (bundle=%q): %w", bundleName, err)
+		return bundleEntitledFromGrace(key, bundleName)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -120,24 +144,90 @@ func bundleEntitledFromCache(key, bundleName string) (bool, error) {
 		return false, fmt.Errorf("license has been revoked (bundle=%q); contact support if this is unexpected", bundleName)
 	}
 
-	tier := strings.ToLower(entry.Tier)
+	if !cacheCoversBundle(entry, bundleName) {
+		return false, fmt.Errorf("bundle %q not found in cached license (tier=%q); connect to validate", bundleName, strings.ToLower(entry.Tier))
+	}
+	return true, nil
+}
+
+// bundleEntitledFromGrace is the DEFAULT network-failure fallback — used
+// whenever NSELF_LICENSE_FAIL_OPEN is not set to "1". Unlike
+// bundleEntitledFromCache (unbounded in time, reserved for deliberately
+// offline CI/air-gap builds), this path is bounded by the documented
+// grace-period ladder in grace.go: a cache under GraceSoftThreshold old is
+// honoured silently, one under GraceHardThreshold old is honoured with a
+// warning, and anything staler — or with WriteAllowed=false, which for a
+// bundle *install* (a write against a paid plugin) means the same thing as a
+// denial — is refused.
+//
+// Revocation is checked before the grace window is even consulted: a
+// revoked licence gets no grace at any cache age. This reuses
+// IsRecordRevoked (internal/license/revocation_refresh_check.go), the same
+// revocation-aware check bundleEntitledFromCache already relies on, so both
+// grace paths share one revocation rule instead of two.
+func bundleEntitledFromGrace(key, bundleName string) (bool, error) {
+	entry, err := ReadCache()
+	if err != nil || entry == nil {
+		return false, fmt.Errorf("license server unreachable and no local license cache available (bundle=%q); connect to the internet or run 'nself license validate'", bundleName)
+	}
+	if entry.KeyHash != HashKey(key) {
+		return false, fmt.Errorf("license server unreachable and cached license does not match current key (bundle=%q)", bundleName)
+	}
+
+	// Revocation is never overridden by grace, regardless of cache freshness.
+	if IsRecordRevoked(LicenseRecord{KeyHash: entry.KeyHash}) {
+		return false, fmt.Errorf("license has been revoked (bundle=%q); contact support if this is unexpected", bundleName)
+	}
+
+	grace := DetermineGraceState(entry)
+	if !grace.CanProceed || !grace.WriteAllowed {
+		return false, fmt.Errorf(
+			"license server unreachable (bundle=%q) and the offline grace period has expired: %s",
+			bundleName, grace.Message,
+		)
+	}
+
+	if !cacheCoversBundle(entry, bundleName) {
+		return false, fmt.Errorf("license server unreachable; cached license does not cover bundle %q (tier=%q)", bundleName, strings.ToLower(entry.Tier))
+	}
+
+	emitGraceWarning(bundleName, grace)
+	return true, nil
+}
+
+// cacheCoversBundle reports whether a cache entry's tier or explicit
+// "bundle:<name>" sentinel covers the named bundle. Shared by the unbounded
+// fail-open cache check and the time-bounded grace fallback so the
+// entitlement rule has exactly one definition instead of two that can drift.
+func cacheCoversBundle(entry *CacheEntry, bundleName string) bool {
 	// ɳSelf+ / owner / enterprise cover all bundles. Delegated to IsAllAccessTier
 	// so this rule has one definition; the plugin installer needs the same one.
-	if IsAllAccessTier(tier) {
-		return true, nil
+	if IsAllAccessTier(strings.ToLower(entry.Tier)) {
+		return true
 	}
-
-	// Heuristic: check if every plugin in a typical bundle is in PluginsAllowed.
+	// Heuristic: "bundle:<name>" sentinel written by a previous live validation.
 	// This is approximate — the authoritative check is the live server call.
-	// If the cache says at least one bundle plugin is allowed, proceed with a warning.
 	for _, allowed := range entry.PluginsAllowed {
-		// "bundle:<name>" sentinel written by a previous live validation.
 		if strings.EqualFold(allowed, "bundle:"+bundleName) {
-			return true, nil
+			return true
 		}
 	}
+	return false
+}
 
-	return false, fmt.Errorf("bundle %q not found in cached license (tier=%q); connect to validate", bundleName, tier)
+// emitGraceWarning prints a one-line warning to stderr stating that the
+// license server was unreachable, that access is continuing on cached
+// entitlement, and when the offline grace period runs out. Every grant made
+// on the grace path must be announced — never silent.
+func emitGraceWarning(bundleName string, grace GraceCheckResult) {
+	remaining := GraceHardThreshold - grace.CacheAge
+	if remaining < 0 {
+		remaining = 0
+	}
+	fmt.Fprintf(os.Stderr,
+		"warning: license server unreachable; continuing bundle %q install on cached entitlement (last validated %s ago). Offline grace period expires in %s.\n",
+		bundleName, formatDuration(grace.CacheAge), formatDuration(remaining),
+	)
 }
 
 // CollectLicenseKey returns the first available license key from env vars or

--- a/internal/license/checker_test.go
+++ b/internal/license/checker_test.go
@@ -6,9 +6,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 // ---- helpers ----------------------------------------------------------------
@@ -435,5 +439,223 @@ func TestBundleEntitled_BundleParamInURL(t *testing.T) {
 	_, _ = BundleEntitled(context.Background(), "nself_pro_abcdefghijklmnopqrstuvwxyz123456", "ntv")
 	if gotBundle != "ntv" {
 		t.Errorf("expected bundle=ntv in URL, got %q", gotBundle)
+	}
+}
+
+// ---- bundleEntitledFromGrace (default network-failure grace path) ----------
+//
+// These cover the 2026-09-06 licensing-panel decision: a network error must
+// no longer fail closed outright. It consults the grace.go ladder instead,
+// bounded by GraceHardThreshold (7d) and never overridden by revocation.
+
+// graceCacheEntry builds a CacheEntry fetched fetchedAgoHours ago, expiring
+// far in the future, keyed by an actual license key (hashed) rather than a
+// raw hash so callers can pass it straight to bundleEntitledFromGrace.
+func graceCacheEntry(key, tier string, fetchedAgoHours float64) *CacheEntry {
+	now := time.Now()
+	return &CacheEntry{
+		KeyHash:   HashKey(key),
+		Tier:      tier,
+		FetchedAt: now.Add(-time.Duration(fetchedAgoHours * float64(time.Hour))).Unix(),
+		ExpiresAt: now.Add(9000 * time.Hour).Unix(),
+	}
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns what
+// was written to it. Not safe for tests using t.Parallel() — none in this
+// file do.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	_ = w.Close()
+	buf, _ := io.ReadAll(r)
+	return string(buf)
+}
+
+func TestBundleEntitledFromGrace_WithinWindow_GrantsAndWarns(t *testing.T) {
+	checkerCacheDir(t)
+	withTempCachePath(t)
+	const key = "nself_pro_abcdefghijklmnopqrstuvwxyz123456"
+	if err := WriteCache(graceCacheEntry(key, "plus", 2)); err != nil { // 2h old, well within 24h
+		t.Fatalf("seeding cache: %v", err)
+	}
+
+	var ok bool
+	var callErr error
+	out := captureStderr(t, func() {
+		ok, callErr = bundleEntitledFromGrace(key, "nclaw")
+	})
+	if callErr != nil {
+		t.Fatalf("unexpected error within grace window: %v", callErr)
+	}
+	if !ok {
+		t.Error("expected true within grace window, got false")
+	}
+	if !strings.Contains(out, "unreachable") || !strings.Contains(out, "grace period") {
+		t.Errorf("expected a grace warning naming the outage and the grace period on stderr, got: %q", out)
+	}
+}
+
+func TestBundleEntitledFromGrace_BeyondWindow_Denies(t *testing.T) {
+	checkerCacheDir(t)
+	withTempCachePath(t)
+	const key = "nself_pro_abcdefghijklmnopqrstuvwxyz123456"
+	// 8 days old: past GraceHardThreshold (7d) -> WriteAllowed=false -> deny.
+	if err := WriteCache(graceCacheEntry(key, "plus", 8*24)); err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+
+	ok, err := bundleEntitledFromGrace(key, "nclaw")
+	if ok {
+		t.Error("expected false beyond the grace window, got true")
+	}
+	if err == nil {
+		t.Error("expected an error beyond the grace window, got nil")
+	}
+}
+
+func TestBundleEntitledFromGrace_RevokedCache_Denies(t *testing.T) {
+	checkerCacheDir(t)
+	withTempCachePath(t)
+	const key = "nself_pro_abcdefghijklmnopqrstuvwxyz123456"
+	hash := HashKey(key)
+	// Fresh cache — well within the grace window on its own.
+	if err := WriteCache(graceCacheEntry(key, "plus", 1)); err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+	if err := WriteRevocationCache(&RevocationCache{
+		FetchedAt: time.Now().Unix(),
+		List: RevocationList{
+			Revoked: []RevocationEntry{{Type: "key_hash", ID: hash, Reason: "test"}},
+		},
+	}); err != nil {
+		t.Fatalf("seeding revocation cache: %v", err)
+	}
+
+	ok, err := bundleEntitledFromGrace(key, "nclaw")
+	if ok {
+		t.Error("expected false for a revoked licence even within the grace window, got true")
+	}
+	if err == nil || !strings.Contains(err.Error(), "revoked") {
+		t.Fatalf("expected a revocation refusal, got: %v", err)
+	}
+}
+
+func TestBundleEntitledFromGrace_NoCache_Denies(t *testing.T) {
+	checkerCacheDir(t)
+	withTempCachePath(t)
+	const key = "nself_pro_abcdefghijklmnopqrstuvwxyz123456"
+
+	ok, err := bundleEntitledFromGrace(key, "nclaw")
+	if ok {
+		t.Error("expected false with no cache at all, got true")
+	}
+	if err == nil {
+		t.Error("expected an error with no cache at all, got nil")
+	}
+}
+
+// TestBundleEntitled_NetworkErrorDefaultsToGrace verifies the wiring end to
+// end: WITHOUT NSELF_LICENSE_FAIL_OPEN set, a network error now grants
+// entitlement from a fresh cache instead of failing closed outright. This is
+// the behaviour change: previously this exact setup returned false+error.
+func TestBundleEntitled_NetworkErrorDefaultsToGrace(t *testing.T) {
+	checkerCacheDir(t)
+	withTempCachePath(t)
+	const key = "nself_pro_abcdefghijklmnopqrstuvwxyz123456"
+	if err := WriteCache(graceCacheEntry(key, "plus", 1)); err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+
+	refuseSrv := newRefusingServer(t)
+	t.Setenv("LICENSE_PING_URL", refuseSrv.URL)
+	t.Setenv("NSELF_LICENSE_FAIL_OPEN", "")
+
+	ok, err := BundleEntitled(context.Background(), key, "nclaw")
+	if err != nil {
+		t.Fatalf("expected grace to grant access on network error, got error: %v", err)
+	}
+	if !ok {
+		t.Error("expected true via default grace path on network error, got false")
+	}
+}
+
+// TestBundleEntitled_NetworkErrorDefaultsToGrace_BeyondWindowStillDenies
+// confirms the default path is bounded, not a second unconditional fail-open:
+// a stale-beyond-7d cache on an unreachable server still fails closed.
+func TestBundleEntitled_NetworkErrorDefaultsToGrace_BeyondWindowStillDenies(t *testing.T) {
+	checkerCacheDir(t)
+	withTempCachePath(t)
+	const key = "nself_pro_abcdefghijklmnopqrstuvwxyz123456"
+	if err := WriteCache(graceCacheEntry(key, "plus", 8*24)); err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+
+	refuseSrv := newRefusingServer(t)
+	t.Setenv("LICENSE_PING_URL", refuseSrv.URL)
+	t.Setenv("NSELF_LICENSE_FAIL_OPEN", "")
+
+	ok, err := BundleEntitled(context.Background(), key, "nclaw")
+	if ok {
+		t.Error("expected false with a stale-beyond-window cache, got true")
+	}
+	if err == nil {
+		t.Error("expected an error with a stale-beyond-window cache, got nil")
+	}
+}
+
+// TestBundleEntitled_ServerRejection_NeverGetsGrace confirms an authoritative
+// "no" from the server (valid:false) is never softened by a cache that would
+// otherwise have granted grace — grace applies only when the server could
+// not be reached at all, never when it answered.
+func TestBundleEntitled_ServerRejection_NeverGetsGrace(t *testing.T) {
+	checkerCacheDir(t)
+	withTempCachePath(t)
+	const key = "nself_pro_abcdefghijklmnopqrstuvwxyz123456"
+	// A fresh, otherwise-valid cache that bundleEntitledFromGrace would grant.
+	if err := WriteCache(graceCacheEntry(key, "plus", 1)); err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+	newBundleServer(t, http.StatusOK, bundleValidateResponse{
+		Valid:  false,
+		Tier:   "free",
+		Reason: "not entitled to this bundle",
+	})
+
+	ok, err := BundleEntitled(context.Background(), key, "nclaw")
+	if ok {
+		t.Error("expected false for an authoritative server rejection, got true")
+	}
+	if err == nil {
+		t.Error("expected an error for the rejection, got nil")
+	}
+}
+
+// TestBundleEntitled_ServerAuthRejection_NeverGetsGrace is the 401/403 sibling
+// of the above: a rejected key must fail closed even with a cache on hand.
+func TestBundleEntitled_ServerAuthRejection_NeverGetsGrace(t *testing.T) {
+	checkerCacheDir(t)
+	withTempCachePath(t)
+	const key = "nself_pro_abcdefghijklmnopqrstuvwxyz123456"
+	if err := WriteCache(graceCacheEntry(key, "plus", 1)); err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+	newBundleServer(t, http.StatusUnauthorized, bundleValidateResponse{})
+
+	ok, err := BundleEntitled(context.Background(), key, "nclaw")
+	if ok {
+		t.Error("expected false for a 401 rejection, got true")
+	}
+	if err == nil {
+		t.Error("expected an error for the 401 rejection, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

Two independent review panels found `BundleEntitled` (internal/license/checker.go) fails CLOSED on any network error to ping.nself.org, with no TTL and no grace window — contradicting the documented fail-open TTL model. The only fail-open branch was `NSELF_LICENSE_FAIL_OPEN=1`, whose own doc comment says production deployments must not set it. Result: an outage on our side locks a paying customer out of `nself bundle install`.

Resolution (from the panel review): wire the existing, revocation-aware `grace.go` ladder into `BundleEntitled`'s network-failure path, instead of inventing a new shorter window. That ladder already has `IsRecordRevoked()` wired in (ticket P6-E10-W5-S1-T6), so a revoked licence cannot ride the grace period — this closes the abuse objection the shorter-window proposal was trying to solve, without a third mechanism.

## What changed

- `BundleEntitled`: on a **network error** (server unreachable), the default fallback is now `bundleEntitledFromGrace`, which consults `grace.go`'s ladder against the local cache:
  - cache < 24h old (`GraceSoftThreshold`): grant, warn.
  - cache < 7d old (`GraceHardThreshold`): grant, warn louder.
  - cache >= 7d old, missing, key-mismatched, or **revoked**: deny.
- An **authoritative** server answer (401/403, or 200 `valid:false`) is untouched — it still fails closed unconditionally. Grace only ever applies when the server could not be reached at all.
- `NSELF_LICENSE_FAIL_OPEN=1` keeps its pre-existing unbounded cache-only behavior (`bundleEntitledFromCache`) for CI/air-gap builds — it's now one of two grace paths, not the only one.
- Extracted `cacheCoversBundle` so the tier/sentinel entitlement rule is defined once and shared by both the unbounded and time-bounded cache paths.
- Added `emitGraceWarning`: a stderr warning naming the outage, that access continues on cached entitlement, and how long until the grace period expires.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes locally (5071 tests, 96 packages)
- [x] New tests cover: network error + valid cache within window (grants, warns) · beyond window (denies) · revoked cache (denies regardless of freshness) · server reachable and says no, incl. with a would-grant cache present (denies, no grace) · 401/403 with a would-grant cache present (denies, no grace) · no cache at all (denies)
- [x] All 424 pre-existing `internal/license` tests plus `internal/bundle` and `internal/plugin` tests pass unchanged