### PR TITLE
fix(installer,ci): stop orphaned curl/zstd from hanging cmd/commands tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
 
     env:
       CGO_ENABLED: 0
+      # Defense-in-depth alongside the cmd/commands TestMain guard: `nself
+      # start`'s zero-config AI auto-install must never fire a real network
+      # install during CI's unit-test run. Same guard already used by
+      # e2e-golden-path.yml and rls-pentest-smoke.yml for the same reason.
+      AI_AUTO_INSTALL: 'false'
 
     steps:
       - name: Checkout

--- a/cmd/commands/bundle_test.go
+++ b/cmd/commands/bundle_test.go
@@ -42,6 +42,23 @@ func TestMain(m *testing.M) {
 	if err := bundle.LoadBytes([]byte(fixtureBundlesJSON)); err != nil {
 		panic("seeding bundle fixture: " + err.Error())
 	}
+
+	// AI_AUTO_INSTALL=false for the whole package's test binary. start.go's
+	// runStart calls autoInstallAIIfNeeded on every invocation, which fires a
+	// real `curl | zstd` Ollama install whenever AI_AUTO_INSTALL is unset
+	// (default enabled) and NSELF_MASTER_SECRET is non-empty in the process
+	// environment. config.Load calls godotenv.Overload for every .env file
+	// it reads, which sets real os.Environ values with no cleanup — so any
+	// start_test.go test can observe a NSELF_MASTER_SECRET left behind by an
+	// unrelated earlier test in this same binary. On CI's Linux runners that
+	// silently downloads a real binary via curl/zstd instead of erroring out
+	// (installer.Install only short-circuits on non-linux GOOS), and an
+	// orphaned curl/zstd surviving a cancelled test context is what produced
+	// the intermittent "Test I/O incomplete" / WaitDelay failures in
+	// cmd/commands on ubuntu-24.04-arm. No test in this package should ever
+	// make a real network install; this is the package-wide guard against it.
+	_ = os.Setenv("AI_AUTO_INSTALL", "false")
+
 	os.Exit(m.Run())
 }
 

--- a/internal/installer/ollama_proc_unix.go
+++ b/internal/installer/ollama_proc_unix.go
@@ -1,0 +1,35 @@
+//go:build darwin || linux
+
+package installer
+
+// Purpose: platform-specific process-group isolation for the Ollama install
+//          script child process, so a context cancellation kills the whole
+//          subtree (sh + curl + zstd) instead of only the immediate child.
+// Inputs:  an *exec.Cmd not yet started (setProcGroupAttr) or already
+//          started (killProcessGroup).
+// Outputs: SysProcAttr mutation; a best-effort SIGKILL to the process group.
+// Constraints: unix-only (darwin/linux); mirrors the identical pattern in
+//          internal/docker/compose_unix.go, which fixed the same
+//          "Test I/O incomplete" failure mode for `docker compose`.
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcGroupAttr places cmd (and every process it spawns) in its own
+// process group, so killProcessGroup can terminate the entire subtree with
+// one signal instead of only the direct child.
+func setProcGroupAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup sends SIGKILL to cmd's whole process group. On unix, the
+// process group id equals the negation of the leader's PID once Setpgid is
+// set, so signalling -pid reaches every descendant (install.sh's curl/zstd
+// children included), not just install.sh itself.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/internal/installer/ollama_proc_windows.go
+++ b/internal/installer/ollama_proc_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package installer
+
+// Purpose: Windows stub for the process-group helpers used by
+//          downloadAndRunInstaller. Unreachable in practice: Install()
+//          refuses to run on any GOOS other than linux before this code
+//          path is reached. The stub exists only so internal/installer
+//          builds on windows-2022 CI (go build/vet ./... compiles every
+//          package regardless of runtime.GOOS gates elsewhere).
+// Inputs:  an *exec.Cmd.
+// Outputs: none.
+// Constraints: mirrors internal/docker/compose_windows.go's no-op pattern.
+
+import "os/exec"
+
+// setProcGroupAttr is a no-op on Windows — this code path is unreachable
+// there, since Install() gates on runtime.GOOS == "linux" first.
+func setProcGroupAttr(_ *exec.Cmd) {}
+
+// killProcessGroup is a no-op on Windows for the same reason.
+func killProcessGroup(_ *exec.Cmd) {}

--- a/internal/installer/ollama_systemd.go
+++ b/internal/installer/ollama_systemd.go
@@ -61,11 +61,55 @@ func downloadAndRunInstaller(ctx context.Context, log func(string, string, map[s
 	// Execute the verified script via sh. The script lives in a private 0700
 	// directory; the path cannot be replaced by a same-uid process between the
 	// checksum verification above and this exec call.
+	//
+	// install.sh itself shells out further — it curls the ollama release
+	// tarball and unpacks it through zstd. Two things must hold or a
+	// cancelled/short-lived ctx (as in any test that runs this via `nself
+	// start`'s AI auto-install) leaves curl/zstd running as orphans that hang
+	// the whole test binary:
+	//
+	//  1. Process-group isolation (setProcGroupAttr + the Cancel hook below):
+	//     without it, ctx cancellation only kills the immediate `sh` process
+	//     via SIGKILL — curl/zstd are reparented and keep running.
+	//  2. Pipe-based I/O forwarding instead of direct `cmd.Stdout = os.Stdout`
+	//     fd inheritance: if curl/zstd inherit the raw fd of this process's
+	//     real stdout, any surviving orphan keeps that fd open even after
+	//     this function returns, and `go test` reports "Test I/O incomplete
+	//     Ns after exiting" for the entire package. Piping means only our own
+	//     io.Copy goroutines below ever touch os.Stdout/os.Stderr directly.
+	//
+	// Same failure mode, same fix, as internal/docker/compose_exec.go's Run.
 	cmd := exec.CommandContext(ctx, "sh", tmpPath)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return errf(ErrOllamaInstallFailed, "install.sh exec", err)
+	cmd.WaitDelay = 5 * time.Second
+	setProcGroupAttr(cmd)
+	cmd.Cancel = func() error {
+		killProcessGroup(cmd)
+		return cmd.Process.Kill()
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return errf(ErrOllamaInstallFailed, "install.sh stdout pipe", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return errf(ErrOllamaInstallFailed, "install.sh stderr pipe", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return errf(ErrOllamaInstallFailed, "install.sh start", err)
+	}
+
+	done := make(chan struct{}, 2)
+	go func() { io.Copy(os.Stdout, stdoutPipe); done <- struct{}{} }() //nolint:errcheck
+	go func() { io.Copy(os.Stderr, stderrPipe); done <- struct{}{} }() //nolint:errcheck
+
+	waitErr := cmd.Wait()
+	<-done
+	<-done
+
+	if waitErr != nil {
+		return errf(ErrOllamaInstallFailed, "install.sh exec", waitErr)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Recurring intermittent `Vet, Build & Test (ubuntu-24.04-arm)` failure (PR #389, PR #391, twice on `main` incl. run 34084327571 / b9b79808): `exec: WaitDelay expired before I/O complete` + `Test I/O incomplete 1m0s after exiting`, with the runner reporting orphaned `curl`/`zstd` processes.
- Root cause, confirmed against the actual failed-attempt log (run 34084327571 attempt 1, job 101625361542): `nself start`'s zero-config AI auto-install (`autoInstallAIIfNeeded`) fires inside `cmd/commands` unit tests whenever `NSELF_MASTER_SECRET` is non-empty in the process environment. `config.Load` calls `godotenv.Overload` for every `.env*` file it reads, which sets real `os.Environ` values with **no cleanup** — a value left behind by an unrelated earlier test in the same test binary can leak forward. On Linux CI runners this reaches `installer.Install`, which downloads and runs Ollama's real `install.sh`, which itself curls a release tarball and unpacks it through `zstd` (matches the `75.4%`/`81.6%` progress bars in the logs).
- `downloadAndRunInstaller` ran that script with `cmd.Stdout`/`cmd.Stderr` wired directly to the test binary's own `os.Stdout`/`os.Stderr`, with no `WaitDelay` and no process-group isolation. When the test's short 3s context cancelled, only the immediate `sh` was killed — `curl`/`zstd` were reparented, kept running, and kept the test binary's real stdout fd open, which is exactly what makes `go test` report `Test I/O incomplete` for the whole package.

## Fix
- `internal/installer/ollama_systemd.go`: `downloadAndRunInstaller` now puts the install script in its own process group and kills the whole group on context cancellation (`setProcGroupAttr`/`killProcessGroup`, unix/windows split in new `ollama_proc_unix.go` / `ollama_proc_windows.go`), forwards output through goroutine-owned pipes instead of raw fd inheritance (so no descendant can hold the real stdout/stderr open), and bounds `cmd.Wait` with a 5s `WaitDelay`. This mirrors `internal/docker/compose_exec.go`'s `Run`, which already fixed the identical failure mode for `docker compose`.
- `cmd/commands/bundle_test.go`: `TestMain` now sets `AI_AUTO_INSTALL=false` for the whole package's test binary, so no test in `cmd/commands` can ever trigger a real network install, regardless of which test leaks the trigger var.
- `.github/workflows/ci.yml`: the `Vet, Build & Test` job now sets `AI_AUTO_INSTALL: 'false'` too, matching the same guard already used by `e2e-golden-path.yml` and `rls-pentest-smoke.yml`.

No timeout raised, no retry added, no skip, no leg excluded — the leg still runs and is expected to go green because the trigger is gone and the orphan-process bug is fixed at its root.

## Test plan
- [x] `go build -mod=vendor ./...` — passes
- [x] `go vet -mod=vendor ./...` — passes
- [x] `gofmt` check (`scripts/ci/gofmt-check.sh`) — passes
- [x] Cross-compiled `internal/installer` for `windows/amd64` and `linux/arm64` — both build (new platform-split files)
- [x] `go test -mod=vendor ./cmd/commands/... -count=1` — 922 passed; `pgrep`/`ps aux` before and after show zero `curl`/`zstd` processes
- [x] `go test -mod=vendor ./...` — 5090 passed, 97 packages
- [ ] CI green on this PR, including `ubuntu-24.04-arm`